### PR TITLE
perf: lazy-load PageBuilder section components (-407 kB on /about)

### DIFF
--- a/components/PageBuilder.tsx
+++ b/components/PageBuilder.tsx
@@ -15,11 +15,18 @@ import {
   SelectValue,
 } from "./ui/select";
 import { v4 as uuidv4 } from 'uuid';
-import HeroSection from "./sections/HeroSection";
-import TextSection from "./sections/TextSection";
-import ImageSection from "./sections/ImageSection";
-import CTASection from "./sections/CTASection";
-import VideoSection from "./sections/VideoSection";
+import dynamic from "next/dynamic";
+// Section components are dynamically imported so each only ships its
+// own JS chunk to pages where it actually appears in the saved data.
+// VideoSection in particular previously leaked ~284 KB gzip (Mux + HLS)
+// to every visitor of every community's about page regardless of whether
+// the community had a video section. See:
+//   docs/superpowers/specs/2026-04-07-bundle-hotspots-findings.md
+const HeroSection = dynamic(() => import("./sections/HeroSection"));
+const TextSection = dynamic(() => import("./sections/TextSection"));
+const ImageSection = dynamic(() => import("./sections/ImageSection"));
+const CTASection = dynamic(() => import("./sections/CTASection"));
+const VideoSection = dynamic(() => import("./sections/VideoSection"), { ssr: false });
 import { Card } from "./ui/card";
 import {
   AlertDialog,


### PR DESCRIPTION
## Summary

Round A perf fix #1 from the bundle hot-spots investigation. **Drops `/[communitySlug]/about` First Load JS from 613 kB to 206 kB (−66%, −407 kB) in a 7-net-line change.**

Source investigation: \`docs/superpowers/specs/2026-04-07-bundle-hotspots-findings.md\`

## The bug

\`PageBuilder.tsx\` statically imports all 5 section components at the top of the file:

\`\`\`ts
import HeroSection from "./sections/HeroSection";
import TextSection from "./sections/TextSection";   // -> Editor (TipTap)
import ImageSection from "./sections/ImageSection";
import CTASection from "./sections/CTASection";    // -> PaymentModal (Stripe)
import VideoSection from "./sections/VideoSection"; // -> @mux/mux-player-react -> hls.js
\`\`\`

Three of the five sections transitively bundle heavy runtimes (Mux+HLS, TipTap+ProseMirror, Stripe Elements). Because the imports are static, **every visitor of every community's about page downloads ALL of those runtimes regardless of whether the community actually uses those section types**.

The traced leak chain for video specifically:

\`\`\`
about/page.tsx (line 8)
  -> import PageBuilder from "@/components/PageBuilder"
        -> import VideoSection from "./sections/VideoSection" (PageBuilder line 22)
              -> import MuxPlayerComponent from "@mux/mux-player-react" (VideoSection top)
                    -> (transitively bundles hls.js)
\`\`\`

## The fix

Replace 5 static \`import\` statements with 5 \`next/dynamic\` calls. \`VideoSection\` uses \`ssr: false\` because MuxPlayerComponent touches \`window\` at module load. The other 4 sections keep default \`ssr: true\` so they still server-render normally — code-splitting is the only behavior change.

\`\`\`ts
import dynamic from "next/dynamic";
const HeroSection = dynamic(() => import("./sections/HeroSection"));
const TextSection = dynamic(() => import("./sections/TextSection"));
const ImageSection = dynamic(() => import("./sections/ImageSection"));
const CTASection = dynamic(() => import("./sections/CTASection"));
const VideoSection = dynamic(() => import("./sections/VideoSection"), { ssr: false });
\`\`\`

The JSX usage of each section (\`<HeroSection ... />\` etc.) is unchanged. \`next/dynamic\` returns a component with the same Props interface.

## Measurements

**Build output (\`bun run build\`):**

| Route | Before | After | Delta |
|---|---|---|---|
| **\`/[communitySlug]/about\`** | **613 kB** | **206 kB** | **−407 kB (−66%)** |
| \`/[communitySlug]/classroom/[courseSlug]\` | 611 kB | 612 kB | +1 kB (unchanged — Mux is justified here) |
| \`/[communitySlug]\` | 411 kB | 411 kB | 0 (PageBuilder isn't on this route) |
| First Load JS shared by all | 87.9 kB | 88.1 kB | +0.2 kB (next/dynamic runtime) |

**Chunk-level verification (from \`.next/app-build-manifest.json\`):**

About page chunks loaded after the fix: **20** (down from 28)

| Heavy chunk | Before | After |
|---|---|---|
| MUX (\`873-*\`) | ✅ loaded | ❌ not loaded |
| HLS (\`a4634e51-*\`) | ✅ loaded | ❌ not loaded |
| TipTap+dnd-kit (\`5668-*\`) | ✅ loaded | ❌ not loaded |
| ProseMirror-view (\`70e0d97a-*\`) | ✅ loaded | ❌ not loaded |

The heavy chunks still exist as separate code-split bundles — they're just loaded on-demand at render time when a community's saved \`about_page.sections\` actually contains a section of that type, instead of unconditionally on every visit.

## Test plan

- [x] \`bun run build\` succeeds with no TypeScript errors
- [x] Build output route table verified (above)
- [x] \`bun dev\` starts cleanly, returns 200 on \`/<community>/about\`
- [x] No errors in dev log
- [ ] **Preprod smoke test** (after merge or via direct preprod restart): visit a community's about page, verify sections render correctly. Specifically:
  - Section with text content renders the text
  - Section with image renders the image
  - Section with hero renders the hero
  - Section with CTA renders the CTA
  - Section with video renders the Mux player
  - Editor mode (\`isEditing=true\`, when admin) still allows drag-reorder, add/delete, save
- [ ] **Browser DevTools verification on preprod**: open about page, check Network tab — confirm Mux/HLS chunks are NOT in the initial page load when visiting a community without a video section

## Risks

**Low risk overall.** The change is mechanical and the build verifies type safety.

| Risk | Mitigation |
|---|---|
| Brief loading flash on first paint as sections code-split chunks fetch | Mitigated by default \`ssr: true\` for the 4 light sections — they SSR normally. Only VideoSection (which is heavy and rare) uses \`ssr: false\` and only flashes when actually needed. |
| Drag-and-drop breaks because dnd-kit can't track dynamically-loaded components | Unlikely — dnd-kit operates on the section IDs, not the components themselves. Will verify in editor-mode smoke test. |
| TypeScript loses prop-type checking on \`<HeroSection />\` etc. | \`next/dynamic\` infers the type from the import expression. Build passed — types are preserved. |
| Hydration mismatch | All 5 sections use either default ssr (matches server) or \`ssr: false\` (no SSR at all). No mismatch surface. |

## Rollback

\`git revert 7067d7d\` — single commit, fully revertable.

## What's NOT in this PR

- Fix #2 (NextStepJS lazy-load): deferred. Adds complexity because \`useNextStep()\` hook needs the provider mounted; needs careful design.
- Fix #3 (TipTap composer lazy-load): deferred. UX risk (focus delay), needs prefetch-on-hover pattern.
- Architectural splits (the original A4/A5/A6): deferred. After this fix lands and we measure user-facing latency, we'll decide if the architectural splits are still worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)