### PR TITLE
perf: replace CommunityHeader CSS background with next/image

### DIFF
--- a/components/community/CommunityHeader.tsx
+++ b/components/community/CommunityHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Users, Settings } from "lucide-react";
@@ -42,9 +43,13 @@ export default function CommunityHeader({
     <div className="relative mb-8">
       {/* Background with gradient overlay */}
       <div className="relative h-64 md:h-72 overflow-hidden rounded-3xl">
-        <div
-          className="absolute inset-0 bg-cover bg-center"
-          style={{ backgroundImage: `url(${imageUrl || "/placeholder.svg"})` }}
+        <Image
+          src={imageUrl || "/placeholder.svg"}
+          alt={name}
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover object-center"
         />
         {/* Subtle dark gradient at bottom for text readability */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />


### PR DESCRIPTION
## Summary

- Replaces the CSS `backgroundImage: url(...)` in `components/community/CommunityHeader.tsx` with `<Image fill priority sizes="100vw">` so the community cover image actually goes through the (now-functional, post #14) Next.js optimizer.

## Why this matters

After PR #14 enabled `sharp`, every `next/image` call across the site started actually optimizing — but the community header background was never going through `next/image` to begin with. CSS `background-image: url(...)` is a complete bypass. So `/[slug]` was still shipping a raw 1.77 MB JPEG cover image to every authenticated visitor regardless of viewport.

Empirical optimizer output for the same source image at `w=750`:

```
1,766,904 bytes JPEG  →  27,140 bytes WebP   (−98.5%)
```

`priority` is set because this is the LCP element on the community landing page.

## Test plan

- [x] `bun run build` — succeeds, no warnings related to the change
- [ ] After merge: `pm2 restart dance-hub`, then visually verify the header on a community page (`/[slug]`) still renders correctly (gradient overlay, member avatars, manage button positioning)
- [ ] Re-run authenticated Lighthouse on `/[slug]` to confirm transferred image bytes drop and LCP improves

## Out of scope (followups)

- **Avatar images** — shadcn `AvatarImage` uses raw `<img>`. The 1.95 MB B2 avatar still bypasses optimization. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)