### PR TITLE
perf: set Mux player preload to metadata on lesson pages

### DIFF
--- a/components/MuxPlayer.tsx
+++ b/components/MuxPlayer.tsx
@@ -12,7 +12,7 @@ export function MuxPlayer({ playbackId }: MuxPlayerProps) {
       <MuxPlayerComponent
         streamType="on-demand"
         playbackId={playbackId}
-        preload="auto"
+        preload="metadata"
         maxResolution="720p"
         onError={(error) => {
           console.error('Mux Player Error:', error);


### PR DESCRIPTION
## Summary

- Changes `preload="auto"` → `preload="metadata"` in `components/MuxPlayer.tsx` (1-line change).
- Stops the HLS segment preloading that was happening on every lesson page visit.

## The bug

The lesson player wrapper (`components/MuxPlayer.tsx`) was configured with `preload="auto"`, which tells the browser to eagerly download HLS video segments as soon as the player mounts — regardless of whether the user has clicked play.

## Measured impact

Lighthouse on `/[slug]/classroom/[courseSlug]` authenticated, against a local prod build of this branch (membership redirects temporarily patched out so the auth-gated route could be measured):

| Metric | Before | After | Δ |
|---|---|---|---|
| **Mobile total page weight** | **23,979 KB** | **1,423 KB** | **−94%** (−22.56 MB) |
| Desktop total page weight | 21,754 KB | 1,436 KB | **−94%** (−20.31 MB) |
| Mobile request count | 246 | 63 | −74% |
| Mux/HLS requests | 192 | 9 | −95% |
| Mobile TBT | 1855 ms | 1523 ms | −332 ms |
| Mobile LCP | 9.2 s | 8.1 s | −1.1 s |

The Lighthouse perf score barely moved (46 → 47) because Lighthouse's weighting doesn't reward "stopped downloading data after LCP" — but the data savings are what matter for real users: **22+ MB less per lesson visit** on mobile, fewer connections, less battery drain, lower Mux delivery cost.

## Why this is the right preload value

- none: player fetches nothing → extra delay on play click, no poster/duration available
- metadata (this PR): fetches HLS manifest + init segment → poster, scrubber, and duration available immediately; content segments wait for play intent → correct balance
- auto (before): fetches as many content segments as the browser thinks it can → the ~22 MB bug

components/sections/VideoSection.tsx (PageBuilder's video block) already used preload=metadata. This PR brings the lesson player in line with that pattern.

## Test plan

- [x] bun run build — succeeds
- [x] Authenticated Lighthouse on mobile + desktop /[slug]/classroom/[courseSlug] — see measured impact above
- [x] Network log inspected — only 9 Mux requests remain (manifest + init), no content segments until play
- [ ] After merge: restart prod PM2, visually verify video still plays correctly on click, re-run Lighthouse on prod to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)