### PR TITLE
fix(calendar): dynamically extend visible hours to cover all scheduled classes

### DIFF
--- a/components/WeekCalendar.tsx
+++ b/components/WeekCalendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { format, addDays, startOfWeek, endOfWeek, isSameDay, parseISO } from "date-fns";
 import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { Button } from "@/components/ui/button";
@@ -28,7 +28,8 @@ interface WeekCalendarProps {
   isTeacher: boolean;
 }
 
-const HOURS = Array.from({ length: 18 }, (_, i) => i + 6); // 6 AM to 11 PM
+const DEFAULT_MIN_HOUR = 6;  // default start of visible day: 6 AM
+const DEFAULT_MAX_HOUR = 23; // default end of visible day:   11 PM
 const HALF_HOURS = [0, 30]; // Support 30-minute increments
 const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
@@ -43,6 +44,30 @@ export default function WeekCalendar({ communityId, communitySlug, isTeacher }: 
   const weekStart = startOfWeek(currentWeek, { weekStartsOn: 0 });
   const weekEnd = endOfWeek(currentWeek, { weekStartsOn: 0 });
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+  // Dynamic visible hour range: default 6 AM - 11 PM, but extend to cover any
+  // scheduled class in the currently-viewed week. Students in other timezones
+  // from the teacher may see classes land at 1 AM or 4 AM local time; we must
+  // not hide those rows from them.
+  const visibleHours = useMemo(() => {
+    let minHour = DEFAULT_MIN_HOUR;
+    let maxHour = DEFAULT_MAX_HOUR;
+    for (const liveClass of liveClasses) {
+      const classStart = parseISO(liveClass.scheduled_start_time);
+      const classEnd = new Date(classStart.getTime() + liveClass.duration_minutes * 60000);
+      const startHour = classStart.getHours();
+      // If the class crosses midnight, its end date is the next day — in that
+      // case cap end-hour at 23 so we don't jump tomorrow's visible range.
+      const crossesMidnight = classEnd.getDate() !== classStart.getDate();
+      const endHour = crossesMidnight ? 23 : classEnd.getHours();
+      if (startHour < minHour) minHour = startHour;
+      if (endHour > maxHour) maxHour = endHour;
+    }
+    minHour = Math.max(0, minHour);
+    maxHour = Math.min(23, maxHour);
+    const length = maxHour - minHour + 1;
+    return Array.from({ length }, (_, i) => i + minHour);
+  }, [liveClasses]);
 
   useEffect(() => {
     fetchLiveClasses();
@@ -173,7 +198,7 @@ export default function WeekCalendar({ communityId, communitySlug, isTeacher }: 
 
             {/* Time slots */}
             <div className="divide-y divide-gray-100">
-              {HOURS.map((hour) => (
+              {visibleHours.map((hour) => (
                 <div key={hour} className="grid grid-cols-8 min-h-[60px]">
                   {/* Time label */}
                   <div className="px-3 py-2 text-xs text-gray-500 border-r border-gray-200 flex items-start bg-gray-50/50">


### PR DESCRIPTION
## The bug

The community calendar hardcodes a visible range of 6 AM – 11 PM local time (`WeekCalendar.tsx` line 31). Any class scheduled outside that window is silently hidden from students.

This is a real cross-timezone UX bug. Concrete example: a teacher in **Las Vegas (PDT, UTC-7)** scheduling a 6 PM local class. In **Swedish local time (CEST, UTC+2)** that's ~3 AM the next day — which is in the 0–5 hour range the calendar never rendered. Students would not see the class at all.

## The fix

Replace the static \`HOURS\` constant with a \`useMemo\` that:

- Defaults to the 6–23 window
- Walks the classes fetched for the currently-viewed week
- Extends \`minHour\` downward if any class starts earlier than 6
- Extends \`maxHour\` upward if any class ends later than 23
- Handles classes that cross midnight by capping end-hour at 23
- Clamps the final range to [0, 23]

**No behaviour change for the common case** (classes inside 6–23) — only widens the window when needed.

## Before / After

- **Before:** static \`HOURS = [6, 7, ..., 23]\`
- **After:** \`visibleHours = useMemo(() => { ... }, [liveClasses])\` with the same shape (\`number[]\`), drop-in replacement at the JSX site.

## Why not just show all 24 hours always?

Considered it — one-line change. Rejected because it adds 6 empty rows for every user on every week, which is wasted vertical space for the common case. Dynamic is better: common case unchanged, edge cases no longer hide content.

## Teacher-creates-at-odd-hour case

Teachers can still schedule a class at any hour via the "Schedule Class" button (which opens a modal with a free datetime picker). They don't need the target hour to be visible in the grid to schedule it.

## Test plan

- [ ] After merge + \`./deploy.sh code\` on prod: visually confirm the Marcela community calendar shows today's class at ~3 AM Swedish time (or whatever the Vegas → student timezone difference works out to tonight) once she schedules it
- [ ] Weeks with no late-night classes still render exactly 6 AM – 11 PM (no regression for the common case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)