### PR TITLE
feat: community broadcasts (teacher emails)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,11 @@ BETTER_AUTH_URL=http://localhost:3000
 # Google OAuth (for Better Auth)
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
+# Community Broadcasts
+# Feature flag — "true" enables the Admin tab + /admin routes for all community
+# owners. Set "false" (default) to keep the feature hidden except for communities
+# with is_broadcast_vip = true in the database.
+NEXT_PUBLIC_BROADCASTS_ENABLED=false
+# Stripe Price ID for the €10/month unlimited broadcast subscription.
+# Create the product in Stripe Dashboard; required only when owners try to upgrade.
+STRIPE_BROADCAST_PRICE_ID=price_xxx

--- a/__tests__/api/broadcasts/quota.test.ts
+++ b/__tests__/api/broadcasts/quota.test.ts
@@ -1,44 +1,51 @@
 import { GET } from '@/app/api/community/[communitySlug]/broadcasts/quota/route';
-import { getSession } from '@/lib/auth-session';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 import { getQuota } from '@/lib/broadcasts/quota';
-import { queryOne } from '@/lib/db';
+import { NextResponse } from 'next/server';
 
-jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/broadcasts/auth', () => ({
+  authorizeBroadcastAccess: jest.fn(),
+}));
 jest.mock('@/lib/broadcasts/quota', () => ({ getQuota: jest.fn() }));
-jest.mock('@/lib/db', () => ({ queryOne: jest.fn() }));
 
-const mockedSession = getSession as jest.Mock;
+const mockedAuthz = authorizeBroadcastAccess as jest.Mock;
 const mockedQuota = getQuota as jest.Mock;
-const mockedQueryOne = queryOne as jest.Mock;
 
-const makeReq = () => new Request('http://localhost/api/community/salsa/broadcasts/quota');
+const makeReq = () =>
+  new Request('http://localhost/api/community/salsa/broadcasts/quota');
 
 describe('GET broadcasts/quota', () => {
   beforeEach(() => {
-    mockedSession.mockReset();
+    mockedAuthz.mockReset();
     mockedQuota.mockReset();
-    mockedQueryOne.mockReset();
   });
 
-  it('returns 401 when not logged in', async () => {
-    mockedSession.mockResolvedValueOnce(null);
-    const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
-    expect(res.status).toBe(401);
-  });
-
-  it('returns 403 when not the community owner', async () => {
-    mockedSession.mockResolvedValueOnce({ user: { id: 'user-2' } });
-    mockedQueryOne.mockResolvedValueOnce({ id: 'c1', created_by: 'user-1' });
+  it('returns the auth response when access is denied', async () => {
+    mockedAuthz.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    });
     const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
     expect(res.status).toBe(403);
   });
 
-  it('returns quota when owner', async () => {
-    mockedSession.mockResolvedValueOnce({ user: { id: 'user-1' } });
-    mockedQueryOne.mockResolvedValueOnce({ id: 'c1', created_by: 'user-1' });
+  it('returns the quota when access is granted', async () => {
+    mockedAuthz.mockResolvedValueOnce({
+      ok: true,
+      session: { user: { id: 'u1', email: 'o@o.com' } },
+      community: {
+        id: 'c1',
+        name: 'Salsa',
+        slug: 'salsa',
+        created_by: 'u1',
+        is_broadcast_vip: false,
+      },
+    });
     mockedQuota.mockResolvedValueOnce({ tier: 'free', used: 3, limit: 10 });
+
     const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ tier: 'free', used: 3, limit: 10 });
+    expect(mockedQuota).toHaveBeenCalledWith('c1');
   });
 });

--- a/__tests__/api/broadcasts/quota.test.ts
+++ b/__tests__/api/broadcasts/quota.test.ts
@@ -1,0 +1,44 @@
+import { GET } from '@/app/api/community/[communitySlug]/broadcasts/quota/route';
+import { getSession } from '@/lib/auth-session';
+import { getQuota } from '@/lib/broadcasts/quota';
+import { queryOne } from '@/lib/db';
+
+jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/broadcasts/quota', () => ({ getQuota: jest.fn() }));
+jest.mock('@/lib/db', () => ({ queryOne: jest.fn() }));
+
+const mockedSession = getSession as jest.Mock;
+const mockedQuota = getQuota as jest.Mock;
+const mockedQueryOne = queryOne as jest.Mock;
+
+const makeReq = () => new Request('http://localhost/api/community/salsa/broadcasts/quota');
+
+describe('GET broadcasts/quota', () => {
+  beforeEach(() => {
+    mockedSession.mockReset();
+    mockedQuota.mockReset();
+    mockedQueryOne.mockReset();
+  });
+
+  it('returns 401 when not logged in', async () => {
+    mockedSession.mockResolvedValueOnce(null);
+    const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when not the community owner', async () => {
+    mockedSession.mockResolvedValueOnce({ user: { id: 'user-2' } });
+    mockedQueryOne.mockResolvedValueOnce({ id: 'c1', created_by: 'user-1' });
+    const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns quota when owner', async () => {
+    mockedSession.mockResolvedValueOnce({ user: { id: 'user-1' } });
+    mockedQueryOne.mockResolvedValueOnce({ id: 'c1', created_by: 'user-1' });
+    mockedQuota.mockResolvedValueOnce({ tier: 'free', used: 3, limit: 10 });
+    const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ tier: 'free', used: 3, limit: 10 });
+  });
+});

--- a/__tests__/api/broadcasts/route.test.ts
+++ b/__tests__/api/broadcasts/route.test.ts
@@ -1,19 +1,50 @@
 import { POST, GET } from '@/app/api/community/[communitySlug]/broadcasts/route';
-import { getSession } from '@/lib/auth-session';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 import { queryOne, query, sql } from '@/lib/db';
 import { checkCanSend } from '@/lib/broadcasts/quota';
 import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
 import { runBroadcast } from '@/lib/broadcasts/sender';
+import { NextResponse } from 'next/server';
 
-jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/broadcasts/auth', () => ({
+  authorizeBroadcastAccess: jest.fn(),
+}));
 jest.mock('@/lib/db', () => ({
   queryOne: jest.fn(),
   query: jest.fn(),
   sql: jest.fn(),
 }));
 jest.mock('@/lib/broadcasts/quota', () => ({ checkCanSend: jest.fn() }));
-jest.mock('@/lib/broadcasts/recipients', () => ({ getActiveRecipientsForCommunity: jest.fn() }));
+jest.mock('@/lib/broadcasts/recipients', () => ({
+  getActiveRecipientsForCommunity: jest.fn(),
+}));
 jest.mock('@/lib/broadcasts/sender', () => ({ runBroadcast: jest.fn() }));
+
+const mockedAuthz = authorizeBroadcastAccess as jest.Mock;
+const mockedQueryOne = queryOne as jest.Mock;
+const mockedQuery = query as jest.Mock;
+const mockedSql = sql as unknown as jest.Mock;
+const mockedCanSend = checkCanSend as jest.Mock;
+const mockedRecipients = getActiveRecipientsForCommunity as jest.Mock;
+const mockedRun = runBroadcast as jest.Mock;
+
+const ownerSession = { user: { id: 'u1', email: 'o@o.com' } };
+const community = {
+  id: 'c1',
+  name: 'Salsa',
+  slug: 'salsa',
+  created_by: 'u1',
+  is_broadcast_vip: false,
+};
+
+const grantAccess = () =>
+  mockedAuthz.mockResolvedValueOnce({ ok: true, session: ownerSession, community });
+
+const denyAccess = (status: number) =>
+  mockedAuthz.mockResolvedValueOnce({
+    ok: false,
+    response: NextResponse.json({ error: 'denied' }, { status }),
+  });
 
 const body = {
   subject: 'Hello',
@@ -30,25 +61,20 @@ const makeReq = (b: unknown = body) =>
   });
 
 describe('POST broadcasts', () => {
-  beforeEach(() => jest.clearAllMocks());
-
-  it('401 when unauthenticated', async () => {
-    (getSession as jest.Mock).mockResolvedValueOnce(null);
-    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
-    expect(res.status).toBe(401);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSql.mockResolvedValue([]);
   });
 
-  it('403 when not owner', async () => {
-    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u2', email: 'x@x.com' } });
-    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' });
+  it('returns auth response when access denied (e.g. 401/403/404)', async () => {
+    denyAccess(403);
     const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
     expect(res.status).toBe(403);
   });
 
-  it('402 when quota exhausted', async () => {
-    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
-    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' });
-    (checkCanSend as jest.Mock).mockResolvedValueOnce({
+  it('402 when free quota exhausted', async () => {
+    grantAccess();
+    mockedCanSend.mockResolvedValueOnce({
       allowed: false,
       reason: 'quota_exhausted',
       quota: { tier: 'free', used: 10, limit: 10 },
@@ -57,32 +83,44 @@ describe('POST broadcasts', () => {
     expect(res.status).toBe(402);
   });
 
-  it('422 when no recipients', async () => {
-    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
-    (queryOne as jest.Mock)
-      .mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' })
-      .mockResolvedValueOnce({ id: 'b-new' });
-    (checkCanSend as jest.Mock).mockResolvedValueOnce({ allowed: true });
-    (getActiveRecipientsForCommunity as jest.Mock).mockResolvedValueOnce([]);
+  it('429 when paid soft cap reached', async () => {
+    grantAccess();
+    mockedCanSend.mockResolvedValueOnce({
+      allowed: false,
+      reason: 'soft_cap_reached',
+      quota: { tier: 'paid', used: 200, limit: 200 },
+    });
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(429);
+  });
+
+  it('422 when no eligible recipients', async () => {
+    grantAccess();
+    mockedCanSend.mockResolvedValueOnce({ allowed: true });
+    mockedQueryOne
+      .mockResolvedValueOnce({ id: 'profile-uuid' }) // sender profile lookup
+      .mockResolvedValueOnce({ id: 'b-new' });        // INSERT … RETURNING id
+    mockedRecipients.mockResolvedValueOnce([]);
     const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
     expect(res.status).toBe(422);
   });
 
-  it('200 happy path — inserts, sends, updates status', async () => {
-    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
-    (queryOne as jest.Mock)
-      .mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' })
+  it('happy path inserts the broadcast and runs the send', async () => {
+    grantAccess();
+    mockedCanSend.mockResolvedValueOnce({ allowed: true });
+    mockedQueryOne
+      .mockResolvedValueOnce({ id: 'profile-uuid' })
       .mockResolvedValueOnce({ id: 'b-new' });
-    (checkCanSend as jest.Mock).mockResolvedValueOnce({ allowed: true });
-    (getActiveRecipientsForCommunity as jest.Mock).mockResolvedValueOnce([
+    mockedRecipients.mockResolvedValueOnce([
       { userId: 'u2', email: 'a@a.com', displayName: 'A', unsubscribeToken: 't' },
     ]);
-    (runBroadcast as jest.Mock).mockResolvedValueOnce({
+    mockedRun.mockResolvedValueOnce({
       status: 'sent',
       resendBatchIds: ['b1'],
       successfulCount: 1,
       failedCount: 0,
     });
+
     const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -93,26 +131,56 @@ describe('POST broadcasts', () => {
         status: 'sent',
       })
     );
-    expect(runBroadcast).toHaveBeenCalledTimes(1);
+    expect(mockedRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the row failed and returns 500 when runBroadcast throws', async () => {
+    grantAccess();
+    mockedCanSend.mockResolvedValueOnce({ allowed: true });
+    mockedQueryOne
+      .mockResolvedValueOnce({ id: 'profile-uuid' })
+      .mockResolvedValueOnce({ id: 'b-new' });
+    mockedRecipients.mockResolvedValueOnce([
+      { userId: 'u2', email: 'a@a.com', displayName: 'A', unsubscribeToken: 't' },
+    ]);
+    mockedRun.mockRejectedValueOnce(new Error('resend down'));
+
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(500);
+    // last sql call should be the cleanup UPDATE marking the row failed
+    const lastCall = mockedSql.mock.calls[mockedSql.mock.calls.length - 1];
+    const sqlText = lastCall[0].join('?');
+    expect(sqlText).toMatch(/UPDATE email_broadcasts/);
+    expect(sqlText).toMatch(/SET status = .*'failed'/);
   });
 });
 
 describe('GET broadcasts', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('401 when unauthenticated', async () => {
-    (getSession as jest.Mock).mockResolvedValueOnce(null);
-    const res = await GET(new Request('http://localhost/x'), { params: { communitySlug: 'salsa' } });
+  it('returns auth response when access denied', async () => {
+    denyAccess(401);
+    const res = await GET(new Request('http://localhost/x'), {
+      params: { communitySlug: 'salsa' },
+    });
     expect(res.status).toBe(401);
   });
 
   it('returns list of broadcasts for owner', async () => {
-    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1' } });
-    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' });
-    (query as jest.Mock).mockResolvedValueOnce([
-      { id: 'b1', subject: 'S', recipient_count: 5, status: 'sent', sent_at: null, created_at: 'now' },
+    grantAccess();
+    mockedQuery.mockResolvedValueOnce([
+      {
+        id: 'b1',
+        subject: 'S',
+        recipient_count: 5,
+        status: 'sent',
+        sent_at: null,
+        created_at: 'now',
+      },
     ]);
-    const res = await GET(new Request('http://localhost/x'), { params: { communitySlug: 'salsa' } });
+    const res = await GET(new Request('http://localhost/x'), {
+      params: { communitySlug: 'salsa' },
+    });
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.broadcasts).toHaveLength(1);

--- a/__tests__/api/broadcasts/route.test.ts
+++ b/__tests__/api/broadcasts/route.test.ts
@@ -1,0 +1,120 @@
+import { POST, GET } from '@/app/api/community/[communitySlug]/broadcasts/route';
+import { getSession } from '@/lib/auth-session';
+import { queryOne, query, sql } from '@/lib/db';
+import { checkCanSend } from '@/lib/broadcasts/quota';
+import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
+import { runBroadcast } from '@/lib/broadcasts/sender';
+
+jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/db', () => ({
+  queryOne: jest.fn(),
+  query: jest.fn(),
+  sql: jest.fn(),
+}));
+jest.mock('@/lib/broadcasts/quota', () => ({ checkCanSend: jest.fn() }));
+jest.mock('@/lib/broadcasts/recipients', () => ({ getActiveRecipientsForCommunity: jest.fn() }));
+jest.mock('@/lib/broadcasts/sender', () => ({ runBroadcast: jest.fn() }));
+
+const body = {
+  subject: 'Hello',
+  htmlContent: '<p>Hello</p>',
+  editorJson: { type: 'doc', content: [] },
+  previewText: 'Hi',
+};
+
+const makeReq = (b: unknown = body) =>
+  new Request('http://localhost/api/community/salsa/broadcasts', {
+    method: 'POST',
+    body: JSON.stringify(b),
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('POST broadcasts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('401 when unauthenticated', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce(null);
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when not owner', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u2', email: 'x@x.com' } });
+    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' });
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(403);
+  });
+
+  it('402 when quota exhausted', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
+    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' });
+    (checkCanSend as jest.Mock).mockResolvedValueOnce({
+      allowed: false,
+      reason: 'quota_exhausted',
+      quota: { tier: 'free', used: 10, limit: 10 },
+    });
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(402);
+  });
+
+  it('422 when no recipients', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
+    (queryOne as jest.Mock)
+      .mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' })
+      .mockResolvedValueOnce({ id: 'b-new' });
+    (checkCanSend as jest.Mock).mockResolvedValueOnce({ allowed: true });
+    (getActiveRecipientsForCommunity as jest.Mock).mockResolvedValueOnce([]);
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(422);
+  });
+
+  it('200 happy path — inserts, sends, updates status', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
+    (queryOne as jest.Mock)
+      .mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' })
+      .mockResolvedValueOnce({ id: 'b-new' });
+    (checkCanSend as jest.Mock).mockResolvedValueOnce({ allowed: true });
+    (getActiveRecipientsForCommunity as jest.Mock).mockResolvedValueOnce([
+      { userId: 'u2', email: 'a@a.com', displayName: 'A', unsubscribeToken: 't' },
+    ]);
+    (runBroadcast as jest.Mock).mockResolvedValueOnce({
+      status: 'sent',
+      resendBatchIds: ['b1'],
+      successfulCount: 1,
+      failedCount: 0,
+    });
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual(
+      expect.objectContaining({
+        broadcastId: 'b-new',
+        recipientCount: 1,
+        status: 'sent',
+      })
+    );
+    expect(runBroadcast).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GET broadcasts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('401 when unauthenticated', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce(null);
+    const res = await GET(new Request('http://localhost/x'), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns list of broadcasts for owner', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1' } });
+    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' });
+    (query as jest.Mock).mockResolvedValueOnce([
+      { id: 'b1', subject: 'S', recipient_count: 5, status: 'sent', sent_at: null, created_at: 'now' },
+    ]);
+    const res = await GET(new Request('http://localhost/x'), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.broadcasts).toHaveLength(1);
+  });
+});

--- a/__tests__/api/broadcasts/subscription.test.ts
+++ b/__tests__/api/broadcasts/subscription.test.ts
@@ -1,0 +1,28 @@
+import { POST } from '@/app/api/community/[communitySlug]/broadcasts/subscription/route';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { createBroadcastCheckoutSession } from '@/lib/broadcasts/billing';
+
+jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/db', () => ({ queryOne: jest.fn(), sql: jest.fn() }));
+jest.mock('@/lib/broadcasts/billing', () => ({ createBroadcastCheckoutSession: jest.fn() }));
+jest.mock('@/lib/stripe', () => ({
+  stripe: { subscriptions: { update: jest.fn().mockResolvedValue({}) } },
+}));
+
+describe('POST subscription', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns checkout URL for owner', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
+    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', created_by: 'u1', slug: 'salsa' });
+    (createBroadcastCheckoutSession as jest.Mock).mockResolvedValueOnce({
+      checkoutUrl: 'https://checkout.url',
+      sessionId: 'cs_1',
+    });
+    const req = new Request('http://localhost', { method: 'POST' });
+    const res = await POST(req, { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ checkoutUrl: 'https://checkout.url' });
+  });
+});

--- a/__tests__/api/broadcasts/subscription.test.ts
+++ b/__tests__/api/broadcasts/subscription.test.ts
@@ -1,22 +1,38 @@
 import { POST } from '@/app/api/community/[communitySlug]/broadcasts/subscription/route';
-import { getSession } from '@/lib/auth-session';
-import { queryOne } from '@/lib/db';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 import { createBroadcastCheckoutSession } from '@/lib/broadcasts/billing';
+import { NextResponse } from 'next/server';
 
-jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/broadcasts/auth', () => ({
+  authorizeBroadcastAccess: jest.fn(),
+}));
 jest.mock('@/lib/db', () => ({ queryOne: jest.fn(), sql: jest.fn() }));
-jest.mock('@/lib/broadcasts/billing', () => ({ createBroadcastCheckoutSession: jest.fn() }));
+jest.mock('@/lib/broadcasts/billing', () => ({
+  createBroadcastCheckoutSession: jest.fn(),
+}));
 jest.mock('@/lib/stripe', () => ({
   stripe: { subscriptions: { update: jest.fn().mockResolvedValue({}) } },
 }));
+
+const mockedAuthz = authorizeBroadcastAccess as jest.Mock;
+const mockedCheckout = createBroadcastCheckoutSession as jest.Mock;
 
 describe('POST subscription', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('returns checkout URL for owner', async () => {
-    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
-    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', created_by: 'u1', slug: 'salsa' });
-    (createBroadcastCheckoutSession as jest.Mock).mockResolvedValueOnce({
+    mockedAuthz.mockResolvedValueOnce({
+      ok: true,
+      session: { user: { id: 'u1', email: 'o@o.com' } },
+      community: {
+        id: 'c1',
+        name: 'Salsa',
+        slug: 'salsa',
+        created_by: 'u1',
+        is_broadcast_vip: false,
+      },
+    });
+    mockedCheckout.mockResolvedValueOnce({
       checkoutUrl: 'https://checkout.url',
       sessionId: 'cs_1',
     });
@@ -24,5 +40,15 @@ describe('POST subscription', () => {
     const res = await POST(req, { params: { communitySlug: 'salsa' } });
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ checkoutUrl: 'https://checkout.url' });
+  });
+
+  it('returns auth response when access denied', async () => {
+    mockedAuthz.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    });
+    const req = new Request('http://localhost', { method: 'POST' });
+    const res = await POST(req, { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(403);
   });
 });

--- a/__tests__/components/emails/QuotaBadge.test.tsx
+++ b/__tests__/components/emails/QuotaBadge.test.tsx
@@ -2,18 +2,30 @@ import { render, screen } from '@testing-library/react';
 import { QuotaBadge } from '@/components/emails/QuotaBadge';
 
 describe('QuotaBadge', () => {
-  it('shows VIP pill when tier is vip', () => {
+  it('shows VIP access when tier is vip', () => {
     render(<QuotaBadge tier="vip" used={5} limit={null} />);
-    expect(screen.getByText(/VIP/)).toBeInTheDocument();
+    expect(screen.getByText(/VIP access/)).toBeInTheDocument();
   });
 
-  it('shows used/limit when tier is free', () => {
+  it('shows Unlimited + usage count when tier is paid', () => {
+    render(<QuotaBadge tier="paid" used={37} limit={200} />);
+    expect(screen.getByText(/Unlimited/)).toBeInTheDocument();
+    expect(screen.getByText(/37 sent this month/)).toBeInTheDocument();
+  });
+
+  it('shows used/limit as narrative text when tier is free', () => {
     render(<QuotaBadge tier="free" used={3} limit={10} />);
-    expect(screen.getByText(/3 \/ 10/)).toBeInTheDocument();
+    expect(screen.getByText(/3 of 10/)).toBeInTheDocument();
+    expect(screen.getByText(/broadcasts this month/)).toBeInTheDocument();
   });
 
-  it('uses amber style when free tier is at limit', () => {
+  it('renders an amber indicator dot when free tier is at limit', () => {
     const { container } = render(<QuotaBadge tier="free" used={10} limit={10} />);
-    expect(container.firstChild).toHaveClass('bg-amber-100');
+    expect(container.querySelector('.bg-amber-500')).not.toBeNull();
+  });
+
+  it('renders a neutral indicator dot when free tier is below limit', () => {
+    const { container } = render(<QuotaBadge tier="free" used={3} limit={10} />);
+    expect(container.querySelector('.bg-slate-400')).not.toBeNull();
   });
 });

--- a/__tests__/components/emails/QuotaBadge.test.tsx
+++ b/__tests__/components/emails/QuotaBadge.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { QuotaBadge } from '@/components/emails/QuotaBadge';
+
+describe('QuotaBadge', () => {
+  it('shows VIP pill when tier is vip', () => {
+    render(<QuotaBadge tier="vip" used={5} limit={null} />);
+    expect(screen.getByText(/VIP/)).toBeInTheDocument();
+  });
+
+  it('shows used/limit when tier is free', () => {
+    render(<QuotaBadge tier="free" used={3} limit={10} />);
+    expect(screen.getByText(/3 \/ 10/)).toBeInTheDocument();
+  });
+
+  it('uses amber style when free tier is at limit', () => {
+    const { container } = render(<QuotaBadge tier="free" used={10} limit={10} />);
+    expect(container.firstChild).toHaveClass('bg-amber-100');
+  });
+});

--- a/__tests__/lib/broadcasts/billing.test.ts
+++ b/__tests__/lib/broadcasts/billing.test.ts
@@ -1,0 +1,82 @@
+import {
+  createBroadcastCheckoutSession,
+  upsertBroadcastSubscription,
+  markBroadcastSubscriptionStatus,
+} from '@/lib/broadcasts/billing';
+
+const mockCreateCheckout = jest.fn();
+jest.mock('@/lib/stripe', () => ({
+  stripe: { checkout: { sessions: { create: (...a: unknown[]) => mockCreateCheckout(...a) } } },
+}));
+
+const mockSql = jest.fn();
+jest.mock('@/lib/db', () => ({
+  sql: (...args: unknown[]) => mockSql(...args),
+  queryOne: jest.fn(),
+}));
+
+describe('createBroadcastCheckoutSession', () => {
+  beforeEach(() => {
+    mockCreateCheckout.mockReset();
+    process.env.STRIPE_BROADCAST_PRICE_ID = 'price_test_123';
+  });
+
+  it('creates a Stripe Checkout session with community metadata', async () => {
+    mockCreateCheckout.mockResolvedValueOnce({ url: 'https://checkout.stripe.com/test', id: 'cs_1' });
+
+    const result = await createBroadcastCheckoutSession({
+      communityId: 'c1',
+      communitySlug: 'salsa',
+      ownerEmail: 'owner@example.com',
+      returnUrl: 'https://app/admin/emails',
+    });
+
+    expect(result).toEqual({ checkoutUrl: 'https://checkout.stripe.com/test', sessionId: 'cs_1' });
+    expect(mockCreateCheckout).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'subscription',
+      line_items: [{ price: 'price_test_123', quantity: 1 }],
+      customer_email: 'owner@example.com',
+      metadata: expect.objectContaining({ communityId: 'c1', purpose: 'broadcast_subscription' }),
+      success_url: expect.stringContaining('salsa'),
+      cancel_url: expect.stringContaining('salsa'),
+    }));
+  });
+
+  it('throws when STRIPE_BROADCAST_PRICE_ID is missing', async () => {
+    delete process.env.STRIPE_BROADCAST_PRICE_ID;
+    await expect(createBroadcastCheckoutSession({
+      communityId: 'c1', communitySlug: 'salsa', ownerEmail: 'o@o.com', returnUrl: '',
+    })).rejects.toThrow(/STRIPE_BROADCAST_PRICE_ID/);
+  });
+});
+
+describe('upsertBroadcastSubscription', () => {
+  beforeEach(() => mockSql.mockReset());
+
+  it('inserts a new subscription row with ON CONFLICT update', async () => {
+    mockSql.mockResolvedValueOnce([]);
+    await upsertBroadcastSubscription({
+      communityId: 'c1',
+      stripeCustomerId: 'cus_1',
+      stripeSubscriptionId: 'sub_1',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-05-01'),
+    });
+    expect(mockSql).toHaveBeenCalled();
+    const sqlText = mockSql.mock.calls[0][0].join('?');
+    expect(sqlText).toMatch(/INSERT INTO community_broadcast_subscriptions/);
+    expect(sqlText).toMatch(/ON CONFLICT/);
+  });
+});
+
+describe('markBroadcastSubscriptionStatus', () => {
+  beforeEach(() => mockSql.mockReset());
+
+  it('updates by stripe_subscription_id', async () => {
+    mockSql.mockResolvedValueOnce([]);
+    await markBroadcastSubscriptionStatus('sub_1', 'canceled', null);
+    const sqlText = mockSql.mock.calls[0][0].join('?');
+    expect(sqlText).toMatch(/UPDATE community_broadcast_subscriptions/);
+    expect(sqlText).toMatch(/stripe_subscription_id/);
+  });
+});

--- a/__tests__/lib/broadcasts/quota.test.ts
+++ b/__tests__/lib/broadcasts/quota.test.ts
@@ -1,0 +1,93 @@
+import { getQuota, checkCanSend } from '@/lib/broadcasts/quota';
+import { queryOne } from '@/lib/db';
+
+jest.mock('@/lib/db', () => ({
+  queryOne: jest.fn(),
+}));
+
+const mockedQueryOne = queryOne as unknown as jest.Mock;
+
+describe('getQuota', () => {
+  beforeEach(() => mockedQueryOne.mockReset());
+
+  it('returns VIP when community is_broadcast_vip=true', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: true })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 3 });
+    const result = await getQuota('c1');
+    expect(result).toEqual({ tier: 'vip', used: 3, limit: null });
+  });
+
+  it('returns paid when active subscription exists', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce({ status: 'active' })
+      .mockResolvedValueOnce({ count: 37 });
+    const result = await getQuota('c1');
+    expect(result).toEqual({ tier: 'paid', used: 37, limit: 200 });
+  });
+
+  it('returns free when no VIP, no active subscription', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 4 });
+    const result = await getQuota('c1');
+    expect(result).toEqual({ tier: 'free', used: 4, limit: 10 });
+  });
+
+  it('returns free when subscription is past_due', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce({ status: 'past_due' })
+      .mockResolvedValueOnce({ count: 2 });
+    const result = await getQuota('c1');
+    expect(result.tier).toBe('free');
+    expect(result.limit).toBe(10);
+  });
+});
+
+describe('checkCanSend', () => {
+  beforeEach(() => mockedQueryOne.mockReset());
+
+  it('allows VIP unconditionally', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: true })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 500 });
+    await expect(checkCanSend('c1')).resolves.toEqual({ allowed: true });
+  });
+
+  it('rejects free tier at 10/10 used', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 10 });
+    await expect(checkCanSend('c1')).resolves.toEqual({
+      allowed: false,
+      reason: 'quota_exhausted',
+      quota: { tier: 'free', used: 10, limit: 10 },
+    });
+  });
+
+  it('rejects paid tier at soft cap 200/200', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce({ status: 'active' })
+      .mockResolvedValueOnce({ count: 200 });
+    await expect(checkCanSend('c1')).resolves.toEqual({
+      allowed: false,
+      reason: 'soft_cap_reached',
+      quota: { tier: 'paid', used: 200, limit: 200 },
+    });
+  });
+
+  it('allows free tier at 9/10', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 9 });
+    await expect(checkCanSend('c1')).resolves.toEqual({ allowed: true });
+  });
+});

--- a/__tests__/lib/broadcasts/recipients.test.ts
+++ b/__tests__/lib/broadcasts/recipients.test.ts
@@ -1,0 +1,49 @@
+import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
+import { query } from '@/lib/db';
+
+jest.mock('@/lib/db', () => ({
+  query: jest.fn(),
+}));
+
+const mockedQuery = query as unknown as jest.Mock;
+
+describe('getActiveRecipientsForCommunity', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+  });
+
+  it('returns active members who opted in to teacher_broadcast', async () => {
+    mockedQuery.mockResolvedValueOnce([
+      { user_id: 'u1', email: 'a@example.com', full_name: 'Alice', unsubscribe_token: 'tok1' },
+      { user_id: 'u2', email: 'b@example.com', full_name: 'Bob', unsubscribe_token: 'tok2' },
+    ]);
+
+    const result = await getActiveRecipientsForCommunity('community-123');
+
+    expect(result).toEqual([
+      { userId: 'u1', email: 'a@example.com', displayName: 'Alice', unsubscribeToken: 'tok1' },
+      { userId: 'u2', email: 'b@example.com', displayName: 'Bob', unsubscribeToken: 'tok2' },
+    ]);
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+    // Spot-check query content
+    const sqlText = mockedQuery.mock.calls[0][0].join('?');
+    expect(sqlText).toMatch(/status = 'active'/);
+    expect(sqlText).toMatch(/teacher_broadcast/);
+    expect(sqlText).toMatch(/unsubscribed_all/);
+  });
+
+  it('returns empty array when no members match', async () => {
+    mockedQuery.mockResolvedValueOnce([]);
+    const result = await getActiveRecipientsForCommunity('community-123');
+    expect(result).toEqual([]);
+  });
+
+  it('defaults displayName to "there" when full_name is null', async () => {
+    mockedQuery.mockResolvedValueOnce([
+      { user_id: 'u1', email: 'a@example.com', full_name: null, unsubscribe_token: null },
+    ]);
+    const result = await getActiveRecipientsForCommunity('c1');
+    expect(result[0].displayName).toBe('there');
+    expect(result[0].unsubscribeToken).toBeNull();
+  });
+});

--- a/__tests__/lib/broadcasts/sender.test.ts
+++ b/__tests__/lib/broadcasts/sender.test.ts
@@ -1,0 +1,98 @@
+import { runBroadcast } from '@/lib/broadcasts/sender';
+
+const mockBatchSend = jest.fn();
+
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({
+    batch: { send: (...args: unknown[]) => mockBatchSend(...args) },
+  })),
+}));
+
+const recipient = (i: number) => ({
+  userId: `u${i}`,
+  email: `user${i}@example.com`,
+  displayName: `User ${i}`,
+  unsubscribeToken: `tok${i}`,
+});
+
+describe('runBroadcast', () => {
+  beforeEach(() => {
+    mockBatchSend.mockReset();
+  });
+
+  it('sends a single batch when recipients <= BATCH_SIZE', async () => {
+    mockBatchSend.mockResolvedValueOnce({ data: { data: [{ id: 'batch-1' }] }, error: null });
+
+    const result = await runBroadcast({
+      broadcastId: 'b1',
+      subject: 'Hello',
+      htmlContent: '<p>hi</p>',
+      previewText: 'preview',
+      recipients: [recipient(1), recipient(2)],
+      fromName: 'My Community',
+      replyTo: 'owner@example.com',
+    });
+
+    expect(mockBatchSend).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('sent');
+    expect(result.resendBatchIds).toEqual(['batch-1']);
+    expect(result.successfulCount).toBe(2);
+    expect(result.failedCount).toBe(0);
+  });
+
+  it('chunks into multiple batches of 100', async () => {
+    mockBatchSend.mockResolvedValue({ data: { data: [{ id: 'batch' }] }, error: null });
+    const recipients = Array.from({ length: 250 }, (_, i) => recipient(i));
+
+    const result = await runBroadcast({
+      broadcastId: 'b1',
+      subject: 'Hello',
+      htmlContent: '<p>hi</p>',
+      recipients,
+      fromName: 'X',
+      replyTo: 'x@example.com',
+    });
+
+    expect(mockBatchSend).toHaveBeenCalledTimes(3); // 100 + 100 + 50
+    expect(result.status).toBe('sent');
+    expect(result.successfulCount).toBe(250);
+  });
+
+  it('returns partial_failure when some batches fail after retries', async () => {
+    // First batch (100) succeeds. Second batch (50) fails all 3 retries.
+    mockBatchSend
+      .mockResolvedValueOnce({ data: { data: [{ id: 'batch-1' }] }, error: null })
+      .mockRejectedValue(new Error('boom'));
+
+    const recipients = Array.from({ length: 150 }, (_, i) => recipient(i));
+
+    const result = await runBroadcast({
+      broadcastId: 'b1',
+      subject: 'Hello',
+      htmlContent: '<p>hi</p>',
+      recipients,
+      fromName: 'X',
+      replyTo: 'x@example.com',
+    });
+
+    expect(result.status).toBe('partial_failure');
+    expect(result.errorMessage).toContain('boom');
+    expect(result.successfulCount).toBe(100);
+    expect(result.failedCount).toBe(50);
+  }, 15000); // allow extra time for retry backoff
+
+  it('returns failed when all batches fail', async () => {
+    mockBatchSend.mockRejectedValue(new Error('boom'));
+    const result = await runBroadcast({
+      broadcastId: 'b1',
+      subject: 'X',
+      htmlContent: '<p>x</p>',
+      recipients: [recipient(1)],
+      fromName: 'X',
+      replyTo: 'x@example.com',
+    });
+    expect(result.status).toBe('failed');
+    expect(result.failedCount).toBe(1);
+    expect(result.successfulCount).toBe(0);
+  }, 15000);
+});

--- a/__tests__/lib/broadcasts/sender.test.ts
+++ b/__tests__/lib/broadcasts/sender.test.ts
@@ -1,5 +1,3 @@
-import { runBroadcast } from '@/lib/broadcasts/sender';
-
 const mockBatchSend = jest.fn();
 
 jest.mock('resend', () => ({
@@ -7,6 +5,17 @@ jest.mock('resend', () => ({
     batch: { send: (...args: unknown[]) => mockBatchSend(...args) },
   })),
 }));
+
+// Avoid pulling in the React Email browser bundle (uses TextDecoder, not in jsdom).
+// runBroadcast's behaviour we care about here is chunking + retry, not template rendering.
+jest.mock('@react-email/components', () => ({
+  render: jest.fn(async (_el: unknown) => '<html><body>FAKE_TEMPLATE</body></html>'),
+}));
+jest.mock('@/lib/resend/templates/marketing/broadcast', () => ({
+  BroadcastEmail: () => null,
+}));
+
+import { runBroadcast } from '@/lib/broadcasts/sender';
 
 const recipient = (i: number) => ({
   userId: `u${i}`,

--- a/app/[communitySlug]/about/page.tsx
+++ b/app/[communitySlug]/about/page.tsx
@@ -175,6 +175,7 @@ export default function AboutPage() {
         communitySlug={communitySlug}
         activePage="about"
         isMember={isMember}
+        isOwner={isCreator}
       />
       <main className="flex-grow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
+++ b/app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { queryOne } from '@/lib/db';
 import { format } from 'date-fns';
 
+export const dynamic = 'force-dynamic';
+
 interface BroadcastRow {
   id: string;
   subject: string;

--- a/app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
+++ b/app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
@@ -79,7 +79,7 @@ export default async function BroadcastDetailPage({
         <div className="flex items-center gap-3 mb-4">
           <span className={`inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT[broadcast.status]}`} />
           <span className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium">
-            {STATUS_LABEL[broadcast.status]} · {community.name}
+            {STATUS_LABEL[broadcast.status]}
           </span>
         </div>
 

--- a/app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
+++ b/app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { queryOne } from '@/lib/db';
+import { Button } from '@/components/ui/button';
+
+interface BroadcastRow {
+  id: string;
+  subject: string;
+  html_content: string;
+  preview_text: string | null;
+  recipient_count: number;
+  status: 'pending' | 'sending' | 'sent' | 'partial_failure' | 'failed';
+  error_message: string | null;
+  sent_at: string | null;
+  created_at: string;
+}
+
+export default async function BroadcastDetailPage({
+  params,
+}: {
+  params: { communitySlug: string; broadcastId: string };
+}) {
+  const community = await queryOne<{ id: string }>`
+    SELECT id FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return null;
+
+  const broadcast = await queryOne<BroadcastRow>`
+    SELECT * FROM email_broadcasts
+    WHERE id = ${params.broadcastId} AND community_id = ${community.id}
+  `;
+  if (!broadcast) return <p>Broadcast not found.</p>;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">{broadcast.subject}</h2>
+          <p className="text-sm text-muted-foreground">
+            {broadcast.sent_at ? `Sent ${new Date(broadcast.sent_at).toLocaleString()}` : 'Not sent'}
+            {' · '}
+            {broadcast.recipient_count} recipients · {broadcast.status}
+          </p>
+          {broadcast.error_message && (
+            <p className="text-sm text-rose-600 mt-2">Error: {broadcast.error_message}</p>
+          )}
+        </div>
+        <Button variant="outline" asChild>
+          <Link href={`/${params.communitySlug}/admin/emails`}>Back</Link>
+        </Button>
+      </div>
+
+      <div className="border rounded-lg p-6 bg-white">
+        <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: broadcast.html_content }} />
+      </div>
+    </div>
+  );
+}

--- a/app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
+++ b/app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { queryOne } from '@/lib/db';
-import { Button } from '@/components/ui/button';
+import { format } from 'date-fns';
 
 interface BroadcastRow {
   id: string;
@@ -14,13 +14,29 @@ interface BroadcastRow {
   created_at: string;
 }
 
+const STATUS_LABEL: Record<BroadcastRow['status'], string> = {
+  pending: 'Draft',
+  sending: 'Sending',
+  sent: 'Published',
+  partial_failure: 'Partial delivery',
+  failed: 'Failed',
+};
+
+const STATUS_DOT: Record<BroadcastRow['status'], string> = {
+  pending: 'bg-slate-400',
+  sending: 'bg-primary animate-pulse',
+  sent: 'bg-emerald-500',
+  partial_failure: 'bg-amber-500',
+  failed: 'bg-rose-500',
+};
+
 export default async function BroadcastDetailPage({
   params,
 }: {
   params: { communitySlug: string; broadcastId: string };
 }) {
-  const community = await queryOne<{ id: string }>`
-    SELECT id FROM communities WHERE slug = ${params.communitySlug}
+  const community = await queryOne<{ id: string; name: string }>`
+    SELECT id, name FROM communities WHERE slug = ${params.communitySlug}
   `;
   if (!community) return null;
 
@@ -28,30 +44,95 @@ export default async function BroadcastDetailPage({
     SELECT * FROM email_broadcasts
     WHERE id = ${params.broadcastId} AND community_id = ${community.id}
   `;
-  if (!broadcast) return <p>Broadcast not found.</p>;
+  if (!broadcast) {
+    return (
+      <div className="py-16">
+        <p className="font-display text-2xl mb-2">Broadcast not found.</p>
+        <Link
+          href={`/${params.communitySlug}/admin/emails`}
+          className="text-sm text-primary hover:underline"
+        >
+          ← Back to archive
+        </Link>
+      </div>
+    );
+  }
+
+  const when = broadcast.sent_at ?? broadcast.created_at;
+  const whenObj = new Date(when);
+  const whenLong = format(whenObj, "MMMM d, yyyy 'at' h:mm a");
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-semibold">{broadcast.subject}</h2>
-          <p className="text-sm text-muted-foreground">
-            {broadcast.sent_at ? `Sent ${new Date(broadcast.sent_at).toLocaleString()}` : 'Not sent'}
-            {' · '}
-            {broadcast.recipient_count} recipients · {broadcast.status}
-          </p>
-          {broadcast.error_message && (
-            <p className="text-sm text-rose-600 mt-2">Error: {broadcast.error_message}</p>
-          )}
-        </div>
-        <Button variant="outline" asChild>
-          <Link href={`/${params.communitySlug}/admin/emails`}>Back</Link>
-        </Button>
-      </div>
+    <article className="animate-in fade-in slide-in-from-bottom-1 duration-500">
+      <Link
+        href={`/${params.communitySlug}/admin/emails`}
+        className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors mb-10"
+      >
+        <span className="mr-1.5">←</span>
+        Back to archive
+      </Link>
 
-      <div className="border rounded-lg p-6 bg-white">
-        <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: broadcast.html_content }} />
+      {/* Masthead */}
+      <header className="mb-10 pb-8 border-b border-border/60">
+        <div className="flex items-center gap-3 mb-4">
+          <span className={`inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT[broadcast.status]}`} />
+          <span className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium">
+            {STATUS_LABEL[broadcast.status]} · {community.name}
+          </span>
+        </div>
+
+        <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground mb-6">
+          {broadcast.subject || 'Untitled'}
+        </h1>
+
+        {broadcast.preview_text && (
+          <p className="font-display text-lg text-muted-foreground italic mb-6 max-w-2xl leading-snug">
+            {broadcast.preview_text}
+          </p>
+        )}
+
+        <dl className="flex flex-wrap gap-x-8 gap-y-3 text-sm">
+          <div>
+            <dt className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground mb-0.5">
+              {broadcast.sent_at ? 'Sent' : 'Created'}
+            </dt>
+            <dd className="text-foreground tabular-nums">{whenLong}</dd>
+          </div>
+          <div>
+            <dt className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground mb-0.5">
+              Readers
+            </dt>
+            <dd className="text-foreground tabular-nums">
+              {broadcast.recipient_count}
+            </dd>
+          </div>
+        </dl>
+
+        {broadcast.error_message && (
+          <div className="mt-6 border-l-2 border-rose-400 pl-4 py-2 bg-rose-50/50">
+            <p className="text-[10px] uppercase tracking-[0.14em] text-rose-700 font-medium mb-1">
+              Delivery note
+            </p>
+            <p className="text-sm text-rose-800">{broadcast.error_message}</p>
+          </div>
+        )}
+      </header>
+
+      {/* The issue itself — framed like a published page */}
+      <div className="mx-auto max-w-2xl">
+        <div className="relative bg-white border border-border/60 shadow-[0_2px_24px_-8px_rgba(80,40,120,0.15)] rounded-sm">
+          <div
+            className="prose prose-sm sm:prose-base max-w-none p-8 sm:p-12
+              prose-headings:font-display prose-headings:text-foreground
+              prose-p:text-foreground/90 prose-a:text-primary
+              prose-strong:text-foreground prose-img:rounded"
+            dangerouslySetInnerHTML={{ __html: broadcast.html_content }}
+          />
+        </div>
+        <p className="text-center text-[10px] uppercase tracking-[0.18em] text-muted-foreground mt-6">
+          — End of broadcast —
+        </p>
       </div>
-    </div>
+    </article>
   );
 }

--- a/app/[communitySlug]/admin/emails/new/page.tsx
+++ b/app/[communitySlug]/admin/emails/new/page.tsx
@@ -37,7 +37,7 @@ export default async function NewEmailPage({
 
       <header className="mb-10">
         <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3">
-          New broadcast · {community.name}
+          New broadcast
         </p>
         <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground">
           Write an issue

--- a/app/[communitySlug]/admin/emails/new/page.tsx
+++ b/app/[communitySlug]/admin/emails/new/page.tsx
@@ -5,6 +5,8 @@ import { getQuota } from '@/lib/broadcasts/quota';
 import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
 import { EmailComposer } from '@/components/emails/EmailComposer';
 
+export const dynamic = 'force-dynamic';
+
 export default async function NewEmailPage({
   params,
 }: {

--- a/app/[communitySlug]/admin/emails/new/page.tsx
+++ b/app/[communitySlug]/admin/emails/new/page.tsx
@@ -1,0 +1,31 @@
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { getQuota } from '@/lib/broadcasts/quota';
+import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
+import { EmailComposer } from '@/components/emails/EmailComposer';
+
+export default async function NewEmailPage({ params }: { params: { communitySlug: string } }) {
+  const session = await getSession();
+  if (!session) return null;
+
+  const community = await queryOne<{ id: string; name: string }>`
+    SELECT id, name FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return null;
+
+  const [quota, recipients] = await Promise.all([
+    getQuota(community.id),
+    getActiveRecipientsForCommunity(community.id),
+  ]);
+
+  return (
+    <EmailComposer
+      communityId={community.id}
+      communitySlug={params.communitySlug}
+      communityName={community.name}
+      ownerEmail={session.user.email}
+      activeMemberCount={recipients.length}
+      quota={quota}
+    />
+  );
+}

--- a/app/[communitySlug]/admin/emails/new/page.tsx
+++ b/app/[communitySlug]/admin/emails/new/page.tsx
@@ -1,10 +1,15 @@
+import Link from 'next/link';
 import { getSession } from '@/lib/auth-session';
 import { queryOne } from '@/lib/db';
 import { getQuota } from '@/lib/broadcasts/quota';
 import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
 import { EmailComposer } from '@/components/emails/EmailComposer';
 
-export default async function NewEmailPage({ params }: { params: { communitySlug: string } }) {
+export default async function NewEmailPage({
+  params,
+}: {
+  params: { communitySlug: string };
+}) {
   const session = await getSession();
   if (!session) return null;
 
@@ -19,13 +24,32 @@ export default async function NewEmailPage({ params }: { params: { communitySlug
   ]);
 
   return (
-    <EmailComposer
-      communityId={community.id}
-      communitySlug={params.communitySlug}
-      communityName={community.name}
-      ownerEmail={session.user.email}
-      activeMemberCount={recipients.length}
-      quota={quota}
-    />
+    <div className="animate-in fade-in slide-in-from-bottom-1 duration-500">
+      <Link
+        href={`/${params.communitySlug}/admin/emails`}
+        className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors mb-8"
+      >
+        <span className="mr-1.5">←</span>
+        Back to archive
+      </Link>
+
+      <header className="mb-10">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3">
+          New broadcast · {community.name}
+        </p>
+        <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground">
+          Write an issue
+        </h1>
+      </header>
+
+      <EmailComposer
+        communityId={community.id}
+        communitySlug={params.communitySlug}
+        communityName={community.name}
+        ownerEmail={session.user.email}
+        activeMemberCount={recipients.length}
+        quota={quota}
+      />
+    </div>
   );
 }

--- a/app/[communitySlug]/admin/emails/new/page.tsx
+++ b/app/[communitySlug]/admin/emails/new/page.tsx
@@ -35,15 +35,6 @@ export default async function NewEmailPage({
         Back to archive
       </Link>
 
-      <header className="mb-10">
-        <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3">
-          New broadcast
-        </p>
-        <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground">
-          Write an issue
-        </h1>
-      </header>
-
       <EmailComposer
         communityId={community.id}
         communitySlug={params.communitySlug}

--- a/app/[communitySlug]/admin/emails/page.tsx
+++ b/app/[communitySlug]/admin/emails/page.tsx
@@ -36,9 +36,6 @@ export default async function EmailsListPage({
     <div className="animate-in fade-in slide-in-from-bottom-1 duration-500">
       <header className="flex flex-wrap items-end justify-between gap-6 mb-10">
         <div>
-          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3">
-            {community.name}
-          </p>
           <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground">
             Broadcasts
           </h1>

--- a/app/[communitySlug]/admin/emails/page.tsx
+++ b/app/[communitySlug]/admin/emails/page.tsx
@@ -7,6 +7,10 @@ import {
   BroadcastHistoryItem,
 } from '@/components/emails/BroadcastHistoryList';
 
+// Always read fresh — broadcast list / quota must reflect rows inserted
+// milliseconds earlier by the send endpoint.
+export const dynamic = 'force-dynamic';
+
 export default async function EmailsListPage({
   params,
 }: {

--- a/app/[communitySlug]/admin/emails/page.tsx
+++ b/app/[communitySlug]/admin/emails/page.tsx
@@ -1,13 +1,19 @@
 import Link from 'next/link';
 import { queryOne, query } from '@/lib/db';
 import { getQuota } from '@/lib/broadcasts/quota';
-import { Button } from '@/components/ui/button';
 import { QuotaBadge } from '@/components/emails/QuotaBadge';
-import { BroadcastHistoryList, BroadcastHistoryItem } from '@/components/emails/BroadcastHistoryList';
+import {
+  BroadcastHistoryList,
+  BroadcastHistoryItem,
+} from '@/components/emails/BroadcastHistoryList';
 
-export default async function EmailsListPage({ params }: { params: { communitySlug: string } }) {
-  const community = await queryOne<{ id: string }>`
-    SELECT id FROM communities WHERE slug = ${params.communitySlug}
+export default async function EmailsListPage({
+  params,
+}: {
+  params: { communitySlug: string };
+}) {
+  const community = await queryOne<{ id: string; name: string }>`
+    SELECT id, name FROM communities WHERE slug = ${params.communitySlug}
   `;
   if (!community) return null;
 
@@ -23,17 +29,40 @@ export default async function EmailsListPage({ params }: { params: { communitySl
   ]);
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <h2 className="text-xl font-semibold">Emails</h2>
-          <QuotaBadge tier={quota.tier} used={quota.used} limit={quota.limit} />
+    <div className="animate-in fade-in slide-in-from-bottom-1 duration-500">
+      <header className="flex flex-wrap items-end justify-between gap-6 mb-10">
+        <div>
+          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3">
+            {community.name}
+          </p>
+          <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground">
+            Broadcasts
+          </h1>
+          <div className="mt-4">
+            <QuotaBadge tier={quota.tier} used={quota.used} limit={quota.limit} />
+          </div>
         </div>
-        <Button asChild>
-          <Link href={`/${params.communitySlug}/admin/emails/new`}>+ New email</Link>
-        </Button>
-      </div>
-      <BroadcastHistoryList broadcasts={broadcasts} communitySlug={params.communitySlug} />
+
+        <Link
+          href={`/${params.communitySlug}/admin/emails/new`}
+          className="group inline-flex items-center gap-2 text-sm font-medium text-foreground border-b border-primary pb-1 hover:text-primary transition-colors"
+        >
+          <span>Write a broadcast</span>
+          <span
+            aria-hidden
+            className="inline-block transition-transform duration-200 group-hover:translate-x-0.5"
+          >
+            →
+          </span>
+        </Link>
+      </header>
+
+      <section aria-label="Archive">
+        <BroadcastHistoryList
+          broadcasts={broadcasts}
+          communitySlug={params.communitySlug}
+        />
+      </section>
     </div>
   );
 }

--- a/app/[communitySlug]/admin/emails/page.tsx
+++ b/app/[communitySlug]/admin/emails/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { queryOne, query } from '@/lib/db';
+import { getQuota } from '@/lib/broadcasts/quota';
+import { Button } from '@/components/ui/button';
+import { QuotaBadge } from '@/components/emails/QuotaBadge';
+import { BroadcastHistoryList, BroadcastHistoryItem } from '@/components/emails/BroadcastHistoryList';
+
+export default async function EmailsListPage({ params }: { params: { communitySlug: string } }) {
+  const community = await queryOne<{ id: string }>`
+    SELECT id FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return null;
+
+  const [quota, broadcasts] = await Promise.all([
+    getQuota(community.id),
+    query<BroadcastHistoryItem>`
+      SELECT id, subject, recipient_count, status, sent_at, created_at::text AS created_at
+      FROM email_broadcasts
+      WHERE community_id = ${community.id}
+      ORDER BY created_at DESC
+      LIMIT 100
+    `,
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold">Emails</h2>
+          <QuotaBadge tier={quota.tier} used={quota.used} limit={quota.limit} />
+        </div>
+        <Button asChild>
+          <Link href={`/${params.communitySlug}/admin/emails/new`}>+ New email</Link>
+        </Button>
+      </div>
+      <BroadcastHistoryList broadcasts={broadcasts} communitySlug={params.communitySlug} />
+    </div>
+  );
+}

--- a/app/[communitySlug]/admin/layout.tsx
+++ b/app/[communitySlug]/admin/layout.tsx
@@ -38,9 +38,8 @@ export default async function AdminLayout({
         isOwner={true}
       />
       <main className="flex-grow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <h1 className="text-2xl font-bold mb-6">Admin · {community.name}</h1>
-          <div className="flex flex-col sm:flex-row gap-6">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 lg:py-14">
+          <div className="flex flex-col sm:flex-row gap-10 lg:gap-16">
             <AdminNav communitySlug={params.communitySlug} />
             <div className="flex-1 min-w-0">{children}</div>
           </div>

--- a/app/[communitySlug]/admin/layout.tsx
+++ b/app/[communitySlug]/admin/layout.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { AdminNav } from '@/components/admin/AdminNav';
+
+export default async function AdminLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { communitySlug: string };
+}) {
+  const session = await getSession();
+  if (!session) redirect('/auth/login');
+
+  const community = await queryOne<{ id: string; created_by: string; name: string; is_broadcast_vip: boolean }>`
+    SELECT id, created_by, name, is_broadcast_vip FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) redirect(`/${params.communitySlug}`);
+  if (community.created_by !== session.user.id) redirect(`/${params.communitySlug}`);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+      <h1 className="text-2xl font-bold mb-6">Admin · {community.name}</h1>
+      <div className="flex flex-col sm:flex-row gap-6">
+        <AdminNav communitySlug={params.communitySlug} />
+        <main className="flex-1 min-w-0">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/app/[communitySlug]/admin/layout.tsx
+++ b/app/[communitySlug]/admin/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth-session';
 import { queryOne } from '@/lib/db';
+import Navbar from '@/app/components/Navbar';
+import CommunityNavbar from '@/components/CommunityNavbar';
 import { AdminNav } from '@/components/admin/AdminNav';
 
 export default async function AdminLayout({
@@ -20,12 +22,23 @@ export default async function AdminLayout({
   if (community.created_by !== session.user.id) redirect(`/${params.communitySlug}`);
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-      <h1 className="text-2xl font-bold mb-6">Admin · {community.name}</h1>
-      <div className="flex flex-col sm:flex-row gap-6">
-        <AdminNav communitySlug={params.communitySlug} />
-        <main className="flex-1 min-w-0">{children}</main>
-      </div>
+    <div className="flex flex-col min-h-screen bg-background font-sans">
+      <Navbar />
+      <CommunityNavbar
+        communitySlug={params.communitySlug}
+        activePage="admin"
+        isMember={true}
+        isOwner={true}
+      />
+      <main className="flex-grow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <h1 className="text-2xl font-bold mb-6">Admin · {community.name}</h1>
+          <div className="flex flex-col sm:flex-row gap-6">
+            <AdminNav communitySlug={params.communitySlug} />
+            <div className="flex-1 min-w-0">{children}</div>
+          </div>
+        </div>
+      </main>
     </div>
   );
 }

--- a/app/[communitySlug]/admin/layout.tsx
+++ b/app/[communitySlug]/admin/layout.tsx
@@ -40,7 +40,10 @@ export default async function AdminLayout({
       <main className="flex-grow">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 lg:py-14">
           <div className="flex flex-col sm:flex-row gap-10 lg:gap-16">
-            <AdminNav communitySlug={params.communitySlug} />
+            <AdminNav
+              communitySlug={params.communitySlug}
+              communityName={community.name}
+            />
             <div className="flex-1 min-w-0">{children}</div>
           </div>
         </div>

--- a/app/[communitySlug]/admin/layout.tsx
+++ b/app/[communitySlug]/admin/layout.tsx
@@ -39,7 +39,7 @@ export default async function AdminLayout({
       />
       <main className="flex-grow">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 lg:py-14">
-          <div className="flex flex-col sm:flex-row gap-6 lg:gap-8">
+          <div className="flex flex-col sm:flex-row gap-3 lg:gap-4">
             <AdminNav
               communitySlug={params.communitySlug}
               communityName={community.name}

--- a/app/[communitySlug]/admin/layout.tsx
+++ b/app/[communitySlug]/admin/layout.tsx
@@ -21,6 +21,13 @@ export default async function AdminLayout({
   if (!community) redirect(`/${params.communitySlug}`);
   if (community.created_by !== session.user.id) redirect(`/${params.communitySlug}`);
 
+  // Kill-switch: admin section is only accessible when the feature flag is on,
+  // or when this community is explicitly marked VIP (pilot / gift access).
+  const broadcastsEnabled = process.env.NEXT_PUBLIC_BROADCASTS_ENABLED === 'true';
+  if (!broadcastsEnabled && !community.is_broadcast_vip) {
+    redirect(`/${params.communitySlug}`);
+  }
+
   return (
     <div className="flex flex-col min-h-screen bg-background font-sans">
       <Navbar />

--- a/app/[communitySlug]/admin/layout.tsx
+++ b/app/[communitySlug]/admin/layout.tsx
@@ -39,7 +39,7 @@ export default async function AdminLayout({
       />
       <main className="flex-grow">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 lg:py-14">
-          <div className="flex flex-col sm:flex-row gap-10 lg:gap-16">
+          <div className="flex flex-col sm:flex-row gap-6 lg:gap-8">
             <AdminNav
               communitySlug={params.communitySlug}
               communityName={community.name}

--- a/app/[communitySlug]/admin/page.tsx
+++ b/app/[communitySlug]/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function AdminIndex({ params }: { params: { communitySlug: string } }) {
+  redirect(`/${params.communitySlug}/admin/emails`);
+}

--- a/app/[communitySlug]/calendar/page.tsx
+++ b/app/[communitySlug]/calendar/page.tsx
@@ -106,10 +106,11 @@ export default function CommunityCalendarPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <Navbar />
-      <CommunityNavbar 
-        communitySlug={communitySlug} 
-        activePage="calendar" 
+      <CommunityNavbar
+        communitySlug={communitySlug}
+        activePage="calendar"
         isMember={isMember}
+        isOwner={isCreator}
       />
       
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/app/[communitySlug]/classroom/[courseSlug]/page.tsx
+++ b/app/[communitySlug]/classroom/[courseSlug]/page.tsx
@@ -1330,6 +1330,7 @@ export default function CoursePage() {
         communitySlug={communitySlug}
         activePage="classroom"
         isMember={true}
+        isOwner={isCreator}
       />
 
       <main className="flex-grow">

--- a/app/[communitySlug]/classroom/page.tsx
+++ b/app/[communitySlug]/classroom/page.tsx
@@ -219,6 +219,7 @@ export default function ClassroomPage() {
           communitySlug={communitySlug}
           activePage="classroom"
           isMember={isMember}
+          isOwner={isCreator}
         />
         <main className="flex-grow">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -250,6 +251,7 @@ export default function ClassroomPage() {
           communitySlug={communitySlug}
           activePage="classroom"
           isMember={isMember}
+          isOwner={isCreator}
         />
         <main className="flex-grow flex items-center justify-center">
           <div className="bg-destructive/10 border border-destructive/20 rounded-2xl p-8 max-w-md text-center">
@@ -277,6 +279,7 @@ export default function ClassroomPage() {
         communitySlug={communitySlug}
         activePage="classroom"
         isMember={isMember}
+        isOwner={isCreator}
       />
       <main className="flex-grow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/app/[communitySlug]/page.tsx
+++ b/app/[communitySlug]/page.tsx
@@ -1008,6 +1008,7 @@ export default function CommunityPage() {
         communitySlug={communitySlug}
         activePage="community"
         isMember={isMember}
+        isOwner={isCreator}
       />
       <main className="flex-grow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">

--- a/app/[communitySlug]/private-lessons/page.tsx
+++ b/app/[communitySlug]/private-lessons/page.tsx
@@ -114,6 +114,7 @@ export default function CommunityPrivateLessonsPage() {
         communitySlug={communitySlug}
         activePage="private-lessons"
         isMember={isMember}
+        isOwner={isCreator}
       />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/app/api/community/[communitySlug]/broadcasts/[broadcastId]/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/[broadcastId]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { communitySlug: string; broadcastId: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; created_by: string }>`
+    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const broadcast = await queryOne`
+    SELECT id, subject, html_content, editor_json, preview_text, recipient_count,
+           status, error_message, sent_at, created_at
+    FROM email_broadcasts
+    WHERE id = ${params.broadcastId} AND community_id = ${community.id}
+  `;
+  if (!broadcast) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(broadcast);
+}

--- a/app/api/community/[communitySlug]/broadcasts/[broadcastId]/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/[broadcastId]/route.ts
@@ -1,21 +1,14 @@
 import { NextResponse } from 'next/server';
-import { getSession } from '@/lib/auth-session';
 import { queryOne } from '@/lib/db';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 
 export async function GET(
   _req: Request,
   { params }: { params: { communitySlug: string; broadcastId: string } }
 ) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  const community = await queryOne<{ id: string; created_by: string }>`
-    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
-  `;
-  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (community.created_by !== session.user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
+  const authz = await authorizeBroadcastAccess(params.communitySlug);
+  if (!authz.ok) return authz.response;
+  const { community } = authz;
 
   const broadcast = await queryOne`
     SELECT id, subject, html_content, editor_json, preview_text, recipient_count,

--- a/app/api/community/[communitySlug]/broadcasts/quota/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/quota/route.ts
@@ -1,23 +1,14 @@
 import { NextResponse } from 'next/server';
-import { getSession } from '@/lib/auth-session';
-import { queryOne } from '@/lib/db';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 import { getQuota } from '@/lib/broadcasts/quota';
 
 export async function GET(
   _req: Request,
   { params }: { params: { communitySlug: string } }
 ) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const authz = await authorizeBroadcastAccess(params.communitySlug);
+  if (!authz.ok) return authz.response;
 
-  const community = await queryOne<{ id: string; created_by: string }>`
-    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
-  `;
-  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (community.created_by !== session.user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const quota = await getQuota(community.id);
+  const quota = await getQuota(authz.community.id);
   return NextResponse.json(quota);
 }

--- a/app/api/community/[communitySlug]/broadcasts/quota/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/quota/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { getQuota } from '@/lib/broadcasts/quota';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; created_by: string }>`
+    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const quota = await getQuota(community.id);
+  return NextResponse.json(quota);
+}

--- a/app/api/community/[communitySlug]/broadcasts/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from 'next/server';
-import { getSession } from '@/lib/auth-session';
 import { queryOne, query, sql } from '@/lib/db';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 import { checkCanSend } from '@/lib/broadcasts/quota';
 import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
 import { runBroadcast } from '@/lib/broadcasts/sender';
-
-interface CommunityRow {
-  id: string;
-  name: string;
-  created_by: string;
-}
 
 interface BroadcastListRow {
   id: string;
@@ -24,107 +18,133 @@ export async function POST(
   req: Request,
   { params }: { params: { communitySlug: string } }
 ) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const authz = await authorizeBroadcastAccess(params.communitySlug);
+  if (!authz.ok) return authz.response;
+  const { session, community } = authz;
 
-  const community = await queryOne<CommunityRow>`
-    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
-  `;
-  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (community.created_by !== session.user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  let broadcastId: string | null = null;
+
+  try {
+    const { subject, htmlContent, editorJson, previewText } = (await req.json()) as {
+      subject: string;
+      htmlContent: string;
+      editorJson: unknown;
+      previewText?: string;
+    };
+    if (!subject || !htmlContent || !editorJson) {
+      return NextResponse.json(
+        { error: 'Missing subject/htmlContent/editorJson' },
+        { status: 400 }
+      );
+    }
+
+    const gate = await checkCanSend(community.id);
+    if (!gate.allowed) {
+      const httpStatus = gate.reason === 'soft_cap_reached' ? 429 : 402;
+      return NextResponse.json(
+        { error: gate.reason, quota: gate.quota },
+        { status: httpStatus }
+      );
+    }
+
+    // email_broadcasts.sender_user_id is uuid REFERENCES profiles(id); session.user.id
+    // is the better-auth text ID, so resolve it to the profile UUID.
+    const senderProfile = await queryOne<{ id: string }>`
+      SELECT id FROM profiles WHERE auth_user_id = ${session.user.id}
+    `;
+    if (!senderProfile) {
+      return NextResponse.json({ error: 'Sender profile not found' }, { status: 500 });
+    }
+
+    const inserted = await queryOne<{ id: string }>`
+      INSERT INTO email_broadcasts
+        (community_id, sender_user_id, subject, html_content, editor_json, preview_text,
+         recipient_count, status)
+      VALUES
+        (${community.id}, ${senderProfile.id}, ${subject}, ${htmlContent},
+         ${JSON.stringify(editorJson)}::jsonb, ${previewText ?? null}, 0, 'sending')
+      RETURNING id
+    `;
+    if (!inserted) {
+      return NextResponse.json({ error: 'Insert failed' }, { status: 500 });
+    }
+    broadcastId = inserted.id;
+
+    const recipients = await getActiveRecipientsForCommunity(community.id);
+    if (recipients.length === 0) {
+      await sql`
+        UPDATE email_broadcasts
+        SET status = 'failed', error_message = 'no_recipients'
+        WHERE id = ${broadcastId}
+      `;
+      return NextResponse.json({ error: 'no_recipients' }, { status: 422 });
+    }
+
+    await sql`
+      UPDATE email_broadcasts
+      SET recipient_count = ${recipients.length}
+      WHERE id = ${broadcastId}
+    `;
+
+    const result = await runBroadcast({
+      broadcastId,
+      subject,
+      htmlContent,
+      previewText,
+      recipients,
+      fromName: community.name,
+      replyTo: session.user.email,
+    });
+
+    await sql`
+      UPDATE email_broadcasts
+      SET status = ${result.status},
+          resend_batch_ids = ${result.resendBatchIds},
+          error_message = ${result.errorMessage ?? null},
+          sent_at = ${
+            result.status === 'sent' || result.status === 'partial_failure'
+              ? new Date()
+              : null
+          }
+      WHERE id = ${broadcastId}
+    `;
+
+    return NextResponse.json({
+      broadcastId,
+      recipientCount: recipients.length,
+      status: result.status,
+      successfulCount: result.successfulCount,
+      failedCount: result.failedCount,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal error';
+    console.error('[broadcasts:POST] failed', err);
+
+    // Best-effort: mark a stuck `sending` row as failed so it doesn't
+    // permanently consume the owner's monthly quota.
+    if (broadcastId) {
+      try {
+        await sql`
+          UPDATE email_broadcasts
+          SET status = 'failed', error_message = ${msg}
+          WHERE id = ${broadcastId} AND status = 'sending'
+        `;
+      } catch (cleanupErr) {
+        console.error('[broadcasts:POST] cleanup failed', cleanupErr);
+      }
+    }
+
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
-
-  const { subject, htmlContent, editorJson, previewText } = (await req.json()) as {
-    subject: string;
-    htmlContent: string;
-    editorJson: unknown;
-    previewText?: string;
-  };
-  if (!subject || !htmlContent || !editorJson) {
-    return NextResponse.json(
-      { error: 'Missing subject/htmlContent/editorJson' },
-      { status: 400 }
-    );
-  }
-
-  const gate = await checkCanSend(community.id);
-  if (!gate.allowed) {
-    const httpStatus = gate.reason === 'soft_cap_reached' ? 429 : 402;
-    return NextResponse.json({ error: gate.reason, quota: gate.quota }, { status: httpStatus });
-  }
-
-  // email_broadcasts.sender_user_id is uuid REFERENCES profiles(id); session.user.id
-  // is the better-auth text ID, so resolve it to the profile UUID.
-  const senderProfile = await queryOne<{ id: string }>`
-    SELECT id FROM profiles WHERE auth_user_id = ${session.user.id}
-  `;
-  if (!senderProfile) {
-    return NextResponse.json({ error: 'Sender profile not found' }, { status: 500 });
-  }
-
-  const inserted = await queryOne<{ id: string }>`
-    INSERT INTO email_broadcasts
-      (community_id, sender_user_id, subject, html_content, editor_json, preview_text,
-       recipient_count, status)
-    VALUES
-      (${community.id}, ${senderProfile.id}, ${subject}, ${htmlContent},
-       ${JSON.stringify(editorJson)}::jsonb, ${previewText ?? null}, 0, 'sending')
-    RETURNING id
-  `;
-  if (!inserted) return NextResponse.json({ error: 'Insert failed' }, { status: 500 });
-  const broadcastId = inserted.id;
-
-  const recipients = await getActiveRecipientsForCommunity(community.id);
-  if (recipients.length === 0) {
-    await sql`UPDATE email_broadcasts SET status = 'failed', error_message = 'no_recipients' WHERE id = ${broadcastId}`;
-    return NextResponse.json({ error: 'no_recipients' }, { status: 422 });
-  }
-
-  await sql`UPDATE email_broadcasts SET recipient_count = ${recipients.length} WHERE id = ${broadcastId}`;
-
-  const result = await runBroadcast({
-    broadcastId,
-    subject,
-    htmlContent,
-    previewText,
-    recipients,
-    fromName: community.name,
-    replyTo: session.user.email,
-  });
-
-  await sql`
-    UPDATE email_broadcasts
-    SET status = ${result.status},
-        resend_batch_ids = ${result.resendBatchIds},
-        error_message = ${result.errorMessage ?? null},
-        sent_at = ${result.status === 'sent' || result.status === 'partial_failure' ? new Date() : null}
-    WHERE id = ${broadcastId}
-  `;
-
-  return NextResponse.json({
-    broadcastId,
-    recipientCount: recipients.length,
-    status: result.status,
-    successfulCount: result.successfulCount,
-    failedCount: result.failedCount,
-  });
 }
 
 export async function GET(
   _req: Request,
   { params }: { params: { communitySlug: string } }
 ) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  const community = await queryOne<CommunityRow>`
-    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
-  `;
-  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (community.created_by !== session.user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
+  const authz = await authorizeBroadcastAccess(params.communitySlug);
+  if (!authz.ok) return authz.response;
+  const { community } = authz;
 
   const rows = await query<BroadcastListRow>`
     SELECT id, subject, recipient_count, status, sent_at, created_at

--- a/app/api/community/[communitySlug]/broadcasts/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/route.ts
@@ -54,12 +54,21 @@ export async function POST(
     return NextResponse.json({ error: gate.reason, quota: gate.quota }, { status: httpStatus });
   }
 
+  // email_broadcasts.sender_user_id is uuid REFERENCES profiles(id); session.user.id
+  // is the better-auth text ID, so resolve it to the profile UUID.
+  const senderProfile = await queryOne<{ id: string }>`
+    SELECT id FROM profiles WHERE auth_user_id = ${session.user.id}
+  `;
+  if (!senderProfile) {
+    return NextResponse.json({ error: 'Sender profile not found' }, { status: 500 });
+  }
+
   const inserted = await queryOne<{ id: string }>`
     INSERT INTO email_broadcasts
       (community_id, sender_user_id, subject, html_content, editor_json, preview_text,
        recipient_count, status)
     VALUES
-      (${community.id}, ${session.user.id}, ${subject}, ${htmlContent},
+      (${community.id}, ${senderProfile.id}, ${subject}, ${htmlContent},
        ${JSON.stringify(editorJson)}::jsonb, ${previewText ?? null}, 0, 'sending')
     RETURNING id
   `;

--- a/app/api/community/[communitySlug]/broadcasts/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne, query, sql } from '@/lib/db';
+import { checkCanSend } from '@/lib/broadcasts/quota';
+import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
+import { runBroadcast } from '@/lib/broadcasts/sender';
+
+interface CommunityRow {
+  id: string;
+  name: string;
+  created_by: string;
+}
+
+interface BroadcastListRow {
+  id: string;
+  subject: string;
+  recipient_count: number;
+  status: string;
+  sent_at: string | null;
+  created_at: string;
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<CommunityRow>`
+    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { subject, htmlContent, editorJson, previewText } = (await req.json()) as {
+    subject: string;
+    htmlContent: string;
+    editorJson: unknown;
+    previewText?: string;
+  };
+  if (!subject || !htmlContent || !editorJson) {
+    return NextResponse.json(
+      { error: 'Missing subject/htmlContent/editorJson' },
+      { status: 400 }
+    );
+  }
+
+  const gate = await checkCanSend(community.id);
+  if (!gate.allowed) {
+    const httpStatus = gate.reason === 'soft_cap_reached' ? 429 : 402;
+    return NextResponse.json({ error: gate.reason, quota: gate.quota }, { status: httpStatus });
+  }
+
+  const inserted = await queryOne<{ id: string }>`
+    INSERT INTO email_broadcasts
+      (community_id, sender_user_id, subject, html_content, editor_json, preview_text,
+       recipient_count, status)
+    VALUES
+      (${community.id}, ${session.user.id}, ${subject}, ${htmlContent},
+       ${JSON.stringify(editorJson)}::jsonb, ${previewText ?? null}, 0, 'sending')
+    RETURNING id
+  `;
+  if (!inserted) return NextResponse.json({ error: 'Insert failed' }, { status: 500 });
+  const broadcastId = inserted.id;
+
+  const recipients = await getActiveRecipientsForCommunity(community.id);
+  if (recipients.length === 0) {
+    await sql`UPDATE email_broadcasts SET status = 'failed', error_message = 'no_recipients' WHERE id = ${broadcastId}`;
+    return NextResponse.json({ error: 'no_recipients' }, { status: 422 });
+  }
+
+  await sql`UPDATE email_broadcasts SET recipient_count = ${recipients.length} WHERE id = ${broadcastId}`;
+
+  const result = await runBroadcast({
+    broadcastId,
+    subject,
+    htmlContent,
+    previewText,
+    recipients,
+    fromName: community.name,
+    replyTo: session.user.email,
+  });
+
+  await sql`
+    UPDATE email_broadcasts
+    SET status = ${result.status},
+        resend_batch_ids = ${result.resendBatchIds},
+        error_message = ${result.errorMessage ?? null},
+        sent_at = ${result.status === 'sent' || result.status === 'partial_failure' ? new Date() : null}
+    WHERE id = ${broadcastId}
+  `;
+
+  return NextResponse.json({
+    broadcastId,
+    recipientCount: recipients.length,
+    status: result.status,
+    successfulCount: result.successfulCount,
+    failedCount: result.failedCount,
+  });
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<CommunityRow>`
+    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const rows = await query<BroadcastListRow>`
+    SELECT id, subject, recipient_count, status, sent_at, created_at
+    FROM email_broadcasts
+    WHERE community_id = ${community.id}
+    ORDER BY created_at DESC
+    LIMIT 100
+  `;
+  return NextResponse.json({ broadcasts: rows });
+}

--- a/app/api/community/[communitySlug]/broadcasts/subscription/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/subscription/route.ts
@@ -1,47 +1,39 @@
 import { NextResponse } from 'next/server';
-import { getSession } from '@/lib/auth-session';
 import { queryOne } from '@/lib/db';
 import { stripe } from '@/lib/stripe';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 import { createBroadcastCheckoutSession } from '@/lib/broadcasts/billing';
 
 export async function POST(
   _req: Request,
   { params }: { params: { communitySlug: string } }
 ) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const authz = await authorizeBroadcastAccess(params.communitySlug);
+  if (!authz.ok) return authz.response;
+  const { session, community } = authz;
 
-  const community = await queryOne<{ id: string; slug: string; created_by: string }>`
-    SELECT id, slug, created_by FROM communities WHERE slug = ${params.communitySlug}
-  `;
-  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (community.created_by !== session.user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  try {
+    const { checkoutUrl } = await createBroadcastCheckoutSession({
+      communityId: community.id,
+      communitySlug: community.slug,
+      ownerEmail: session.user.email,
+      returnUrl: '',
+    });
+    return NextResponse.json({ checkoutUrl });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal error';
+    console.error('[broadcasts:subscription:POST] failed', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
-
-  const { checkoutUrl } = await createBroadcastCheckoutSession({
-    communityId: community.id,
-    communitySlug: community.slug,
-    ownerEmail: session.user.email,
-    returnUrl: '',
-  });
-  return NextResponse.json({ checkoutUrl });
 }
 
 export async function DELETE(
   _req: Request,
   { params }: { params: { communitySlug: string } }
 ) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  const community = await queryOne<{ id: string; created_by: string }>`
-    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
-  `;
-  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (community.created_by !== session.user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
+  const authz = await authorizeBroadcastAccess(params.communitySlug);
+  if (!authz.ok) return authz.response;
+  const { community } = authz;
 
   const sub = await queryOne<{ stripe_subscription_id: string }>`
     SELECT stripe_subscription_id FROM community_broadcast_subscriptions
@@ -49,6 +41,8 @@ export async function DELETE(
   `;
   if (!sub) return NextResponse.json({ error: 'No active subscription' }, { status: 404 });
 
-  await stripe.subscriptions.update(sub.stripe_subscription_id, { cancel_at_period_end: true });
+  await stripe.subscriptions.update(sub.stripe_subscription_id, {
+    cancel_at_period_end: true,
+  });
   return NextResponse.json({ ok: true, cancelsAtPeriodEnd: true });
 }

--- a/app/api/community/[communitySlug]/broadcasts/subscription/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/subscription/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { stripe } from '@/lib/stripe';
+import { createBroadcastCheckoutSession } from '@/lib/broadcasts/billing';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; slug: string; created_by: string }>`
+    SELECT id, slug, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { checkoutUrl } = await createBroadcastCheckoutSession({
+    communityId: community.id,
+    communitySlug: community.slug,
+    ownerEmail: session.user.email,
+    returnUrl: '',
+  });
+  return NextResponse.json({ checkoutUrl });
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; created_by: string }>`
+    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const sub = await queryOne<{ stripe_subscription_id: string }>`
+    SELECT stripe_subscription_id FROM community_broadcast_subscriptions
+    WHERE community_id = ${community.id} AND status = 'active'
+  `;
+  if (!sub) return NextResponse.json({ error: 'No active subscription' }, { status: 404 });
+
+  await stripe.subscriptions.update(sub.stripe_subscription_id, { cancel_at_period_end: true });
+  return NextResponse.json({ ok: true, cancelsAtPeriodEnd: true });
+}

--- a/app/api/community/[communitySlug]/broadcasts/test/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/test/route.ts
@@ -1,48 +1,46 @@
 import { NextResponse } from 'next/server';
-import { getSession } from '@/lib/auth-session';
-import { queryOne } from '@/lib/db';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 import { runBroadcast } from '@/lib/broadcasts/sender';
 
 export async function POST(
   req: Request,
   { params }: { params: { communitySlug: string } }
 ) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const authz = await authorizeBroadcastAccess(params.communitySlug);
+  if (!authz.ok) return authz.response;
+  const { session, community } = authz;
 
-  const community = await queryOne<{ id: string; name: string; created_by: string }>`
-    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
-  `;
-  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  if (community.created_by !== session.user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  try {
+    const { subject, htmlContent, previewText } = (await req.json()) as {
+      subject: string;
+      htmlContent: string;
+      previewText?: string;
+    };
+    if (!subject || !htmlContent) {
+      return NextResponse.json({ error: 'Missing subject or htmlContent' }, { status: 400 });
+    }
+
+    const result = await runBroadcast({
+      broadcastId: 'test',
+      subject: `[TEST] ${subject}`,
+      htmlContent,
+      previewText,
+      recipients: [
+        {
+          userId: session.user.id,
+          email: session.user.email,
+          displayName: (session.user as { name?: string }).name || 'there',
+          unsubscribeToken: null,
+        },
+      ],
+      fromName: community.name,
+      replyTo: session.user.email,
+    });
+
+    return NextResponse.json({ status: result.status, failedCount: result.failedCount });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal error';
+    console.error('[broadcasts:test] failed', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
-
-  const { subject, htmlContent, previewText } = (await req.json()) as {
-    subject: string;
-    htmlContent: string;
-    previewText?: string;
-  };
-  if (!subject || !htmlContent) {
-    return NextResponse.json({ error: 'Missing subject or htmlContent' }, { status: 400 });
-  }
-
-  const result = await runBroadcast({
-    broadcastId: 'test',
-    subject: `[TEST] ${subject}`,
-    htmlContent,
-    previewText,
-    recipients: [
-      {
-        userId: session.user.id,
-        email: session.user.email,
-        displayName: (session.user as { name?: string }).name || 'there',
-        unsubscribeToken: null,
-      },
-    ],
-    fromName: community.name,
-    replyTo: session.user.email,
-  });
-
-  return NextResponse.json({ status: result.status, failedCount: result.failedCount });
 }

--- a/app/api/community/[communitySlug]/broadcasts/test/route.ts
+++ b/app/api/community/[communitySlug]/broadcasts/test/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { runBroadcast } from '@/lib/broadcasts/sender';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; name: string; created_by: string }>`
+    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { subject, htmlContent, previewText } = (await req.json()) as {
+    subject: string;
+    htmlContent: string;
+    previewText?: string;
+  };
+  if (!subject || !htmlContent) {
+    return NextResponse.json({ error: 'Missing subject or htmlContent' }, { status: 400 });
+  }
+
+  const result = await runBroadcast({
+    broadcastId: 'test',
+    subject: `[TEST] ${subject}`,
+    htmlContent,
+    previewText,
+    recipients: [
+      {
+        userId: session.user.id,
+        email: session.user.email,
+        displayName: (session.user as { name?: string }).name || 'there',
+        unsubscribeToken: null,
+      },
+    ],
+    fromName: community.name,
+    replyTo: session.user.email,
+  });
+
+  return NextResponse.json({ status: result.status, failedCount: result.failedCount });
+}

--- a/app/api/upload/broadcast-image/route.ts
+++ b/app/api/upload/broadcast-image/route.ts
@@ -1,16 +1,14 @@
 import { NextResponse } from 'next/server';
 import { v4 as uuid } from 'uuid';
-import { getSession } from '@/lib/auth-session';
-import { queryOne } from '@/lib/db';
+import { authorizeBroadcastAccess } from '@/lib/broadcasts/auth';
 import { uploadFile } from '@/lib/storage';
 
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 
 export async function POST(req: Request) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
+  // Validate the form first so we don't bother with auth/DB lookups for
+  // obviously bad requests, then authorise before we touch B2.
   const formData = await req.formData();
   const file = formData.get('file') as File | null;
   const communitySlug = formData.get('communitySlug') as string | null;
@@ -24,12 +22,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'File too large (max 5MB)' }, { status: 400 });
   }
 
-  const community = await queryOne<{ id: string; created_by: string }>`
-    SELECT id, created_by FROM communities WHERE slug = ${communitySlug}
-  `;
-  if (!community || community.created_by !== session.user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
+  const authz = await authorizeBroadcastAccess(communitySlug);
+  if (!authz.ok) return authz.response;
+  const { community } = authz;
 
   const ext = file.name.split('.').pop() || 'bin';
   const key = `email-assets/${community.id}/${uuid()}.${ext}`;

--- a/app/api/upload/broadcast-image/route.ts
+++ b/app/api/upload/broadcast-image/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { v4 as uuid } from 'uuid';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { uploadFile } from '@/lib/storage';
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export async function POST(req: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const formData = await req.formData();
+  const file = formData.get('file') as File | null;
+  const communitySlug = formData.get('communitySlug') as string | null;
+  if (!file || !communitySlug) {
+    return NextResponse.json({ error: 'Missing file or communitySlug' }, { status: 400 });
+  }
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json({ error: 'Unsupported file type' }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: 'File too large (max 5MB)' }, { status: 400 });
+  }
+
+  const community = await queryOne<{ id: string; created_by: string }>`
+    SELECT id, created_by FROM communities WHERE slug = ${communitySlug}
+  `;
+  if (!community || community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const ext = file.name.split('.').pop() || 'bin';
+  const key = `email-assets/${community.id}/${uuid()}.${ext}`;
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  const url = await uploadFile(buffer, key, file.type);
+  return NextResponse.json({ url });
+}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -8,6 +8,10 @@ import { BookingConfirmationEmail } from '@/lib/resend/templates/booking/booking
 import { PaymentReceiptEmail } from '@/lib/resend/templates/booking/payment-receipt';
 import { MemberWelcomeEmail } from '@/lib/resend/templates/community/member-welcome';
 import { CommunityOpeningEmail } from '@/lib/resend/templates/community/community-opening';
+import {
+  upsertBroadcastSubscription,
+  markBroadcastSubscriptionStatus,
+} from '@/lib/broadcasts/billing';
 import React from 'react';
 import Stripe from 'stripe';
 
@@ -58,6 +62,36 @@ interface Community {
 interface UserProfile {
   full_name: string | null;
   email: string | null;
+}
+
+async function handleBroadcastCheckoutCompleted(session: Stripe.Checkout.Session) {
+  if (session.metadata?.purpose !== 'broadcast_subscription') return;
+  const communityId = session.metadata?.communityId;
+  if (!communityId) {
+    console.error('[Broadcast sub] missing communityId in metadata');
+    return;
+  }
+  const subscriptionId = session.subscription as string;
+  const sub = await stripe.subscriptions.retrieve(subscriptionId);
+  await upsertBroadcastSubscription({
+    communityId,
+    stripeCustomerId: sub.customer as string,
+    stripeSubscriptionId: sub.id,
+    status: sub.status as 'active' | 'past_due' | 'canceled' | 'incomplete',
+    currentPeriodEnd: (sub as any).current_period_end
+      ? new Date((sub as any).current_period_end * 1000)
+      : null,
+  });
+}
+
+async function handleBroadcastSubscriptionLifecycle(sub: Stripe.Subscription): Promise<boolean> {
+  if (sub.metadata?.purpose !== 'broadcast_subscription') return false;
+  await markBroadcastSubscriptionStatus(
+    sub.id,
+    sub.status as 'active' | 'past_due' | 'canceled' | 'incomplete',
+    (sub as any).current_period_end ? new Date((sub as any).current_period_end * 1000) : null
+  );
+  return true;
 }
 
 export async function POST(request: Request) {
@@ -705,6 +739,12 @@ export async function POST(request: Request) {
       case 'customer.subscription.updated':
         const subscription = event.data.object as Stripe.Subscription;
 
+        // Broadcast subscriptions are handled separately; short-circuit before the
+        // membership-metadata guard below.
+        if (await handleBroadcastSubscriptionLifecycle(subscription)) {
+          break;
+        }
+
         if (!subscription.metadata?.user_id || !subscription.metadata?.community_id) {
           console.error('Missing metadata in subscription:', subscription.id);
           return NextResponse.json({ error: 'Missing metadata' }, { status: 400 });
@@ -807,6 +847,11 @@ export async function POST(request: Request) {
         break;
 
       // Note: customer.subscription.updated is already handled above in the combined case
+
+      case 'checkout.session.completed': {
+        await handleBroadcastCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+        break;
+      }
     }
 
     return NextResponse.json({ received: true });

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,8 @@
         "@stripe/stripe-js": "^4.9.0",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.47.12",
+        "@tiptap/extension-image": "^2.9.1",
+        "@tiptap/extension-link": "^2.9.1",
         "@tiptap/extension-placeholder": "^2.11.0",
         "@tiptap/extension-text-align": "^2.9.1",
         "@tiptap/extension-text-style": "^2.11.2",
@@ -833,7 +835,11 @@
 
     "@tiptap/extension-horizontal-rule": ["@tiptap/extension-horizontal-rule@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0" } }, "sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg=="],
 
+    "@tiptap/extension-image": ["@tiptap/extension-image@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-5zL/BY41FIt72azVrCrv3n+2YJ/JyO8wxCcA4Dk1eXIobcgVyIdo4rG39gCqIOiqziAsqnqoj12QHTBtHsJ6mQ=="],
+
     "@tiptap/extension-italic": ["@tiptap/extension-italic@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg=="],
+
+    "@tiptap/extension-link": ["@tiptap/extension-link@2.27.2", "", { "dependencies": { "linkifyjs": "^4.3.2" }, "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0" } }, "sha512-bnP61qkr0Kj9Cgnop1hxn2zbOCBzNtmawxr92bVTOE31fJv6FhtCnQiD6tuPQVGMYhcmAj7eihtvuEMFfqEPcQ=="],
 
     "@tiptap/extension-list-item": ["@tiptap/extension-list-item@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg=="],
 
@@ -1650,6 +1656,8 @@
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
+    "linkifyjs": ["linkifyjs@4.3.2", "", {}, "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA=="],
 
     "livekit-client": ["livekit-client@2.18.0", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.44.0", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-wjH4y0rw5fnkPmmaxutPhD4XcAq6goQszS8lw9PEpGXVwiRE6sI/ZH+mOT/s8AHJnEC3tjmfiMZ4MQt8BlaWew=="],
 

--- a/components/CommunityNavbar.tsx
+++ b/components/CommunityNavbar.tsx
@@ -5,20 +5,23 @@ interface CommunityNavbarProps {
   communitySlug: string;
   activePage: string;
   isMember: boolean;
+  isOwner?: boolean;
 }
 
-export default function CommunityNavbar({ communitySlug, activePage, isMember }: CommunityNavbarProps) {
-  const navItems = [
+export default function CommunityNavbar({ communitySlug, activePage, isMember, isOwner = false }: CommunityNavbarProps) {
+  const navItems: Array<{ label: string; href: string; memberOnly?: boolean; ownerOnly?: boolean }> = [
     { label: "Community", href: `/${communitySlug}` },
     { label: "Classroom", href: `/${communitySlug}/classroom`, memberOnly: true },
     { label: "Private Lessons", href: `/${communitySlug}/private-lessons`, memberOnly: false },
     { label: "Calendar", href: `/${communitySlug}/calendar`, memberOnly: true },
     { label: "About", href: `/${communitySlug}/about` },
+    { label: "Admin", href: `/${communitySlug}/admin`, ownerOnly: true },
   ];
 
-  // Filter items based on membership status
+  // Filter items based on membership and ownership status
   const visibleItems = navItems.filter(item =>
-    !item.memberOnly || isMember
+    (!item.memberOnly || isMember) &&
+    (!item.ownerOnly || isOwner)
   );
 
   return (

--- a/components/CommunityNavbar.tsx
+++ b/components/CommunityNavbar.tsx
@@ -18,11 +18,16 @@ export default function CommunityNavbar({ communitySlug, activePage, isMember, i
     { label: "Admin", href: `/${communitySlug}/admin`, ownerOnly: true },
   ];
 
+  const broadcastsEnabled = process.env.NEXT_PUBLIC_BROADCASTS_ENABLED === "true";
+
   // Filter items based on membership and ownership status
-  const visibleItems = navItems.filter(item =>
-    (!item.memberOnly || isMember) &&
-    (!item.ownerOnly || isOwner)
-  );
+  const visibleItems = navItems.filter(item => {
+    if (item.memberOnly && !isMember) return false;
+    if (item.ownerOnly && !isOwner) return false;
+    // Gate the Admin tab behind the broadcasts feature flag
+    if (item.label === "Admin" && !broadcastsEnabled) return false;
+    return true;
+  });
 
   return (
     <nav className="bg-card border-b border-border/50 sticky top-0 z-30 backdrop-blur-sm bg-card/95" id="navigation-tabs">

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -1,31 +1,42 @@
 'use client';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Mail } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export function AdminNav({ communitySlug }: { communitySlug: string }) {
   const pathname = usePathname();
   const items = [
-    { href: `/${communitySlug}/admin/emails`, label: 'Emails', icon: Mail },
+    { href: `/${communitySlug}/admin/emails`, label: 'Broadcasts' },
   ];
 
   return (
-    <nav className="w-full sm:w-56 shrink-0 border-b sm:border-b-0 sm:border-r bg-muted/20">
-      <ul className="flex sm:flex-col p-2 gap-1">
+    <nav className="w-full sm:w-48 shrink-0">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3 pl-1">
+        Studio
+      </p>
+      <ul className="flex sm:flex-col gap-0.5">
         {items.map((item) => {
           const active = pathname.startsWith(item.href);
-          const Icon = item.icon;
           return (
             <li key={item.href}>
               <Link
                 href={item.href}
                 className={cn(
-                  'flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
-                  active ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+                  'group flex items-center gap-2 pl-3 pr-2 py-2 text-sm transition-colors relative',
+                  active
+                    ? 'text-foreground font-medium'
+                    : 'text-muted-foreground hover:text-foreground'
                 )}
               >
-                <Icon className="h-4 w-4" />
+                <span
+                  aria-hidden
+                  className={cn(
+                    'absolute left-0 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full transition-all',
+                    active
+                      ? 'bg-primary opacity-100'
+                      : 'bg-primary/0 opacity-0 group-hover:opacity-40'
+                  )}
+                />
                 {item.label}
               </Link>
             </li>

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -3,7 +3,13 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
-export function AdminNav({ communitySlug }: { communitySlug: string }) {
+export function AdminNav({
+  communitySlug,
+  communityName,
+}: {
+  communitySlug: string;
+  communityName: string;
+}) {
   const pathname = usePathname();
   const items = [
     { href: `/${communitySlug}/admin/emails`, label: 'Broadcasts' },
@@ -12,7 +18,7 @@ export function AdminNav({ communitySlug }: { communitySlug: string }) {
   return (
     <nav className="w-full sm:w-48 shrink-0">
       <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3 pl-1">
-        Studio
+        {communityName}
       </p>
       <ul className="flex sm:flex-col gap-0.5">
         {items.map((item) => {

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -1,0 +1,37 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Mail } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export function AdminNav({ communitySlug }: { communitySlug: string }) {
+  const pathname = usePathname();
+  const items = [
+    { href: `/${communitySlug}/admin/emails`, label: 'Emails', icon: Mail },
+  ];
+
+  return (
+    <nav className="w-full sm:w-56 shrink-0 border-b sm:border-b-0 sm:border-r bg-muted/20">
+      <ul className="flex sm:flex-col p-2 gap-1">
+        {items.map((item) => {
+          const active = pathname.startsWith(item.href);
+          const Icon = item.icon;
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className={cn(
+                  'flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
+                  active ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+                )}
+              >
+                <Icon className="h-4 w-4" />
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/components/emails/BroadcastHistoryList.tsx
+++ b/components/emails/BroadcastHistoryList.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
-import { formatDistanceToNow } from 'date-fns';
+import { format, formatDistanceToNowStrict } from 'date-fns';
+import { ArrowUpRight } from 'lucide-react';
 
 export interface BroadcastHistoryItem {
   id: string;
@@ -10,53 +11,76 @@ export interface BroadcastHistoryItem {
   created_at: string;
 }
 
-const STATUS_LABEL: Record<BroadcastHistoryItem['status'], string> = {
-  pending: 'Pending',
-  sending: 'Sending…',
-  sent: 'Sent',
-  partial_failure: 'Partial delivery',
-  failed: 'Failed',
-};
-
-const STATUS_COLOR: Record<BroadcastHistoryItem['status'], string> = {
-  pending: 'bg-slate-100 text-slate-700',
-  sending: 'bg-indigo-100 text-indigo-800',
-  sent: 'bg-emerald-100 text-emerald-800',
-  partial_failure: 'bg-amber-100 text-amber-800',
-  failed: 'bg-rose-100 text-rose-800',
+const STATUS_META: Record<
+  BroadcastHistoryItem['status'],
+  { label: string; dot: string; text: string }
+> = {
+  pending: { label: 'Draft', dot: 'bg-slate-400', text: 'text-slate-600' },
+  sending: { label: 'Sending', dot: 'bg-primary animate-pulse', text: 'text-primary' },
+  sent: { label: 'Published', dot: 'bg-emerald-500', text: 'text-emerald-700' },
+  partial_failure: { label: 'Partial delivery', dot: 'bg-amber-500', text: 'text-amber-700' },
+  failed: { label: 'Failed', dot: 'bg-rose-500', text: 'text-rose-700' },
 };
 
 export function BroadcastHistoryList({
-  broadcasts, communitySlug,
-}: { broadcasts: BroadcastHistoryItem[]; communitySlug: string }) {
+  broadcasts,
+  communitySlug,
+}: {
+  broadcasts: BroadcastHistoryItem[];
+  communitySlug: string;
+}) {
   if (broadcasts.length === 0) {
-    return <p className="text-sm text-muted-foreground py-8 text-center">No broadcasts yet.</p>;
+    return (
+      <div className="py-16 border-t border-border/50">
+        <p className="font-display text-2xl text-foreground/80 mb-2">
+          Nothing published yet.
+        </p>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          Your archive will live here. Start with a welcome note, a class
+          announcement, or a Sunday recap.
+        </p>
+      </div>
+    );
   }
 
   return (
-    <ul className="divide-y border rounded-lg">
-      {broadcasts.map((b) => (
-        <li key={b.id}>
-          <Link
-            href={`/${communitySlug}/admin/emails/${b.id}`}
-            className="flex items-center justify-between gap-4 p-4 hover:bg-muted/40 transition-colors"
-          >
-            <div className="min-w-0 flex-1">
-              <p className="font-medium truncate">{b.subject}</p>
-              <p className="text-xs text-muted-foreground mt-1">
-                {b.sent_at
-                  ? `Sent ${formatDistanceToNow(new Date(b.sent_at), { addSuffix: true })}`
-                  : `Created ${formatDistanceToNow(new Date(b.created_at), { addSuffix: true })}`}
-                {' · '}
-                {b.recipient_count} recipient{b.recipient_count === 1 ? '' : 's'}
-              </p>
-            </div>
-            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${STATUS_COLOR[b.status]}`}>
-              {STATUS_LABEL[b.status]}
-            </span>
-          </Link>
-        </li>
-      ))}
+    <ul className="divide-y divide-border/60">
+      {broadcasts.map((b) => {
+        const status = STATUS_META[b.status];
+        const date = b.sent_at ?? b.created_at;
+        const dateObj = new Date(date);
+        const absolute = format(dateObj, 'MMM d, yyyy');
+        const relative = formatDistanceToNowStrict(dateObj, { addSuffix: true });
+
+        return (
+          <li key={b.id}>
+            <Link
+              href={`/${communitySlug}/admin/emails/${b.id}`}
+              className="group grid grid-cols-[1fr_auto] items-baseline gap-6 py-5 transition-colors hover:bg-muted/20 -mx-2 px-2 rounded-sm"
+            >
+              <div className="min-w-0">
+                <div className="flex items-baseline gap-3 mb-1">
+                  <span className={`inline-block h-1.5 w-1.5 rounded-full ${status.dot} shrink-0 translate-y-[-2px]`} />
+                  <span className={`text-[10px] uppercase tracking-[0.14em] font-medium ${status.text}`}>
+                    {status.label}
+                  </span>
+                  <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                    · {b.recipient_count} {b.recipient_count === 1 ? 'reader' : 'readers'}
+                  </span>
+                </div>
+                <h3 className="font-display text-xl sm:text-2xl leading-tight text-foreground truncate group-hover:text-primary transition-colors">
+                  {b.subject || 'Untitled'}
+                </h3>
+              </div>
+
+              <div className="text-right shrink-0 self-center">
+                <p className="text-sm text-foreground tabular-nums">{absolute}</p>
+                <p className="text-xs text-muted-foreground">{relative}</p>
+              </div>
+            </Link>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/components/emails/BroadcastHistoryList.tsx
+++ b/components/emails/BroadcastHistoryList.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import { formatDistanceToNow } from 'date-fns';
+
+export interface BroadcastHistoryItem {
+  id: string;
+  subject: string;
+  recipient_count: number;
+  status: 'pending' | 'sending' | 'sent' | 'partial_failure' | 'failed';
+  sent_at: string | null;
+  created_at: string;
+}
+
+const STATUS_LABEL: Record<BroadcastHistoryItem['status'], string> = {
+  pending: 'Pending',
+  sending: 'Sending…',
+  sent: 'Sent',
+  partial_failure: 'Partial delivery',
+  failed: 'Failed',
+};
+
+const STATUS_COLOR: Record<BroadcastHistoryItem['status'], string> = {
+  pending: 'bg-slate-100 text-slate-700',
+  sending: 'bg-indigo-100 text-indigo-800',
+  sent: 'bg-emerald-100 text-emerald-800',
+  partial_failure: 'bg-amber-100 text-amber-800',
+  failed: 'bg-rose-100 text-rose-800',
+};
+
+export function BroadcastHistoryList({
+  broadcasts, communitySlug,
+}: { broadcasts: BroadcastHistoryItem[]; communitySlug: string }) {
+  if (broadcasts.length === 0) {
+    return <p className="text-sm text-muted-foreground py-8 text-center">No broadcasts yet.</p>;
+  }
+
+  return (
+    <ul className="divide-y border rounded-lg">
+      {broadcasts.map((b) => (
+        <li key={b.id}>
+          <Link
+            href={`/${communitySlug}/admin/emails/${b.id}`}
+            className="flex items-center justify-between gap-4 p-4 hover:bg-muted/40 transition-colors"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="font-medium truncate">{b.subject}</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                {b.sent_at
+                  ? `Sent ${formatDistanceToNow(new Date(b.sent_at), { addSuffix: true })}`
+                  : `Created ${formatDistanceToNow(new Date(b.created_at), { addSuffix: true })}`}
+                {' · '}
+                {b.recipient_count} recipient{b.recipient_count === 1 ? '' : 's'}
+              </p>
+            </div>
+            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${STATUS_COLOR[b.status]}`}>
+              {STATUS_LABEL[b.status]}
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/emails/EmailComposer.tsx
+++ b/components/emails/EmailComposer.tsx
@@ -3,9 +3,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-hot-toast';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
 import { EmailEditor } from './EmailEditor';
 import { QuotaBadge } from './QuotaBadge';
 import { UpgradeDialog } from './UpgradeDialog';
@@ -32,13 +29,22 @@ export function EmailComposer(props: Props) {
   const atLimit = props.quota.limit !== null && props.quota.used >= props.quota.limit;
 
   const validate = () => {
-    if (!subject.trim()) { toast.error('Subject is required'); return false; }
-    if (!html.trim() || html === '<p></p>') { toast.error('Message is empty'); return false; }
+    if (!subject.trim()) {
+      toast.error('Subject is required');
+      return false;
+    }
+    if (!html.trim() || html === '<p></p>') {
+      toast.error('Message is empty');
+      return false;
+    }
     return true;
   };
 
   const handleSend = async () => {
-    if (atLimit && props.quota.tier === 'free') { setUpgradeOpen(true); return; }
+    if (atLimit && props.quota.tier === 'free') {
+      setUpgradeOpen(true);
+      return;
+    }
     if (!validate()) return;
     setSending(true);
     try {
@@ -47,13 +53,26 @@ export function EmailComposer(props: Props) {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ subject, htmlContent: html, editorJson: json, previewText }),
       });
-      if (res.status === 402) { setUpgradeOpen(true); return; }
-      if (!res.ok) throw new Error((await res.json()).error || 'Send failed');
+      if (res.status === 402) {
+        setUpgradeOpen(true);
+        return;
+      }
+      if (!res.ok) {
+        const body = await res.text();
+        let msg = 'Send failed';
+        try {
+          msg = JSON.parse(body).error || msg;
+        } catch {}
+        throw new Error(msg);
+      }
       const data = await res.json();
       if (data.status === 'partial_failure') {
-        toast(`Sent to ${data.successfulCount} of ${data.recipientCount}. ${data.failedCount} failed.`, { icon: '⚠️' });
+        toast(
+          `Sent to ${data.successfulCount} of ${data.recipientCount}. ${data.failedCount} failed.`,
+          { icon: '⚠️' }
+        );
       } else {
-        toast.success(`Sent to ${data.recipientCount} members.`);
+        toast.success(`Published to ${data.recipientCount} readers.`);
       }
       router.push(`/${props.communitySlug}/admin/emails/${data.broadcastId}`);
     } catch (err) {
@@ -67,11 +86,14 @@ export function EmailComposer(props: Props) {
     if (!validate()) return;
     setTesting(true);
     try {
-      const res = await fetch(`/api/community/${props.communitySlug}/broadcasts/test`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ subject, htmlContent: html, previewText }),
-      });
+      const res = await fetch(
+        `/api/community/${props.communitySlug}/broadcasts/test`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ subject, htmlContent: html, previewText }),
+        }
+      );
       if (!res.ok) throw new Error('Test send failed');
       toast.success(`Test sent to ${props.ownerEmail}`);
     } catch (err) {
@@ -82,50 +104,122 @@ export function EmailComposer(props: Props) {
   };
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-      <div className="lg:col-span-2 space-y-4">
-        <div>
-          <Label htmlFor="subject">Subject</Label>
-          <Input id="subject" value={subject} onChange={(e) => setSubject(e.target.value)} placeholder="e.g., Spring schedule update" />
+    <div className="grid grid-cols-1 lg:grid-cols-[1fr_18rem] gap-10">
+      {/* Composer */}
+      <div className="space-y-8 min-w-0">
+        <div className="space-y-1">
+          <label
+            htmlFor="subject"
+            className="block text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium"
+          >
+            Subject
+          </label>
+          <input
+            id="subject"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="Your headline"
+            className="w-full bg-transparent border-0 border-b border-border/60 rounded-none px-0 py-2 font-display text-3xl leading-tight text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary transition-colors"
+          />
         </div>
-        <div>
-          <Label htmlFor="preview">Preview text (optional)</Label>
-          <Input id="preview" value={previewText} onChange={(e) => setPreviewText(e.target.value)} placeholder="Short description shown in inbox" />
-        </div>
-        <EmailEditor communitySlug={props.communitySlug} onChange={(h, j) => { setHtml(h); setJson(j); }} />
-      </div>
 
-      <aside className="space-y-4">
-        <div className="border rounded-lg p-4 space-y-3">
-          <div>
-            <div className="text-xs text-muted-foreground">Recipients</div>
-            <div className="text-lg font-semibold">{props.activeMemberCount} active members</div>
-          </div>
-          <div>
-            <div className="text-xs text-muted-foreground">Sending from</div>
-            <div className="text-sm">{props.communityName} &lt;community@dance-hub.io&gt;</div>
-          </div>
-          <div>
-            <div className="text-xs text-muted-foreground">Reply-to</div>
-            <div className="text-sm">{props.ownerEmail}</div>
-          </div>
-          <div>
-            <div className="text-xs text-muted-foreground mb-1">Quota</div>
-            <QuotaBadge {...props.quota} />
-          </div>
+        <div className="space-y-1">
+          <label
+            htmlFor="preview"
+            className="block text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium"
+          >
+            Preview text
+          </label>
+          <input
+            id="preview"
+            value={previewText}
+            onChange={(e) => setPreviewText(e.target.value)}
+            placeholder="The line people see in their inbox before opening"
+            className="w-full bg-transparent border-0 border-b border-border/60 rounded-none px-0 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary transition-colors italic"
+          />
         </div>
 
         <div className="space-y-2">
-          <Button onClick={handleSend} disabled={sending} className="w-full">
-            {sending ? 'Sending…' : atLimit && props.quota.tier === 'free' ? 'Upgrade to send →' : 'Send now'}
-          </Button>
-          <Button variant="outline" onClick={handleSendTest} disabled={testing} className="w-full">
-            {testing ? 'Sending test…' : 'Send test to me'}
-          </Button>
+          <label className="block text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium">
+            Body
+          </label>
+          <EmailEditor
+            communitySlug={props.communitySlug}
+            onChange={(h, j) => {
+              setHtml(h);
+              setJson(j);
+            }}
+          />
         </div>
+      </div>
+
+      {/* Side panel */}
+      <aside className="space-y-8">
+        <section>
+          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3">
+            Readership
+          </p>
+          <p className="font-display text-3xl leading-none text-foreground">
+            {props.activeMemberCount}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {props.activeMemberCount === 1 ? 'active member' : 'active members'}
+          </p>
+        </section>
+
+        <section className="space-y-3 pt-6 border-t border-border/50">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground mb-1">
+              From
+            </p>
+            <p className="text-sm text-foreground leading-snug">
+              {props.communityName}
+              <span className="block text-xs text-muted-foreground">
+                community@dance-hub.io
+              </span>
+            </p>
+          </div>
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground mb-1">
+              Reply-to
+            </p>
+            <p className="text-sm text-foreground break-all">{props.ownerEmail}</p>
+          </div>
+        </section>
+
+        <section className="pt-6 border-t border-border/50">
+          <QuotaBadge {...props.quota} />
+        </section>
+
+        <section className="space-y-2 pt-2">
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={sending}
+            className="w-full bg-primary text-primary-foreground py-3 px-4 rounded-sm text-sm font-medium tracking-wide hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {sending
+              ? 'Publishing…'
+              : atLimit && props.quota.tier === 'free'
+              ? 'Upgrade to publish →'
+              : 'Publish broadcast'}
+          </button>
+          <button
+            type="button"
+            onClick={handleSendTest}
+            disabled={testing}
+            className="w-full bg-transparent text-foreground py-3 px-4 rounded-sm text-sm font-medium border border-border hover:border-primary hover:text-primary transition-colors disabled:opacity-50"
+          >
+            {testing ? 'Sending test…' : 'Send test to myself'}
+          </button>
+        </section>
       </aside>
 
-      <UpgradeDialog open={upgradeOpen} onOpenChange={setUpgradeOpen} communitySlug={props.communitySlug} />
+      <UpgradeDialog
+        open={upgradeOpen}
+        onOpenChange={setUpgradeOpen}
+        communitySlug={props.communitySlug}
+      />
     </div>
   );
 }

--- a/components/emails/EmailComposer.tsx
+++ b/components/emails/EmailComposer.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-hot-toast';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { EmailEditor } from './EmailEditor';
+import { QuotaBadge } from './QuotaBadge';
+import { UpgradeDialog } from './UpgradeDialog';
+
+interface Props {
+  communityId: string;
+  communitySlug: string;
+  communityName: string;
+  ownerEmail: string;
+  activeMemberCount: number;
+  quota: { tier: 'vip' | 'paid' | 'free'; used: number; limit: number | null };
+}
+
+export function EmailComposer(props: Props) {
+  const router = useRouter();
+  const [subject, setSubject] = useState('');
+  const [previewText, setPreviewText] = useState('');
+  const [html, setHtml] = useState('');
+  const [json, setJson] = useState<unknown>(null);
+  const [sending, setSending] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
+
+  const atLimit = props.quota.limit !== null && props.quota.used >= props.quota.limit;
+
+  const validate = () => {
+    if (!subject.trim()) { toast.error('Subject is required'); return false; }
+    if (!html.trim() || html === '<p></p>') { toast.error('Message is empty'); return false; }
+    return true;
+  };
+
+  const handleSend = async () => {
+    if (atLimit && props.quota.tier === 'free') { setUpgradeOpen(true); return; }
+    if (!validate()) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/api/community/${props.communitySlug}/broadcasts`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject, htmlContent: html, editorJson: json, previewText }),
+      });
+      if (res.status === 402) { setUpgradeOpen(true); return; }
+      if (!res.ok) throw new Error((await res.json()).error || 'Send failed');
+      const data = await res.json();
+      if (data.status === 'partial_failure') {
+        toast(`Sent to ${data.successfulCount} of ${data.recipientCount}. ${data.failedCount} failed.`, { icon: '⚠️' });
+      } else {
+        toast.success(`Sent to ${data.recipientCount} members.`);
+      }
+      router.push(`/${props.communitySlug}/admin/emails/${data.broadcastId}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Send failed');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleSendTest = async () => {
+    if (!validate()) return;
+    setTesting(true);
+    try {
+      const res = await fetch(`/api/community/${props.communitySlug}/broadcasts/test`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject, htmlContent: html, previewText }),
+      });
+      if (!res.ok) throw new Error('Test send failed');
+      toast.success(`Test sent to ${props.ownerEmail}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Test send failed');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="lg:col-span-2 space-y-4">
+        <div>
+          <Label htmlFor="subject">Subject</Label>
+          <Input id="subject" value={subject} onChange={(e) => setSubject(e.target.value)} placeholder="e.g., Spring schedule update" />
+        </div>
+        <div>
+          <Label htmlFor="preview">Preview text (optional)</Label>
+          <Input id="preview" value={previewText} onChange={(e) => setPreviewText(e.target.value)} placeholder="Short description shown in inbox" />
+        </div>
+        <EmailEditor communitySlug={props.communitySlug} onChange={(h, j) => { setHtml(h); setJson(j); }} />
+      </div>
+
+      <aside className="space-y-4">
+        <div className="border rounded-lg p-4 space-y-3">
+          <div>
+            <div className="text-xs text-muted-foreground">Recipients</div>
+            <div className="text-lg font-semibold">{props.activeMemberCount} active members</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Sending from</div>
+            <div className="text-sm">{props.communityName} &lt;community@dance-hub.io&gt;</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Reply-to</div>
+            <div className="text-sm">{props.ownerEmail}</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground mb-1">Quota</div>
+            <QuotaBadge {...props.quota} />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Button onClick={handleSend} disabled={sending} className="w-full">
+            {sending ? 'Sending…' : atLimit && props.quota.tier === 'free' ? 'Upgrade to send →' : 'Send now'}
+          </Button>
+          <Button variant="outline" onClick={handleSendTest} disabled={testing} className="w-full">
+            {testing ? 'Sending test…' : 'Send test to me'}
+          </Button>
+        </div>
+      </aside>
+
+      <UpgradeDialog open={upgradeOpen} onOpenChange={setUpgradeOpen} communitySlug={props.communitySlug} />
+    </div>
+  );
+}

--- a/components/emails/EmailEditor.tsx
+++ b/components/emails/EmailEditor.tsx
@@ -31,7 +31,13 @@ export function EmailEditor({ communitySlug, initialHtml = '', onChange }: Email
         codeBlock: false,
       }),
       TextAlign.configure({ types: ['heading', 'paragraph'], alignments: ['left', 'center', 'right'] }),
-      Link.configure({ openOnClick: false, HTMLAttributes: { class: 'text-indigo-600 underline' } }),
+      Link.configure({
+        openOnClick: false,
+        HTMLAttributes: { class: 'text-indigo-600 underline' },
+        // Reject javascript:/data:/vbscript: URLs to prevent XSS via the link picker
+        validate: (href: string) =>
+          /^https?:\/\//i.test(href) || /^mailto:/i.test(href) || /^tel:/i.test(href),
+      }),
       Image.configure({ HTMLAttributes: { class: 'max-w-full rounded' } }),
       Placeholder.configure({ placeholder: 'Write your email…' }),
     ],

--- a/components/emails/EmailEditor.tsx
+++ b/components/emails/EmailEditor.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import TextAlign from '@tiptap/extension-text-align';
+import Link from '@tiptap/extension-link';
+import Image from '@tiptap/extension-image';
+import Placeholder from '@tiptap/extension-placeholder';
+import {
+  Bold, Italic, List, ListOrdered, AlignLeft, AlignCenter, AlignRight,
+  Heading1, Heading2, Link as LinkIcon, ImageIcon, Eraser,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface EmailEditorProps {
+  communitySlug: string;
+  initialHtml?: string;
+  onChange: (html: string, json: unknown) => void;
+}
+
+export function EmailEditor({ communitySlug, initialHtml = '', onChange }: EmailEditorProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [1, 2] },
+        blockquote: false,
+        codeBlock: false,
+      }),
+      TextAlign.configure({ types: ['heading', 'paragraph'], alignments: ['left', 'center', 'right'] }),
+      Link.configure({ openOnClick: false, HTMLAttributes: { class: 'text-indigo-600 underline' } }),
+      Image.configure({ HTMLAttributes: { class: 'max-w-full rounded' } }),
+      Placeholder.configure({ placeholder: 'Write your email…' }),
+    ],
+    content: initialHtml,
+    editorProps: {
+      attributes: {
+        class: 'prose prose-sm max-w-full focus:outline-none min-h-[400px] p-4',
+      },
+    },
+    onUpdate: ({ editor }) => onChange(editor.getHTML(), editor.getJSON()),
+    immediatelyRender: false,
+  });
+
+  if (!editor) return null;
+
+  const setLink = () => {
+    const previous = editor.getAttributes('link').href;
+    const url = window.prompt('URL', previous);
+    if (url === null) return;
+    if (url === '') {
+      editor.chain().focus().extendMarkRange('link').unsetLink().run();
+      return;
+    }
+    editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+  };
+
+  const insertImage = async (file: File) => {
+    setUploading(true);
+    try {
+      const form = new FormData();
+      form.set('file', file);
+      form.set('communitySlug', communitySlug);
+      const res = await fetch('/api/upload/broadcast-image', { method: 'POST', body: form });
+      if (!res.ok) throw new Error(await res.text());
+      const { url } = await res.json();
+      editor.chain().focus().setImage({ src: url }).run();
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const Btn = ({ onClick, active, children, label }: { onClick: () => void; active?: boolean; children: React.ReactNode; label: string }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className={cn(
+        'h-8 w-8 flex items-center justify-center rounded-lg transition-colors',
+        active ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-primary/10'
+      )}
+    >
+      {children}
+    </button>
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 border rounded-lg p-2 bg-muted/30">
+        <Btn onClick={() => editor.chain().focus().toggleBold().run()} active={editor.isActive('bold')} label="Bold"><Bold className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleItalic().run()} active={editor.isActive('italic')} label="Italic"><Italic className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()} active={editor.isActive('heading', { level: 1 })} label="Heading 1"><Heading1 className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()} active={editor.isActive('heading', { level: 2 })} label="Heading 2"><Heading2 className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleBulletList().run()} active={editor.isActive('bulletList')} label="Bullet list"><List className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleOrderedList().run()} active={editor.isActive('orderedList')} label="Numbered list"><ListOrdered className="h-4 w-4" /></Btn>
+        <Btn onClick={setLink} active={editor.isActive('link')} label="Link"><LinkIcon className="h-4 w-4" /></Btn>
+        <Btn onClick={() => fileInputRef.current?.click()} label="Image"><ImageIcon className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().setTextAlign('left').run()} active={editor.isActive({ textAlign: 'left' })} label="Align left"><AlignLeft className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().setTextAlign('center').run()} active={editor.isActive({ textAlign: 'center' })} label="Align center"><AlignCenter className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().setTextAlign('right').run()} active={editor.isActive({ textAlign: 'right' })} label="Align right"><AlignRight className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().unsetAllMarks().clearNodes().run()} label="Clear formatting"><Eraser className="h-4 w-4" /></Btn>
+        {uploading && <span className="text-xs text-muted-foreground">Uploading…</span>}
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        className="hidden"
+        onChange={(e) => e.target.files?.[0] && insertImage(e.target.files[0])}
+      />
+
+      <div className="border-2 border-border/30 rounded-2xl bg-card">
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  );
+}

--- a/components/emails/QuotaBadge.tsx
+++ b/components/emails/QuotaBadge.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils';
+
+export interface QuotaBadgeProps {
+  tier: 'vip' | 'paid' | 'free';
+  used: number;
+  limit: number | null;
+  className?: string;
+}
+
+export function QuotaBadge({ tier, used, limit, className }: QuotaBadgeProps) {
+  if (tier === 'vip') {
+    return (
+      <span className={cn('inline-flex items-center rounded-full bg-emerald-100 text-emerald-800 px-3 py-1 text-xs font-medium', className)}>
+        VIP · Unlimited
+      </span>
+    );
+  }
+  if (tier === 'paid') {
+    return (
+      <span className={cn('inline-flex items-center rounded-full bg-indigo-100 text-indigo-800 px-3 py-1 text-xs font-medium', className)}>
+        Unlimited · {used} sent this month
+      </span>
+    );
+  }
+  const atLimit = limit !== null && used >= limit;
+  return (
+    <span className={cn(
+      'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium',
+      atLimit ? 'bg-amber-100 text-amber-800' : 'bg-slate-100 text-slate-800',
+      className
+    )}>
+      {used} / {limit} this month
+    </span>
+  );
+}

--- a/components/emails/QuotaBadge.tsx
+++ b/components/emails/QuotaBadge.tsx
@@ -7,29 +7,44 @@ export interface QuotaBadgeProps {
   className?: string;
 }
 
+/**
+ * Narrative quota line — intentionally typographic, not a pill.
+ * Use in the emails list hero and composer side panel.
+ */
 export function QuotaBadge({ tier, used, limit, className }: QuotaBadgeProps) {
   if (tier === 'vip') {
     return (
-      <span className={cn('inline-flex items-center rounded-full bg-emerald-100 text-emerald-800 px-3 py-1 text-xs font-medium', className)}>
-        VIP · Unlimited
-      </span>
+      <p className={cn('text-sm text-muted-foreground', className)}>
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 mr-2 align-middle" />
+        <span className="text-foreground font-medium">VIP access</span>
+        <span className="text-muted-foreground"> · unlimited broadcasts</span>
+      </p>
     );
   }
+
   if (tier === 'paid') {
     return (
-      <span className={cn('inline-flex items-center rounded-full bg-indigo-100 text-indigo-800 px-3 py-1 text-xs font-medium', className)}>
-        Unlimited · {used} sent this month
-      </span>
+      <p className={cn('text-sm text-muted-foreground', className)}>
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary mr-2 align-middle" />
+        <span className="text-foreground font-medium">Unlimited</span>
+        <span className="text-muted-foreground">
+          {' · '}
+          {used} sent this month
+        </span>
+      </p>
     );
   }
+
   const atLimit = limit !== null && used >= limit;
+  const dotColor = atLimit ? 'bg-amber-500' : 'bg-slate-400';
+
   return (
-    <span className={cn(
-      'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium',
-      atLimit ? 'bg-amber-100 text-amber-800' : 'bg-slate-100 text-slate-800',
-      className
-    )}>
-      {used} / {limit} this month
-    </span>
+    <p className={cn('text-sm text-muted-foreground', className)}>
+      <span className={cn('inline-block h-1.5 w-1.5 rounded-full mr-2 align-middle', dotColor)} />
+      <span className="text-foreground font-medium">
+        {used} of {limit}
+      </span>
+      <span className="text-muted-foreground"> broadcasts this month</span>
+    </p>
   );
 }

--- a/components/emails/UpgradeDialog.tsx
+++ b/components/emails/UpgradeDialog.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export interface UpgradeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  communitySlug: string;
+}
+
+export function UpgradeDialog({ open, onOpenChange, communitySlug }: UpgradeDialogProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleSubscribe = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/community/${communitySlug}/broadcasts/subscription`, { method: 'POST' });
+      if (!res.ok) throw new Error('Checkout failed');
+      const { checkoutUrl } = await res.json();
+      window.location.href = checkoutUrl;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Upgrade to unlimited broadcasts</DialogTitle>
+          <DialogDescription>
+            You&apos;ve sent 10 emails this month. Upgrade to send unlimited broadcasts for €10/month.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="text-sm space-y-2 py-2">
+          <li>Unlimited broadcasts to your community</li>
+          <li>Cancel anytime from the same page</li>
+          <li>Fair-use cap of 200 sends per month</li>
+        </ul>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button onClick={handleSubscribe} disabled={loading}>
+            {loading ? 'Redirecting…' : 'Subscribe — €10/month'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/docs/superpowers/plans/2026-04-14-community-broadcasts.md
+++ b/docs/superpowers/plans/2026-04-14-community-broadcasts.md
@@ -1,0 +1,2978 @@
+# Community Broadcasts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let community owners send rich-text email broadcasts to their active members, with a 10-per-month free quota, a €10/month unlimited tier, and an admin-toggleable VIP bypass.
+
+**Architecture:** Owner opens an "Admin → Emails" section of their community, composes a rich-text email (Tiptap, inline images on B2), and sends it as a broadcast. Server-side, `lib/broadcasts/` modules handle quota checking, recipient filtering, Stripe billing, and Resend Batch API orchestration. A new `email_broadcasts` table is the audit trail and quota source. Stripe subscriptions (platform, not Connect) gate the unlimited tier.
+
+**Tech Stack:** Next.js 14 App Router, Neon Postgres via `@neondatabase/serverless`, better-auth, Resend (Batch API), Tiptap, Backblaze B2 (S3-compatible), Stripe (platform account), React Email, Jest, Playwright.
+
+**Spec:** [`docs/superpowers/specs/2026-04-14-community-broadcasts-design.md`](../specs/2026-04-14-community-broadcasts-design.md)
+
+---
+
+## File structure
+
+**New files (created by this plan):**
+
+```
+# Migrations (folder is named supabase/migrations/ historically — still the migration home)
+supabase/migrations/2026-04-14_create_email_broadcasts.sql
+supabase/migrations/2026-04-14_create_community_broadcast_subscriptions.sql
+supabase/migrations/2026-04-14_add_is_broadcast_vip.sql
+supabase/migrations/2026-04-14_add_teacher_broadcast_preference.sql
+
+# Server-side lib
+lib/broadcasts/quota.ts                    # getQuota, checkCanSend
+lib/broadcasts/recipients.ts               # getActiveRecipientsForCommunity
+lib/broadcasts/sender.ts                   # runBroadcast — batch send orchestration
+lib/broadcasts/billing.ts                  # Stripe checkout + subscription helpers
+lib/broadcasts/constants.ts                # FREE_QUOTA, SOFT_CAP, BATCH_SIZE, BATCH_DELAY_MS
+
+# Resend template
+lib/resend/templates/marketing/broadcast.tsx
+
+# API routes
+app/api/community/[communitySlug]/broadcasts/route.ts
+app/api/community/[communitySlug]/broadcasts/[broadcastId]/route.ts
+app/api/community/[communitySlug]/broadcasts/quota/route.ts
+app/api/community/[communitySlug]/broadcasts/subscription/route.ts
+app/api/community/[communitySlug]/broadcasts/test/route.ts
+app/api/upload/broadcast-image/route.ts    # inline image upload endpoint
+
+# UI pages
+app/[communitySlug]/admin/layout.tsx
+app/[communitySlug]/admin/page.tsx
+app/[communitySlug]/admin/emails/page.tsx
+app/[communitySlug]/admin/emails/new/page.tsx
+app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
+
+# UI components
+components/admin/AdminNav.tsx
+components/emails/EmailEditor.tsx
+components/emails/EmailComposer.tsx
+components/emails/QuotaBadge.tsx
+components/emails/UpgradeDialog.tsx
+components/emails/BroadcastHistoryList.tsx
+
+# Tests
+__tests__/lib/broadcasts/quota.test.ts
+__tests__/lib/broadcasts/recipients.test.ts
+__tests__/lib/broadcasts/sender.test.ts
+__tests__/lib/broadcasts/billing.test.ts
+__tests__/api/broadcasts/route.test.ts
+__tests__/api/broadcasts/subscription.test.ts
+__tests__/api/broadcasts/quota.test.ts
+__tests__/components/emails/EmailEditor.test.tsx
+__tests__/components/emails/QuotaBadge.test.tsx
+e2e/community-broadcasts.spec.ts
+```
+
+**Modified files:**
+
+```
+lib/resend/check-preferences.ts       # add 'teacher_broadcast' category
+app/api/webhooks/stripe/route.ts      # add broadcast subscription event handlers
+components/CommunityNavbar.tsx        # add owner-only "Admin" tab (path found during Task 25)
+```
+
+**File responsibilities:**
+
+- **`lib/broadcasts/quota.ts`** — Pure async functions over the DB: quota lookup, send-gate decision. No Resend, no Stripe calls.
+- **`lib/broadcasts/recipients.ts`** — Query active opted-in members for a community. Returns `{ userId, email, displayName, unsubscribeToken }[]`.
+- **`lib/broadcasts/sender.ts`** — Given a broadcast row + recipient list, chunks and calls `resend.batch.send`, handles retries and partial failure. Updates the broadcast row.
+- **`lib/broadcasts/billing.ts`** — Creates Stripe Checkout sessions and handles subscription lifecycle writes to `community_broadcast_subscriptions`.
+- **`lib/broadcasts/constants.ts`** — `FREE_QUOTA_PER_MONTH = 10`, `PAID_SOFT_CAP_PER_MONTH = 200`, `BATCH_SIZE = 100`, `BATCH_DELAY_MS = 250`, `MAX_BATCH_RETRIES = 3`. Change these in one place.
+
+---
+
+## Implementation philosophy
+
+- **Test-first for logic modules** (`lib/broadcasts/*`) and API routes — every function gets a failing test before implementation.
+- **Lighter coverage for UI components** — one smoke test per interactive component, visual QA via Playwright smoke + manual checklist.
+- **Commit after every green test**, and after each UI component is wired up. Keep commits small so review is easy.
+- **No scaffolding before it's used.** If a later task needs a helper, the task that introduces it defines it — don't create empty shells.
+
+---
+
+## Phase 1 — Database foundation
+
+### Task 1: Create `email_broadcasts` table
+
+**Files:**
+- Create: `supabase/migrations/2026-04-14_create_email_broadcasts.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- supabase/migrations/2026-04-14_create_email_broadcasts.sql
+
+CREATE TABLE email_broadcasts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  community_id uuid NOT NULL REFERENCES communities(id) ON DELETE CASCADE,
+  sender_user_id uuid NOT NULL REFERENCES profiles(id),
+  subject text NOT NULL,
+  html_content text NOT NULL,
+  editor_json jsonb NOT NULL,
+  preview_text text,
+  recipient_count integer NOT NULL DEFAULT 0,
+  status text NOT NULL
+    CHECK (status IN ('pending', 'sending', 'sent', 'partial_failure', 'failed')),
+  resend_batch_ids text[] NOT NULL DEFAULT '{}',
+  error_message text,
+  sent_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_email_broadcasts_community_created
+  ON email_broadcasts (community_id, created_at DESC);
+
+COMMENT ON TABLE email_broadcasts IS
+  'Audit trail of community broadcast emails. Also the source of truth for monthly quota counting.';
+```
+
+- [ ] **Step 2: Apply migration against preprod branch**
+
+Run: `psql "$NEON_PREPROD_DATABASE_URL" -f supabase/migrations/2026-04-14_create_email_broadcasts.sql`
+
+Expected: `CREATE TABLE`, `CREATE INDEX`, `COMMENT` — no errors.
+
+- [ ] **Step 3: Verify**
+
+Run: `psql "$NEON_PREPROD_DATABASE_URL" -c "\d email_broadcasts"`
+Expected: Table description listing all columns with correct types, the FK constraints, and the index.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/2026-04-14_create_email_broadcasts.sql
+git commit -m "feat(broadcasts): add email_broadcasts table"
+```
+
+---
+
+### Task 2: Create `community_broadcast_subscriptions` table
+
+**Files:**
+- Create: `supabase/migrations/2026-04-14_create_community_broadcast_subscriptions.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- supabase/migrations/2026-04-14_create_community_broadcast_subscriptions.sql
+
+CREATE TABLE community_broadcast_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  community_id uuid NOT NULL UNIQUE REFERENCES communities(id) ON DELETE CASCADE,
+  stripe_customer_id text NOT NULL,
+  stripe_subscription_id text NOT NULL,
+  status text NOT NULL
+    CHECK (status IN ('active', 'past_due', 'canceled', 'incomplete')),
+  current_period_end timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_community_broadcast_subscriptions_stripe_sub
+  ON community_broadcast_subscriptions (stripe_subscription_id);
+
+COMMENT ON TABLE community_broadcast_subscriptions IS
+  'Stripe subscription state for the €10/month unlimited broadcast tier, one row per community.';
+```
+
+- [ ] **Step 2: Apply + verify**
+
+Run: `psql "$NEON_PREPROD_DATABASE_URL" -f supabase/migrations/2026-04-14_create_community_broadcast_subscriptions.sql && psql "$NEON_PREPROD_DATABASE_URL" -c "\d community_broadcast_subscriptions"`
+Expected: table created, UNIQUE constraint on community_id listed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/2026-04-14_create_community_broadcast_subscriptions.sql
+git commit -m "feat(broadcasts): add community_broadcast_subscriptions table"
+```
+
+---
+
+### Task 3: Add `is_broadcast_vip` to `communities`
+
+**Files:**
+- Create: `supabase/migrations/2026-04-14_add_is_broadcast_vip.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- supabase/migrations/2026-04-14_add_is_broadcast_vip.sql
+
+ALTER TABLE communities
+  ADD COLUMN is_broadcast_vip boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN communities.is_broadcast_vip IS
+  'Platform-admin-toggleable flag. When true, this community bypasses broadcast quota and billing checks.';
+```
+
+- [ ] **Step 2: Apply + verify**
+
+Run: `psql "$NEON_PREPROD_DATABASE_URL" -f supabase/migrations/2026-04-14_add_is_broadcast_vip.sql && psql "$NEON_PREPROD_DATABASE_URL" -c "\d communities" | grep is_broadcast_vip`
+Expected: `is_broadcast_vip | boolean | ... | not null | false`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/2026-04-14_add_is_broadcast_vip.sql
+git commit -m "feat(broadcasts): add is_broadcast_vip flag to communities"
+```
+
+---
+
+### Task 4: Add `teacher_broadcast` email preference column
+
+**Context:** `lib/resend/check-preferences.ts` reads boolean columns from `email_preferences` (e.g., `marketing_emails`, `lesson_reminders`). We're adding a new column for the broadcast category.
+
+**Files:**
+- Create: `supabase/migrations/2026-04-14_add_teacher_broadcast_preference.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- supabase/migrations/2026-04-14_add_teacher_broadcast_preference.sql
+
+ALTER TABLE email_preferences
+  ADD COLUMN teacher_broadcast boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN email_preferences.teacher_broadcast IS
+  'Whether this user accepts teacher/community-owner newsletter broadcasts. Default true — members opt in by joining a community.';
+```
+
+- [ ] **Step 2: Apply + verify**
+
+Run: `psql "$NEON_PREPROD_DATABASE_URL" -f supabase/migrations/2026-04-14_add_teacher_broadcast_preference.sql`
+Expected: `ALTER TABLE` — no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/2026-04-14_add_teacher_broadcast_preference.sql
+git commit -m "feat(broadcasts): add teacher_broadcast email preference"
+```
+
+---
+
+## Phase 2 — Core library modules
+
+### Task 5: `lib/broadcasts/constants.ts`
+
+**Files:**
+- Create: `lib/broadcasts/constants.ts`
+
+- [ ] **Step 1: Write the file**
+
+```ts
+// lib/broadcasts/constants.ts
+
+export const FREE_QUOTA_PER_MONTH = 10;
+export const PAID_SOFT_CAP_PER_MONTH = 200;
+export const BATCH_SIZE = 100;          // Resend batch API: max 100 emails per call
+export const BATCH_DELAY_MS = 250;      // ~4 req/sec, stays under Resend's 5 req/sec team cap
+export const MAX_BATCH_RETRIES = 3;
+
+export const BROADCAST_FROM_ADDRESS = 'community@dance-hub.io';
+
+// Stripe — the €10/month price must be created in Stripe Dashboard, ID set here via env
+export const BROADCAST_PRICE_ID_ENV = 'STRIPE_BROADCAST_PRICE_ID';
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lib/broadcasts/constants.ts
+git commit -m "feat(broadcasts): add shared constants"
+```
+
+---
+
+### Task 6: `lib/broadcasts/recipients.ts` — get active opted-in members
+
+**Files:**
+- Create: `lib/broadcasts/recipients.ts`
+- Test: `__tests__/lib/broadcasts/recipients.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/lib/broadcasts/recipients.test.ts
+import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
+import { sql } from '@/lib/db';
+
+jest.mock('@/lib/db', () => ({
+  sql: jest.fn(),
+}));
+
+const mockedSql = sql as unknown as jest.Mock;
+
+describe('getActiveRecipientsForCommunity', () => {
+  beforeEach(() => {
+    mockedSql.mockReset();
+  });
+
+  it('returns active members who opted in to teacher_broadcast', async () => {
+    mockedSql.mockResolvedValueOnce([
+      { user_id: 'u1', email: 'a@example.com', full_name: 'Alice', unsubscribe_token: 'tok1' },
+      { user_id: 'u2', email: 'b@example.com', full_name: 'Bob', unsubscribe_token: 'tok2' },
+    ]);
+
+    const result = await getActiveRecipientsForCommunity('community-123');
+
+    expect(result).toEqual([
+      { userId: 'u1', email: 'a@example.com', displayName: 'Alice', unsubscribeToken: 'tok1' },
+      { userId: 'u2', email: 'b@example.com', displayName: 'Bob', unsubscribeToken: 'tok2' },
+    ]);
+    expect(mockedSql).toHaveBeenCalledTimes(1);
+    // Query must filter: active status, teacher_broadcast = true, not unsubscribed_all
+    const sqlCall = mockedSql.mock.calls[0];
+    const sqlText = sqlCall[0].join('?');
+    expect(sqlText).toMatch(/status = 'active'/);
+    expect(sqlText).toMatch(/teacher_broadcast/);
+    expect(sqlText).toMatch(/unsubscribed_all/);
+  });
+
+  it('returns empty array when no members match', async () => {
+    mockedSql.mockResolvedValueOnce([]);
+    const result = await getActiveRecipientsForCommunity('community-123');
+    expect(result).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test __tests__/lib/broadcasts/recipients.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// lib/broadcasts/recipients.ts
+import { query } from '@/lib/db';
+
+export interface BroadcastRecipient {
+  userId: string;
+  email: string;
+  displayName: string;
+  unsubscribeToken: string | null;
+}
+
+interface RecipientRow {
+  user_id: string;
+  email: string;
+  full_name: string | null;
+  unsubscribe_token: string | null;
+}
+
+export async function getActiveRecipientsForCommunity(
+  communityId: string
+): Promise<BroadcastRecipient[]> {
+  const rows = await query<RecipientRow>`
+    SELECT
+      m.user_id,
+      p.email,
+      p.full_name,
+      ep.unsubscribe_token
+    FROM community_members m
+    JOIN profiles p ON p.id = m.user_id
+    LEFT JOIN email_preferences ep ON ep.email = p.email
+    WHERE m.community_id = ${communityId}
+      AND m.status = 'active'
+      AND (m.subscription_status = 'active' OR m.subscription_status IS NULL)
+      AND (ep.teacher_broadcast IS DISTINCT FROM false)
+      AND (ep.unsubscribed_all IS DISTINCT FROM true)
+      AND p.email IS NOT NULL
+  `;
+
+  return rows.map((row) => ({
+    userId: row.user_id,
+    email: row.email,
+    displayName: row.full_name ?? 'there',
+    unsubscribeToken: row.unsubscribe_token,
+  }));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test __tests__/lib/broadcasts/recipients.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/broadcasts/recipients.ts __tests__/lib/broadcasts/recipients.test.ts
+git commit -m "feat(broadcasts): add recipient query"
+```
+
+---
+
+### Task 7: `lib/broadcasts/quota.ts` — quota check logic
+
+**Files:**
+- Create: `lib/broadcasts/quota.ts`
+- Test: `__tests__/lib/broadcasts/quota.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/lib/broadcasts/quota.test.ts
+import { getQuota, checkCanSend } from '@/lib/broadcasts/quota';
+import { queryOne } from '@/lib/db';
+
+jest.mock('@/lib/db', () => ({
+  queryOne: jest.fn(),
+}));
+
+const mockedQueryOne = queryOne as unknown as jest.Mock;
+
+describe('getQuota', () => {
+  beforeEach(() => mockedQueryOne.mockReset());
+
+  it('returns VIP when community is_broadcast_vip=true', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: true })
+      .mockResolvedValueOnce(null);
+    const result = await getQuota('c1');
+    expect(result).toEqual({ tier: 'vip', used: expect.any(Number), limit: null });
+  });
+
+  it('returns paid when active subscription exists', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce({ status: 'active' })
+      .mockResolvedValueOnce({ count: 37 });
+    const result = await getQuota('c1');
+    expect(result).toEqual({ tier: 'paid', used: 37, limit: 200 });
+  });
+
+  it('returns free when no VIP, no active subscription', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 4 });
+    const result = await getQuota('c1');
+    expect(result).toEqual({ tier: 'free', used: 4, limit: 10 });
+  });
+
+  it('returns free when subscription is past_due', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce({ status: 'past_due' })
+      .mockResolvedValueOnce({ count: 2 });
+    const result = await getQuota('c1');
+    expect(result.tier).toBe('free');
+    expect(result.limit).toBe(10);
+  });
+});
+
+describe('checkCanSend', () => {
+  beforeEach(() => mockedQueryOne.mockReset());
+
+  it('allows VIP unconditionally', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: true })
+      .mockResolvedValueOnce(null);
+    await expect(checkCanSend('c1')).resolves.toEqual({ allowed: true });
+  });
+
+  it('rejects free tier at 10/10 used', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 10 });
+    await expect(checkCanSend('c1')).resolves.toEqual({
+      allowed: false,
+      reason: 'quota_exhausted',
+      quota: { tier: 'free', used: 10, limit: 10 },
+    });
+  });
+
+  it('rejects paid tier at soft cap 200/200', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce({ status: 'active' })
+      .mockResolvedValueOnce({ count: 200 });
+    await expect(checkCanSend('c1')).resolves.toEqual({
+      allowed: false,
+      reason: 'soft_cap_reached',
+      quota: { tier: 'paid', used: 200, limit: 200 },
+    });
+  });
+
+  it('allows free tier at 9/10', async () => {
+    mockedQueryOne
+      .mockResolvedValueOnce({ is_broadcast_vip: false })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ count: 9 });
+    await expect(checkCanSend('c1')).resolves.toEqual({ allowed: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test __tests__/lib/broadcasts/quota.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+```ts
+// lib/broadcasts/quota.ts
+import { queryOne } from '@/lib/db';
+import { FREE_QUOTA_PER_MONTH, PAID_SOFT_CAP_PER_MONTH } from './constants';
+
+export type QuotaTier = 'vip' | 'paid' | 'free';
+
+export interface Quota {
+  tier: QuotaTier;
+  used: number;
+  /** Null when unlimited (VIP). */
+  limit: number | null;
+}
+
+export type CanSendResult =
+  | { allowed: true }
+  | { allowed: false; reason: 'quota_exhausted' | 'soft_cap_reached'; quota: Quota };
+
+async function getUsedThisMonth(communityId: string): Promise<number> {
+  const row = await queryOne<{ count: number }>`
+    SELECT COUNT(*)::int AS count
+    FROM email_broadcasts
+    WHERE community_id = ${communityId}
+      AND created_at >= date_trunc('month', now())
+      AND status IN ('sent', 'sending', 'partial_failure')
+  `;
+  return row?.count ?? 0;
+}
+
+export async function getQuota(communityId: string): Promise<Quota> {
+  const community = await queryOne<{ is_broadcast_vip: boolean }>`
+    SELECT is_broadcast_vip FROM communities WHERE id = ${communityId}
+  `;
+
+  const subscription = await queryOne<{ status: string }>`
+    SELECT status
+    FROM community_broadcast_subscriptions
+    WHERE community_id = ${communityId}
+  `;
+
+  const used = await getUsedThisMonth(communityId);
+
+  if (community?.is_broadcast_vip) {
+    return { tier: 'vip', used, limit: null };
+  }
+
+  if (subscription?.status === 'active') {
+    return { tier: 'paid', used, limit: PAID_SOFT_CAP_PER_MONTH };
+  }
+
+  // past_due, canceled, incomplete, or no subscription → free tier
+  return { tier: 'free', used, limit: FREE_QUOTA_PER_MONTH };
+}
+
+export async function checkCanSend(communityId: string): Promise<CanSendResult> {
+  const quota = await getQuota(communityId);
+
+  if (quota.limit === null) {
+    return { allowed: true };
+  }
+
+  if (quota.used < quota.limit) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    reason: quota.tier === 'paid' ? 'soft_cap_reached' : 'quota_exhausted',
+    quota,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test __tests__/lib/broadcasts/quota.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/broadcasts/quota.ts __tests__/lib/broadcasts/quota.test.ts
+git commit -m "feat(broadcasts): add quota and checkCanSend"
+```
+
+---
+
+### Task 8: `lib/broadcasts/sender.ts` — batch send orchestration
+
+**Files:**
+- Create: `lib/broadcasts/sender.ts`
+- Test: `__tests__/lib/broadcasts/sender.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/lib/broadcasts/sender.test.ts
+import { runBroadcast } from '@/lib/broadcasts/sender';
+
+const mockBatchSend = jest.fn();
+const mockSql = jest.fn();
+
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({
+    batch: { send: (...args: unknown[]) => mockBatchSend(...args) },
+  })),
+}));
+
+jest.mock('@/lib/db', () => ({
+  sql: (...args: unknown[]) => mockSql(...args),
+  queryOne: jest.fn(),
+}));
+
+const recipient = (i: number) => ({
+  userId: `u${i}`,
+  email: `user${i}@example.com`,
+  displayName: `User ${i}`,
+  unsubscribeToken: `tok${i}`,
+});
+
+describe('runBroadcast', () => {
+  beforeEach(() => {
+    mockBatchSend.mockReset();
+    mockSql.mockReset();
+    mockSql.mockResolvedValue([]);
+  });
+
+  it('sends a single batch when recipients <= BATCH_SIZE', async () => {
+    mockBatchSend.mockResolvedValueOnce({ data: { data: [{ id: 'batch-1' }] }, error: null });
+
+    const result = await runBroadcast({
+      broadcastId: 'b1',
+      subject: 'Hello',
+      htmlContent: '<p>hi</p>',
+      previewText: 'preview',
+      recipients: [recipient(1), recipient(2)],
+      fromName: 'My Community',
+      replyTo: 'owner@example.com',
+    });
+
+    expect(mockBatchSend).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('sent');
+    expect(result.resendBatchIds).toEqual(['batch-1']);
+  });
+
+  it('chunks into multiple batches of 100', async () => {
+    mockBatchSend.mockResolvedValue({ data: { data: [{ id: 'batch' }] }, error: null });
+    const recipients = Array.from({ length: 250 }, (_, i) => recipient(i));
+
+    const result = await runBroadcast({
+      broadcastId: 'b1',
+      subject: 'Hello',
+      htmlContent: '<p>hi</p>',
+      recipients,
+      fromName: 'X',
+      replyTo: 'x@example.com',
+    });
+
+    expect(mockBatchSend).toHaveBeenCalledTimes(3); // 100 + 100 + 50
+    expect(result.status).toBe('sent');
+  });
+
+  it('returns partial_failure when some batches fail after retries', async () => {
+    mockBatchSend
+      .mockResolvedValueOnce({ data: { data: [{ id: 'batch-1' }] }, error: null })
+      .mockRejectedValue(new Error('boom'));
+
+    const recipients = Array.from({ length: 150 }, (_, i) => recipient(i));
+
+    const result = await runBroadcast({
+      broadcastId: 'b1',
+      subject: 'Hello',
+      htmlContent: '<p>hi</p>',
+      recipients,
+      fromName: 'X',
+      replyTo: 'x@example.com',
+    });
+
+    expect(result.status).toBe('partial_failure');
+    expect(result.errorMessage).toContain('boom');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test __tests__/lib/broadcasts/sender.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+```ts
+// lib/broadcasts/sender.ts
+import { Resend } from 'resend';
+import { BroadcastRecipient } from './recipients';
+import {
+  BATCH_SIZE,
+  BATCH_DELAY_MS,
+  MAX_BATCH_RETRIES,
+  BROADCAST_FROM_ADDRESS,
+} from './constants';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export interface RunBroadcastInput {
+  broadcastId: string;
+  subject: string;
+  htmlContent: string;
+  previewText?: string;
+  recipients: BroadcastRecipient[];
+  fromName: string;
+  replyTo: string;
+}
+
+export interface RunBroadcastResult {
+  status: 'sent' | 'partial_failure' | 'failed';
+  resendBatchIds: string[];
+  errorMessage?: string;
+  successfulCount: number;
+  failedCount: number;
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size));
+  return chunks;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function buildUnsubscribeUrl(token: string | null): string {
+  const base = process.env.NEXT_PUBLIC_SITE_URL || 'https://dance-hub.io';
+  if (!token) return `${base}/settings/email-preferences`;
+  return `${base}/api/email/unsubscribe?token=${encodeURIComponent(token)}&type=teacher_broadcast`;
+}
+
+function personalizeHtml(html: string, recipient: BroadcastRecipient): string {
+  // Replace placeholders that the template inserts: {{unsubscribeUrl}}, {{displayName}}
+  return html
+    .replace(/{{unsubscribeUrl}}/g, buildUnsubscribeUrl(recipient.unsubscribeToken))
+    .replace(/{{displayName}}/g, recipient.displayName);
+}
+
+async function sendBatchWithRetry(
+  batch: BroadcastRecipient[],
+  subject: string,
+  htmlContent: string,
+  fromName: string,
+  replyTo: string,
+  previewText?: string
+): Promise<{ batchId: string | null; error?: Error }> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt < MAX_BATCH_RETRIES; attempt++) {
+    try {
+      const emails = batch.map((r) => ({
+        from: `${fromName} <${BROADCAST_FROM_ADDRESS}>`,
+        to: r.email,
+        replyTo,
+        subject,
+        html: personalizeHtml(htmlContent, r),
+        headers: previewText ? { 'X-Preview': previewText } : undefined,
+        tags: [{ name: 'category', value: 'teacher_broadcast' }],
+      }));
+
+      const result = await resend.batch.send(emails);
+      const firstId = (result as { data?: { data?: Array<{ id: string }> } })?.data?.data?.[0]?.id ?? null;
+      return { batchId: firstId };
+    } catch (err) {
+      lastError = err as Error;
+      if (attempt < MAX_BATCH_RETRIES - 1) {
+        await sleep(BATCH_DELAY_MS * Math.pow(2, attempt));
+      }
+    }
+  }
+  return { batchId: null, error: lastError };
+}
+
+export async function runBroadcast(input: RunBroadcastInput): Promise<RunBroadcastResult> {
+  const { recipients, subject, htmlContent, fromName, replyTo, previewText } = input;
+  const chunks = chunk(recipients, BATCH_SIZE);
+
+  const batchIds: string[] = [];
+  const errors: Error[] = [];
+  let successfulCount = 0;
+  let failedCount = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const batch = chunks[i];
+    const { batchId, error } = await sendBatchWithRetry(
+      batch,
+      subject,
+      htmlContent,
+      fromName,
+      replyTo,
+      previewText
+    );
+    if (batchId) {
+      batchIds.push(batchId);
+      successfulCount += batch.length;
+    } else {
+      if (error) errors.push(error);
+      failedCount += batch.length;
+    }
+    // Throttle between batches (not after the last one)
+    if (i < chunks.length - 1) await sleep(BATCH_DELAY_MS);
+  }
+
+  let status: RunBroadcastResult['status'];
+  if (failedCount === 0) status = 'sent';
+  else if (successfulCount === 0) status = 'failed';
+  else status = 'partial_failure';
+
+  return {
+    status,
+    resendBatchIds: batchIds,
+    errorMessage: errors.length > 0 ? errors.map((e) => e.message).join('; ') : undefined,
+    successfulCount,
+    failedCount,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test __tests__/lib/broadcasts/sender.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/broadcasts/sender.ts __tests__/lib/broadcasts/sender.test.ts
+git commit -m "feat(broadcasts): add batch send orchestration with retries"
+```
+
+---
+
+### Task 9: `lib/broadcasts/billing.ts` — Stripe Checkout + subscription helpers
+
+**Files:**
+- Create: `lib/broadcasts/billing.ts`
+- Test: `__tests__/lib/broadcasts/billing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/lib/broadcasts/billing.test.ts
+import {
+  createBroadcastCheckoutSession,
+  upsertBroadcastSubscription,
+  markBroadcastSubscriptionStatus,
+} from '@/lib/broadcasts/billing';
+
+const mockCreateCheckout = jest.fn();
+jest.mock('@/lib/stripe', () => ({
+  stripe: { checkout: { sessions: { create: (...a: unknown[]) => mockCreateCheckout(...a) } } },
+}));
+
+const mockSql = jest.fn();
+jest.mock('@/lib/db', () => ({
+  sql: (...args: unknown[]) => mockSql(...args),
+  queryOne: jest.fn(),
+}));
+
+describe('createBroadcastCheckoutSession', () => {
+  beforeEach(() => {
+    mockCreateCheckout.mockReset();
+    process.env.STRIPE_BROADCAST_PRICE_ID = 'price_test_123';
+  });
+
+  it('creates a Stripe Checkout session with community metadata', async () => {
+    mockCreateCheckout.mockResolvedValueOnce({ url: 'https://checkout.stripe.com/test', id: 'cs_1' });
+
+    const result = await createBroadcastCheckoutSession({
+      communityId: 'c1',
+      communitySlug: 'salsa',
+      ownerEmail: 'owner@example.com',
+      returnUrl: 'https://app/admin/emails',
+    });
+
+    expect(result).toEqual({ checkoutUrl: 'https://checkout.stripe.com/test', sessionId: 'cs_1' });
+    expect(mockCreateCheckout).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'subscription',
+      line_items: [{ price: 'price_test_123', quantity: 1 }],
+      customer_email: 'owner@example.com',
+      metadata: expect.objectContaining({ communityId: 'c1', purpose: 'broadcast_subscription' }),
+      success_url: expect.stringContaining('salsa'),
+      cancel_url: expect.stringContaining('salsa'),
+    }));
+  });
+});
+
+describe('upsertBroadcastSubscription', () => {
+  it('inserts a new subscription row', async () => {
+    mockSql.mockResolvedValueOnce([]);
+    await upsertBroadcastSubscription({
+      communityId: 'c1',
+      stripeCustomerId: 'cus_1',
+      stripeSubscriptionId: 'sub_1',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-05-01'),
+    });
+    expect(mockSql).toHaveBeenCalled();
+    const sqlText = mockSql.mock.calls[0][0].join('?');
+    expect(sqlText).toMatch(/INSERT INTO community_broadcast_subscriptions/);
+    expect(sqlText).toMatch(/ON CONFLICT/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test __tests__/lib/broadcasts/billing.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+```ts
+// lib/broadcasts/billing.ts
+import { stripe } from '@/lib/stripe';
+import { sql } from '@/lib/db';
+import { BROADCAST_PRICE_ID_ENV } from './constants';
+
+export interface CreateCheckoutSessionInput {
+  communityId: string;
+  communitySlug: string;
+  ownerEmail: string;
+  returnUrl: string; // base URL to build success/cancel
+}
+
+export interface CreateCheckoutSessionResult {
+  checkoutUrl: string;
+  sessionId: string;
+}
+
+export async function createBroadcastCheckoutSession(
+  input: CreateCheckoutSessionInput
+): Promise<CreateCheckoutSessionResult> {
+  const priceId = process.env[BROADCAST_PRICE_ID_ENV];
+  if (!priceId) throw new Error(`Missing ${BROADCAST_PRICE_ID_ENV}`);
+
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://dance-hub.io';
+  const successUrl = `${baseUrl}/${input.communitySlug}/admin/emails?subscription=success`;
+  const cancelUrl = `${baseUrl}/${input.communitySlug}/admin/emails?subscription=cancelled`;
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    customer_email: input.ownerEmail,
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    metadata: {
+      communityId: input.communityId,
+      purpose: 'broadcast_subscription',
+    },
+    subscription_data: {
+      metadata: {
+        communityId: input.communityId,
+        purpose: 'broadcast_subscription',
+      },
+    },
+  });
+
+  if (!session.url) throw new Error('Stripe did not return a checkout URL');
+
+  return { checkoutUrl: session.url, sessionId: session.id };
+}
+
+export interface UpsertSubscriptionInput {
+  communityId: string;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string;
+  status: 'active' | 'past_due' | 'canceled' | 'incomplete';
+  currentPeriodEnd: Date | null;
+}
+
+export async function upsertBroadcastSubscription(input: UpsertSubscriptionInput): Promise<void> {
+  await sql`
+    INSERT INTO community_broadcast_subscriptions
+      (community_id, stripe_customer_id, stripe_subscription_id, status, current_period_end)
+    VALUES
+      (${input.communityId}, ${input.stripeCustomerId}, ${input.stripeSubscriptionId},
+       ${input.status}, ${input.currentPeriodEnd})
+    ON CONFLICT (community_id) DO UPDATE SET
+      stripe_customer_id = EXCLUDED.stripe_customer_id,
+      stripe_subscription_id = EXCLUDED.stripe_subscription_id,
+      status = EXCLUDED.status,
+      current_period_end = EXCLUDED.current_period_end,
+      updated_at = now()
+  `;
+}
+
+export async function markBroadcastSubscriptionStatus(
+  stripeSubscriptionId: string,
+  status: UpsertSubscriptionInput['status'],
+  currentPeriodEnd: Date | null
+): Promise<void> {
+  await sql`
+    UPDATE community_broadcast_subscriptions
+    SET status = ${status},
+        current_period_end = ${currentPeriodEnd},
+        updated_at = now()
+    WHERE stripe_subscription_id = ${stripeSubscriptionId}
+  `;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test __tests__/lib/broadcasts/billing.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/broadcasts/billing.ts __tests__/lib/broadcasts/billing.test.ts
+git commit -m "feat(broadcasts): add Stripe billing helpers"
+```
+
+---
+
+### Task 10: React Email template for broadcasts
+
+**Context:** Wraps the owner's composed HTML in the shared `BaseLayout`, with footer showing unsubscribe + preferences links. The placeholders `{{unsubscribeUrl}}` and `{{displayName}}` are inserted into the raw HTML and replaced per-recipient by `sender.ts`.
+
+**Files:**
+- Create: `lib/resend/templates/marketing/broadcast.tsx`
+
+- [ ] **Step 1: Write the template**
+
+```tsx
+// lib/resend/templates/marketing/broadcast.tsx
+import React from 'react';
+import { Section, Text } from '@react-email/components';
+import { BaseLayout } from '../base-layout';
+
+interface BroadcastEmailProps {
+  communityName: string;
+  subject: string;
+  bodyHtml: string;       // sanitized HTML from the editor
+  previewText?: string;
+}
+
+/**
+ * The broadcast email template. The `bodyHtml` placeholder-interpolations
+ * (e.g. {{unsubscribeUrl}}, {{displayName}}) are replaced later in sender.ts
+ * per recipient. The footer's unsubscribe link uses {{unsubscribeUrl}}.
+ */
+export const BroadcastEmail: React.FC<BroadcastEmailProps> = ({
+  communityName,
+  subject,
+  bodyHtml,
+  previewText,
+}) => (
+  <BaseLayout
+    preview={previewText ?? subject}
+    footer={{
+      showUnsubscribe: true,
+      unsubscribeUrl: '{{unsubscribeUrl}}',
+      preferencesUrl: '{{unsubscribeUrl}}',
+    }}
+  >
+    <Section>
+      <Text style={{ fontSize: '13px', color: '#6b7280', marginBottom: '16px' }}>
+        A message from {communityName}
+      </Text>
+      <div dangerouslySetInnerHTML={{ __html: bodyHtml }} />
+    </Section>
+  </BaseLayout>
+);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lib/resend/templates/marketing/broadcast.tsx
+git commit -m "feat(broadcasts): add react-email template"
+```
+
+---
+
+### Task 11: Update `check-preferences.ts` to handle `teacher_broadcast`
+
+**Files:**
+- Modify: `lib/resend/check-preferences.ts`
+
+- [ ] **Step 1: Add the category to the union type**
+
+Edit `lib/resend/check-preferences.ts`:
+
+Change line 11–17 from:
+```ts
+export type EmailCategory =
+  | 'transactional'
+  | 'marketing'
+  | 'course_announcements'
+  | 'lesson_reminders'
+  | 'community_updates'
+  | 'weekly_digest';
+```
+to:
+```ts
+export type EmailCategory =
+  | 'transactional'
+  | 'marketing'
+  | 'course_announcements'
+  | 'lesson_reminders'
+  | 'community_updates'
+  | 'weekly_digest'
+  | 'teacher_broadcast';
+```
+
+- [ ] **Step 2: Add the column to the `EmailPreferences` interface**
+
+Inside the interface (around line 19–28), add:
+```ts
+  teacher_broadcast: boolean | null;
+```
+
+- [ ] **Step 3: Include column in the SELECT**
+
+In the `canSendEmail` function's SELECT (around lines 48–60), add `teacher_broadcast,` after `weekly_digest,`.
+
+- [ ] **Step 4: Add the switch case**
+
+In the switch statement (around lines 75–88), add **before** `default`:
+```ts
+      case 'teacher_broadcast':
+        return preferences.teacher_broadcast ?? true;
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/resend/check-preferences.ts
+git commit -m "feat(broadcasts): add teacher_broadcast email category"
+```
+
+---
+
+## Phase 3 — API routes
+
+### Task 12: `GET /api/community/[communitySlug]/broadcasts/quota`
+
+**Files:**
+- Create: `app/api/community/[communitySlug]/broadcasts/quota/route.ts`
+- Test: `__tests__/api/broadcasts/quota.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/api/broadcasts/quota.test.ts
+import { GET } from '@/app/api/community/[communitySlug]/broadcasts/quota/route';
+import { getSession } from '@/lib/auth-session';
+import { getQuota } from '@/lib/broadcasts/quota';
+import { queryOne } from '@/lib/db';
+
+jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/broadcasts/quota', () => ({ getQuota: jest.fn() }));
+jest.mock('@/lib/db', () => ({ queryOne: jest.fn() }));
+
+const mockedSession = getSession as jest.Mock;
+const mockedQuota = getQuota as jest.Mock;
+const mockedQueryOne = queryOne as jest.Mock;
+
+function makeReq() {
+  return new Request('http://localhost/api/community/salsa/broadcasts/quota');
+}
+
+describe('GET broadcasts/quota', () => {
+  beforeEach(() => {
+    mockedSession.mockReset();
+    mockedQuota.mockReset();
+    mockedQueryOne.mockReset();
+  });
+
+  it('returns 401 when not logged in', async () => {
+    mockedSession.mockResolvedValueOnce(null);
+    const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when not the community owner', async () => {
+    mockedSession.mockResolvedValueOnce({ user: { id: 'user-2' } });
+    mockedQueryOne.mockResolvedValueOnce({ id: 'c1', created_by: 'user-1' });
+    const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns quota when owner', async () => {
+    mockedSession.mockResolvedValueOnce({ user: { id: 'user-1' } });
+    mockedQueryOne.mockResolvedValueOnce({ id: 'c1', created_by: 'user-1' });
+    mockedQuota.mockResolvedValueOnce({ tier: 'free', used: 3, limit: 10 });
+
+    const res = await GET(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ tier: 'free', used: 3, limit: 10 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test __tests__/api/broadcasts/quota.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+```ts
+// app/api/community/[communitySlug]/broadcasts/quota/route.ts
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { getQuota } from '@/lib/broadcasts/quota';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; created_by: string }>`
+    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const quota = await getQuota(community.id);
+  return NextResponse.json(quota);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test __tests__/api/broadcasts/quota.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/community/[communitySlug]/broadcasts/quota/route.ts __tests__/api/broadcasts/quota.test.ts
+git commit -m "feat(broadcasts): add quota API endpoint"
+```
+
+---
+
+### Task 13: `POST /api/community/[communitySlug]/broadcasts` — send a broadcast
+
+**Files:**
+- Create: `app/api/community/[communitySlug]/broadcasts/route.ts`
+- Test: `__tests__/api/broadcasts/route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/api/broadcasts/route.test.ts
+import { POST, GET } from '@/app/api/community/[communitySlug]/broadcasts/route';
+import { getSession } from '@/lib/auth-session';
+import { queryOne, query, sql } from '@/lib/db';
+import { checkCanSend } from '@/lib/broadcasts/quota';
+import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
+import { runBroadcast } from '@/lib/broadcasts/sender';
+
+jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/db', () => ({
+  queryOne: jest.fn(),
+  query: jest.fn(),
+  sql: jest.fn(),
+}));
+jest.mock('@/lib/broadcasts/quota', () => ({ checkCanSend: jest.fn() }));
+jest.mock('@/lib/broadcasts/recipients', () => ({ getActiveRecipientsForCommunity: jest.fn() }));
+jest.mock('@/lib/broadcasts/sender', () => ({ runBroadcast: jest.fn() }));
+
+const body = {
+  subject: 'Hello',
+  htmlContent: '<p>Hello</p>',
+  editorJson: { type: 'doc', content: [] },
+  previewText: 'Hi',
+};
+
+function makeReq(b = body) {
+  return new Request('http://localhost/api/community/salsa/broadcasts', {
+    method: 'POST',
+    body: JSON.stringify(b),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('POST broadcasts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('401 when unauthenticated', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce(null);
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when not owner', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u2', email: 'x@x.com' } });
+    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' });
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(403);
+  });
+
+  it('402 when quota exhausted', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
+    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' });
+    (checkCanSend as jest.Mock).mockResolvedValueOnce({
+      allowed: false, reason: 'quota_exhausted',
+      quota: { tier: 'free', used: 10, limit: 10 },
+    });
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(402);
+  });
+
+  it('422 when no recipients', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
+    (queryOne as jest.Mock)
+      .mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' })
+      .mockResolvedValueOnce({ id: 'b-new' }); // insert returns id
+    (checkCanSend as jest.Mock).mockResolvedValueOnce({ allowed: true });
+    (getActiveRecipientsForCommunity as jest.Mock).mockResolvedValueOnce([]);
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(422);
+  });
+
+  it('200 happy path — inserts row, calls runBroadcast, updates status', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
+    (queryOne as jest.Mock)
+      .mockResolvedValueOnce({ id: 'c1', name: 'Salsa', created_by: 'u1' })
+      .mockResolvedValueOnce({ id: 'b-new' });
+    (checkCanSend as jest.Mock).mockResolvedValueOnce({ allowed: true });
+    (getActiveRecipientsForCommunity as jest.Mock).mockResolvedValueOnce([
+      { userId: 'u2', email: 'a@a.com', displayName: 'A', unsubscribeToken: 't' },
+    ]);
+    (runBroadcast as jest.Mock).mockResolvedValueOnce({
+      status: 'sent', resendBatchIds: ['b1'], successfulCount: 1, failedCount: 0,
+    });
+    const res = await POST(makeReq(), { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual(expect.objectContaining({
+      broadcastId: 'b-new',
+      recipientCount: 1,
+      status: 'sent',
+    }));
+    expect(runBroadcast).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test __tests__/api/broadcasts/route.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+```ts
+// app/api/community/[communitySlug]/broadcasts/route.ts
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne, query, sql } from '@/lib/db';
+import { checkCanSend } from '@/lib/broadcasts/quota';
+import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
+import { runBroadcast } from '@/lib/broadcasts/sender';
+
+interface CommunityRow {
+  id: string;
+  name: string;
+  created_by: string;
+}
+
+interface BroadcastListRow {
+  id: string;
+  subject: string;
+  recipient_count: number;
+  status: string;
+  sent_at: string | null;
+  created_at: string;
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<CommunityRow>`
+    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const { subject, htmlContent, editorJson, previewText } = body as {
+    subject: string;
+    htmlContent: string;
+    editorJson: unknown;
+    previewText?: string;
+  };
+  if (!subject || !htmlContent || !editorJson) {
+    return NextResponse.json({ error: 'Missing subject/htmlContent/editorJson' }, { status: 400 });
+  }
+
+  const gate = await checkCanSend(community.id);
+  if (!gate.allowed) {
+    const httpStatus = gate.reason === 'soft_cap_reached' ? 429 : 402;
+    return NextResponse.json({ error: gate.reason, quota: gate.quota }, { status: httpStatus });
+  }
+
+  // Insert broadcast row (status=sending) — quota query counts this row, preventing races
+  const inserted = await queryOne<{ id: string }>`
+    INSERT INTO email_broadcasts
+      (community_id, sender_user_id, subject, html_content, editor_json, preview_text,
+       recipient_count, status)
+    VALUES
+      (${community.id}, ${session.user.id}, ${subject}, ${htmlContent},
+       ${JSON.stringify(editorJson)}::jsonb, ${previewText ?? null}, 0, 'sending')
+    RETURNING id
+  `;
+  if (!inserted) return NextResponse.json({ error: 'Insert failed' }, { status: 500 });
+  const broadcastId = inserted.id;
+
+  const recipients = await getActiveRecipientsForCommunity(community.id);
+  if (recipients.length === 0) {
+    await sql`UPDATE email_broadcasts SET status = 'failed', error_message = 'no_recipients' WHERE id = ${broadcastId}`;
+    return NextResponse.json({ error: 'no_recipients' }, { status: 422 });
+  }
+
+  await sql`UPDATE email_broadcasts SET recipient_count = ${recipients.length} WHERE id = ${broadcastId}`;
+
+  const result = await runBroadcast({
+    broadcastId,
+    subject,
+    htmlContent,
+    previewText,
+    recipients,
+    fromName: community.name,
+    replyTo: session.user.email,
+  });
+
+  await sql`
+    UPDATE email_broadcasts
+    SET status = ${result.status},
+        resend_batch_ids = ${result.resendBatchIds},
+        error_message = ${result.errorMessage ?? null},
+        sent_at = ${result.status === 'sent' || result.status === 'partial_failure' ? new Date() : null}
+    WHERE id = ${broadcastId}
+  `;
+
+  return NextResponse.json({
+    broadcastId,
+    recipientCount: recipients.length,
+    status: result.status,
+    successfulCount: result.successfulCount,
+    failedCount: result.failedCount,
+  });
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<CommunityRow>`
+    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const rows = await query<BroadcastListRow>`
+    SELECT id, subject, recipient_count, status, sent_at, created_at
+    FROM email_broadcasts
+    WHERE community_id = ${community.id}
+    ORDER BY created_at DESC
+    LIMIT 100
+  `;
+  return NextResponse.json({ broadcasts: rows });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test __tests__/api/broadcasts/route.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/community/[communitySlug]/broadcasts/route.ts __tests__/api/broadcasts/route.test.ts
+git commit -m "feat(broadcasts): add POST/GET broadcasts endpoint"
+```
+
+---
+
+### Task 14: `GET /api/community/[communitySlug]/broadcasts/[broadcastId]`
+
+**Files:**
+- Create: `app/api/community/[communitySlug]/broadcasts/[broadcastId]/route.ts`
+
+- [ ] **Step 1: Write implementation** (skipping TDD — trivial read endpoint with the same auth pattern as Task 12)
+
+```ts
+// app/api/community/[communitySlug]/broadcasts/[broadcastId]/route.ts
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { communitySlug: string; broadcastId: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; created_by: string }>`
+    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const broadcast = await queryOne`
+    SELECT id, subject, html_content, editor_json, preview_text, recipient_count,
+           status, error_message, sent_at, created_at
+    FROM email_broadcasts
+    WHERE id = ${params.broadcastId} AND community_id = ${community.id}
+  `;
+  if (!broadcast) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(broadcast);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/api/community/[communitySlug]/broadcasts/[broadcastId]/route.ts
+git commit -m "feat(broadcasts): add GET single broadcast endpoint"
+```
+
+---
+
+### Task 15: `POST /api/community/[communitySlug]/broadcasts/test` — send test to self
+
+**Files:**
+- Create: `app/api/community/[communitySlug]/broadcasts/test/route.ts`
+
+- [ ] **Step 1: Write implementation**
+
+```ts
+// app/api/community/[communitySlug]/broadcasts/test/route.ts
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { runBroadcast } from '@/lib/broadcasts/sender';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; name: string; created_by: string }>`
+    SELECT id, name, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { subject, htmlContent, previewText } = await req.json();
+  if (!subject || !htmlContent) {
+    return NextResponse.json({ error: 'Missing subject or htmlContent' }, { status: 400 });
+  }
+
+  // Send only to the owner, no DB insert (test sends don't count)
+  const result = await runBroadcast({
+    broadcastId: 'test',
+    subject: `[TEST] ${subject}`,
+    htmlContent,
+    previewText,
+    recipients: [{
+      userId: session.user.id,
+      email: session.user.email,
+      displayName: session.user.name || 'there',
+      unsubscribeToken: null,
+    }],
+    fromName: community.name,
+    replyTo: session.user.email,
+  });
+
+  return NextResponse.json({ status: result.status, failedCount: result.failedCount });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/api/community/[communitySlug]/broadcasts/test/route.ts
+git commit -m "feat(broadcasts): add test-send-to-self endpoint"
+```
+
+---
+
+### Task 16: `POST/DELETE /api/community/[communitySlug]/broadcasts/subscription`
+
+**Files:**
+- Create: `app/api/community/[communitySlug]/broadcasts/subscription/route.ts`
+- Test: `__tests__/api/broadcasts/subscription.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/api/broadcasts/subscription.test.ts
+import { POST, DELETE } from '@/app/api/community/[communitySlug]/broadcasts/subscription/route';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { createBroadcastCheckoutSession } from '@/lib/broadcasts/billing';
+
+jest.mock('@/lib/auth-session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/db', () => ({ queryOne: jest.fn(), sql: jest.fn() }));
+jest.mock('@/lib/broadcasts/billing', () => ({ createBroadcastCheckoutSession: jest.fn() }));
+jest.mock('@/lib/stripe', () => ({
+  stripe: { subscriptions: { cancel: jest.fn().mockResolvedValue({}) } },
+}));
+
+describe('POST subscription', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns checkout URL for owner', async () => {
+    (getSession as jest.Mock).mockResolvedValueOnce({ user: { id: 'u1', email: 'o@o.com' } });
+    (queryOne as jest.Mock).mockResolvedValueOnce({ id: 'c1', created_by: 'u1', slug: 'salsa' });
+    (createBroadcastCheckoutSession as jest.Mock).mockResolvedValueOnce({
+      checkoutUrl: 'https://checkout.url', sessionId: 'cs_1',
+    });
+    const req = new Request('http://localhost', { method: 'POST' });
+    const res = await POST(req, { params: { communitySlug: 'salsa' } });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ checkoutUrl: 'https://checkout.url' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test __tests__/api/broadcasts/subscription.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+```ts
+// app/api/community/[communitySlug]/broadcasts/subscription/route.ts
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { queryOne, sql } from '@/lib/db';
+import { stripe } from '@/lib/stripe';
+import { createBroadcastCheckoutSession } from '@/lib/broadcasts/billing';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; slug: string; created_by: string }>`
+    SELECT id, slug, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { checkoutUrl } = await createBroadcastCheckoutSession({
+    communityId: community.id,
+    communitySlug: community.slug,
+    ownerEmail: session.user.email,
+    returnUrl: '',
+  });
+  return NextResponse.json({ checkoutUrl });
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const community = await queryOne<{ id: string; created_by: string }>`
+    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const sub = await queryOne<{ stripe_subscription_id: string }>`
+    SELECT stripe_subscription_id FROM community_broadcast_subscriptions
+    WHERE community_id = ${community.id} AND status = 'active'
+  `;
+  if (!sub) return NextResponse.json({ error: 'No active subscription' }, { status: 404 });
+
+  // Cancel at period end — member retains unlimited until period ends
+  await stripe.subscriptions.update(sub.stripe_subscription_id, { cancel_at_period_end: true });
+  return NextResponse.json({ ok: true, cancelsAtPeriodEnd: true });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test __tests__/api/broadcasts/subscription.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/community/[communitySlug]/broadcasts/subscription/route.ts __tests__/api/broadcasts/subscription.test.ts
+git commit -m "feat(broadcasts): add subscription checkout + cancel endpoint"
+```
+
+---
+
+### Task 17: Extend Stripe webhook for broadcast subscription events
+
+**Files:**
+- Modify: `app/api/webhooks/stripe/route.ts`
+
+**Context:** The existing webhook handles Connect events and platform events. We add three handlers for the broadcast subscription: `checkout.session.completed` (with `metadata.purpose === 'broadcast_subscription'`), `customer.subscription.updated`, `customer.subscription.deleted`.
+
+- [ ] **Step 1: Read existing switch/event-handling structure**
+
+Read `app/api/webhooks/stripe/route.ts` fully to locate where `event.type` is handled (search for a `switch (event.type)` or chained `if` blocks). Identify where platform events are handled (not Connect — Connect events go through the Connect secret branch).
+
+- [ ] **Step 2: Add handler functions at the bottom of the file (before the closing of `POST`)**
+
+```ts
+// ...existing code...
+
+import {
+  upsertBroadcastSubscription,
+  markBroadcastSubscriptionStatus,
+} from '@/lib/broadcasts/billing';
+
+async function handleBroadcastCheckoutCompleted(session: Stripe.Checkout.Session) {
+  if (session.metadata?.purpose !== 'broadcast_subscription') return;
+  const communityId = session.metadata?.communityId;
+  if (!communityId) {
+    console.error('[Broadcast sub] missing communityId in metadata');
+    return;
+  }
+  const subscriptionId = session.subscription as string;
+  const sub = await stripe.subscriptions.retrieve(subscriptionId);
+  await upsertBroadcastSubscription({
+    communityId,
+    stripeCustomerId: sub.customer as string,
+    stripeSubscriptionId: sub.id,
+    status: sub.status as 'active' | 'past_due' | 'canceled' | 'incomplete',
+    currentPeriodEnd: sub.current_period_end ? new Date(sub.current_period_end * 1000) : null,
+  });
+}
+
+async function handleBroadcastSubscriptionUpdated(sub: Stripe.Subscription) {
+  if (sub.metadata?.purpose !== 'broadcast_subscription') return;
+  await markBroadcastSubscriptionStatus(
+    sub.id,
+    sub.status as 'active' | 'past_due' | 'canceled' | 'incomplete',
+    sub.current_period_end ? new Date(sub.current_period_end * 1000) : null
+  );
+}
+```
+
+- [ ] **Step 3: Wire the handlers into the event dispatch**
+
+Locate the existing `switch (event.type)` or if-chain for platform events. Add cases:
+
+```ts
+case 'checkout.session.completed':
+  await handleBroadcastCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+  // …existing logic below this, or if existing code handles checkout.session.completed, call
+  //   both handlers — broadcast handler no-ops when metadata.purpose isn't broadcast_subscription.
+  break;
+
+case 'customer.subscription.updated':
+case 'customer.subscription.deleted':
+  await handleBroadcastSubscriptionUpdated(event.data.object as Stripe.Subscription);
+  break;
+```
+
+If the existing webhook already has these cases for other purposes, **add the broadcast handler call alongside existing logic** — it safely no-ops for non-broadcast events thanks to the `metadata.purpose` check.
+
+- [ ] **Step 4: Verify no typescript errors**
+
+Run: `bun run build` (if fast enough) or `bunx tsc --noEmit`
+Expected: No new type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/webhooks/stripe/route.ts
+git commit -m "feat(broadcasts): wire Stripe webhook for subscription lifecycle"
+```
+
+---
+
+### Task 18: `POST /api/upload/broadcast-image` — inline image upload
+
+**Files:**
+- Create: `app/api/upload/broadcast-image/route.ts`
+
+**Context:** Mirrors the pattern of other uploads in `lib/storage-client.ts`. The endpoint takes multipart/form-data, uploads to B2 under `email-assets/<communityId>/<uuid>.<ext>`, returns the public URL.
+
+- [ ] **Step 1: Read existing storage pattern**
+
+Run: Read `lib/storage.ts` (the `uploadFile` function) and check any existing upload route for request-parsing pattern (e.g., `app/api/upload/`).
+
+- [ ] **Step 2: Write implementation**
+
+```ts
+// app/api/upload/broadcast-image/route.ts
+import { NextResponse } from 'next/server';
+import { v4 as uuid } from 'uuid';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { uploadFile } from '@/lib/storage';
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export async function POST(req: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const formData = await req.formData();
+  const file = formData.get('file') as File | null;
+  const communitySlug = formData.get('communitySlug') as string | null;
+  if (!file || !communitySlug) {
+    return NextResponse.json({ error: 'Missing file or communitySlug' }, { status: 400 });
+  }
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json({ error: 'Unsupported file type' }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: 'File too large (max 5MB)' }, { status: 400 });
+  }
+
+  const community = await queryOne<{ id: string; created_by: string }>`
+    SELECT id, created_by FROM communities WHERE slug = ${communitySlug}
+  `;
+  if (!community || community.created_by !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const ext = file.name.split('.').pop() || 'bin';
+  const key = `email-assets/${community.id}/${uuid()}.${ext}`;
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  const url = await uploadFile(buffer, key, file.type);
+  return NextResponse.json({ url });
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/upload/broadcast-image/route.ts
+git commit -m "feat(broadcasts): add inline image upload endpoint"
+```
+
+---
+
+## Phase 4 — UI
+
+### Task 19: `EmailEditor` component — Tiptap with image upload
+
+**Files:**
+- Create: `components/emails/EmailEditor.tsx`
+
+**Context:** Reuses the same Tiptap extensions as `components/Editor.tsx` but adds a Link button (via `@tiptap/extension-link` — installed in Step 1), an Image button (uploads via `/api/upload/broadcast-image`), and drops the blockquote (not useful in email). We don't reuse `Editor.tsx` directly because the two toolbars diverge and the email editor needs image upload.
+
+- [ ] **Step 1: Install Tiptap Link and Image extensions**
+
+Run: `bun add @tiptap/extension-link @tiptap/extension-image`
+Expected: packages added to `package.json`.
+
+- [ ] **Step 2: Write the component**
+
+```tsx
+// components/emails/EmailEditor.tsx
+'use client';
+
+import { useRef, useState } from 'react';
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import TextAlign from '@tiptap/extension-text-align';
+import Link from '@tiptap/extension-link';
+import Image from '@tiptap/extension-image';
+import Placeholder from '@tiptap/extension-placeholder';
+import {
+  Bold, Italic, List, ListOrdered, AlignLeft, AlignCenter, AlignRight,
+  Heading1, Heading2, Link as LinkIcon, ImageIcon, Eraser,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface EmailEditorProps {
+  communitySlug: string;
+  initialHtml?: string;
+  onChange: (html: string, json: unknown) => void;
+}
+
+export function EmailEditor({ communitySlug, initialHtml = '', onChange }: EmailEditorProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [1, 2] },
+        blockquote: false,
+        codeBlock: false,
+      }),
+      TextAlign.configure({ types: ['heading', 'paragraph'], alignments: ['left', 'center', 'right'] }),
+      Link.configure({ openOnClick: false, HTMLAttributes: { class: 'text-indigo-600 underline' } }),
+      Image.configure({ HTMLAttributes: { class: 'max-w-full rounded' } }),
+      Placeholder.configure({ placeholder: 'Write your email…' }),
+    ],
+    content: initialHtml,
+    editorProps: {
+      attributes: {
+        class: 'prose prose-sm max-w-full focus:outline-none min-h-[400px] p-4',
+      },
+    },
+    onUpdate: ({ editor }) => onChange(editor.getHTML(), editor.getJSON()),
+  });
+
+  if (!editor) return null;
+
+  const setLink = () => {
+    const previous = editor.getAttributes('link').href;
+    const url = window.prompt('URL', previous);
+    if (url === null) return;
+    if (url === '') {
+      editor.chain().focus().extendMarkRange('link').unsetLink().run();
+      return;
+    }
+    editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+  };
+
+  const insertImage = async (file: File) => {
+    setUploading(true);
+    try {
+      const form = new FormData();
+      form.set('file', file);
+      form.set('communitySlug', communitySlug);
+      const res = await fetch('/api/upload/broadcast-image', { method: 'POST', body: form });
+      if (!res.ok) throw new Error(await res.text());
+      const { url } = await res.json();
+      editor.chain().focus().setImage({ src: url }).run();
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const Btn = ({ onClick, active, children, label }: { onClick: () => void; active?: boolean; children: React.ReactNode; label: string }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className={cn(
+        'h-8 w-8 flex items-center justify-center rounded-lg transition-colors',
+        active ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-primary/10'
+      )}
+    >
+      {children}
+    </button>
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 border rounded-lg p-2 bg-muted/30">
+        <Btn onClick={() => editor.chain().focus().toggleBold().run()} active={editor.isActive('bold')} label="Bold"><Bold className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleItalic().run()} active={editor.isActive('italic')} label="Italic"><Italic className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()} active={editor.isActive('heading', { level: 1 })} label="Heading 1"><Heading1 className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()} active={editor.isActive('heading', { level: 2 })} label="Heading 2"><Heading2 className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleBulletList().run()} active={editor.isActive('bulletList')} label="Bullet list"><List className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().toggleOrderedList().run()} active={editor.isActive('orderedList')} label="Numbered list"><ListOrdered className="h-4 w-4" /></Btn>
+        <Btn onClick={setLink} active={editor.isActive('link')} label="Link"><LinkIcon className="h-4 w-4" /></Btn>
+        <Btn onClick={() => fileInputRef.current?.click()} label="Image"><ImageIcon className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().setTextAlign('left').run()} active={editor.isActive({ textAlign: 'left' })} label="Align left"><AlignLeft className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().setTextAlign('center').run()} active={editor.isActive({ textAlign: 'center' })} label="Align center"><AlignCenter className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().setTextAlign('right').run()} active={editor.isActive({ textAlign: 'right' })} label="Align right"><AlignRight className="h-4 w-4" /></Btn>
+        <Btn onClick={() => editor.chain().focus().unsetAllMarks().clearNodes().run()} label="Clear formatting"><Eraser className="h-4 w-4" /></Btn>
+        {uploading && <span className="text-xs text-muted-foreground">Uploading…</span>}
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        className="hidden"
+        onChange={(e) => e.target.files?.[0] && insertImage(e.target.files[0])}
+      />
+
+      <div className="border-2 border-border/30 rounded-2xl bg-card">
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/emails/EmailEditor.tsx package.json bun.lockb
+git commit -m "feat(broadcasts): add EmailEditor component"
+```
+
+---
+
+### Task 20: `QuotaBadge` component
+
+**Files:**
+- Create: `components/emails/QuotaBadge.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/emails/QuotaBadge.tsx
+import { cn } from '@/lib/utils';
+
+export interface QuotaBadgeProps {
+  tier: 'vip' | 'paid' | 'free';
+  used: number;
+  limit: number | null;
+  className?: string;
+}
+
+export function QuotaBadge({ tier, used, limit, className }: QuotaBadgeProps) {
+  if (tier === 'vip') {
+    return (
+      <span className={cn('inline-flex items-center rounded-full bg-emerald-100 text-emerald-800 px-3 py-1 text-xs font-medium', className)}>
+        VIP · Unlimited
+      </span>
+    );
+  }
+  if (tier === 'paid') {
+    return (
+      <span className={cn('inline-flex items-center rounded-full bg-indigo-100 text-indigo-800 px-3 py-1 text-xs font-medium', className)}>
+        Unlimited · {used} sent this month
+      </span>
+    );
+  }
+  const atLimit = limit !== null && used >= limit;
+  return (
+    <span className={cn(
+      'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium',
+      atLimit ? 'bg-amber-100 text-amber-800' : 'bg-slate-100 text-slate-800',
+      className
+    )}>
+      {used} / {limit} this month
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/emails/QuotaBadge.tsx
+git commit -m "feat(broadcasts): add QuotaBadge component"
+```
+
+---
+
+### Task 21: `UpgradeDialog` component
+
+**Files:**
+- Create: `components/emails/UpgradeDialog.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/emails/UpgradeDialog.tsx
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export interface UpgradeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  communitySlug: string;
+}
+
+export function UpgradeDialog({ open, onOpenChange, communitySlug }: UpgradeDialogProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleSubscribe = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/community/${communitySlug}/broadcasts/subscription`, { method: 'POST' });
+      if (!res.ok) throw new Error('Checkout failed');
+      const { checkoutUrl } = await res.json();
+      window.location.href = checkoutUrl;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Upgrade to unlimited broadcasts</DialogTitle>
+          <DialogDescription>
+            You've sent 10 emails this month. Upgrade to send unlimited broadcasts for €10/month.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="text-sm space-y-2 py-2">
+          <li>Unlimited broadcasts to your community</li>
+          <li>Cancel anytime from the same page</li>
+          <li>Fair-use cap of 200 sends per month</li>
+        </ul>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button onClick={handleSubscribe} disabled={loading}>
+            {loading ? 'Redirecting…' : 'Subscribe — €10/month'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/emails/UpgradeDialog.tsx
+git commit -m "feat(broadcasts): add UpgradeDialog component"
+```
+
+---
+
+### Task 22: `BroadcastHistoryList` component
+
+**Files:**
+- Create: `components/emails/BroadcastHistoryList.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/emails/BroadcastHistoryList.tsx
+import Link from 'next/link';
+import { formatDistanceToNow } from 'date-fns';
+
+export interface BroadcastHistoryItem {
+  id: string;
+  subject: string;
+  recipient_count: number;
+  status: 'pending' | 'sending' | 'sent' | 'partial_failure' | 'failed';
+  sent_at: string | null;
+  created_at: string;
+}
+
+const STATUS_LABEL: Record<BroadcastHistoryItem['status'], string> = {
+  pending: 'Pending',
+  sending: 'Sending…',
+  sent: 'Sent',
+  partial_failure: 'Partial delivery',
+  failed: 'Failed',
+};
+
+const STATUS_COLOR: Record<BroadcastHistoryItem['status'], string> = {
+  pending: 'bg-slate-100 text-slate-700',
+  sending: 'bg-indigo-100 text-indigo-800',
+  sent: 'bg-emerald-100 text-emerald-800',
+  partial_failure: 'bg-amber-100 text-amber-800',
+  failed: 'bg-rose-100 text-rose-800',
+};
+
+export function BroadcastHistoryList({
+  broadcasts,
+  communitySlug,
+}: {
+  broadcasts: BroadcastHistoryItem[];
+  communitySlug: string;
+}) {
+  if (broadcasts.length === 0) {
+    return <p className="text-sm text-muted-foreground py-8 text-center">No broadcasts yet.</p>;
+  }
+
+  return (
+    <ul className="divide-y border rounded-lg">
+      {broadcasts.map((b) => (
+        <li key={b.id}>
+          <Link
+            href={`/${communitySlug}/admin/emails/${b.id}`}
+            className="flex items-center justify-between gap-4 p-4 hover:bg-muted/40 transition-colors"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="font-medium truncate">{b.subject}</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                {b.sent_at
+                  ? `Sent ${formatDistanceToNow(new Date(b.sent_at), { addSuffix: true })}`
+                  : `Created ${formatDistanceToNow(new Date(b.created_at), { addSuffix: true })}`}
+                {' · '}
+                {b.recipient_count} recipient{b.recipient_count === 1 ? '' : 's'}
+              </p>
+            </div>
+            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${STATUS_COLOR[b.status]}`}>
+              {STATUS_LABEL[b.status]}
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/emails/BroadcastHistoryList.tsx
+git commit -m "feat(broadcasts): add BroadcastHistoryList component"
+```
+
+---
+
+### Task 23: `EmailComposer` component — the main compose form
+
+**Files:**
+- Create: `components/emails/EmailComposer.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/emails/EmailComposer.tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-hot-toast';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { EmailEditor } from './EmailEditor';
+import { QuotaBadge } from './QuotaBadge';
+import { UpgradeDialog } from './UpgradeDialog';
+
+interface Props {
+  communityId: string;
+  communitySlug: string;
+  communityName: string;
+  ownerEmail: string;
+  activeMemberCount: number;
+  quota: { tier: 'vip' | 'paid' | 'free'; used: number; limit: number | null };
+}
+
+export function EmailComposer(props: Props) {
+  const router = useRouter();
+  const [subject, setSubject] = useState('');
+  const [previewText, setPreviewText] = useState('');
+  const [html, setHtml] = useState('');
+  const [json, setJson] = useState<unknown>(null);
+  const [sending, setSending] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
+
+  const atLimit = props.quota.limit !== null && props.quota.used >= props.quota.limit;
+
+  const validate = () => {
+    if (!subject.trim()) { toast.error('Subject is required'); return false; }
+    if (!html.trim() || html === '<p></p>') { toast.error('Message is empty'); return false; }
+    return true;
+  };
+
+  const handleSend = async () => {
+    if (atLimit && props.quota.tier === 'free') { setUpgradeOpen(true); return; }
+    if (!validate()) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/api/community/${props.communitySlug}/broadcasts`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject, htmlContent: html, editorJson: json, previewText }),
+      });
+      if (res.status === 402) { setUpgradeOpen(true); return; }
+      if (!res.ok) throw new Error((await res.json()).error || 'Send failed');
+      const data = await res.json();
+      if (data.status === 'partial_failure') {
+        toast(`Sent to ${data.successfulCount} of ${data.recipientCount}. ${data.failedCount} failed.`, { icon: '⚠️' });
+      } else {
+        toast.success(`Sent to ${data.recipientCount} members.`);
+      }
+      router.push(`/${props.communitySlug}/admin/emails/${data.broadcastId}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Send failed');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleSendTest = async () => {
+    if (!validate()) return;
+    setTesting(true);
+    try {
+      const res = await fetch(`/api/community/${props.communitySlug}/broadcasts/test`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ subject, htmlContent: html, previewText }),
+      });
+      if (!res.ok) throw new Error('Test send failed');
+      toast.success(`Test sent to ${props.ownerEmail}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Test send failed');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="lg:col-span-2 space-y-4">
+        <div>
+          <Label htmlFor="subject">Subject</Label>
+          <Input id="subject" value={subject} onChange={(e) => setSubject(e.target.value)} placeholder="e.g., Spring schedule update" />
+        </div>
+        <div>
+          <Label htmlFor="preview">Preview text (optional)</Label>
+          <Input id="preview" value={previewText} onChange={(e) => setPreviewText(e.target.value)} placeholder="Short description shown in inbox" />
+        </div>
+        <EmailEditor communitySlug={props.communitySlug} onChange={(h, j) => { setHtml(h); setJson(j); }} />
+      </div>
+
+      <aside className="space-y-4">
+        <div className="border rounded-lg p-4 space-y-3">
+          <div>
+            <div className="text-xs text-muted-foreground">Recipients</div>
+            <div className="text-lg font-semibold">{props.activeMemberCount} active members</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Sending from</div>
+            <div className="text-sm">{props.communityName} &lt;community@dance-hub.io&gt;</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Reply-to</div>
+            <div className="text-sm">{props.ownerEmail}</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground mb-1">Quota</div>
+            <QuotaBadge {...props.quota} />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Button onClick={handleSend} disabled={sending} className="w-full">
+            {sending ? 'Sending…' : atLimit && props.quota.tier === 'free' ? 'Upgrade to send →' : 'Send now'}
+          </Button>
+          <Button variant="outline" onClick={handleSendTest} disabled={testing} className="w-full">
+            {testing ? 'Sending test…' : 'Send test to me'}
+          </Button>
+        </div>
+      </aside>
+
+      <UpgradeDialog open={upgradeOpen} onOpenChange={setUpgradeOpen} communitySlug={props.communitySlug} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/emails/EmailComposer.tsx
+git commit -m "feat(broadcasts): add EmailComposer component"
+```
+
+---
+
+### Task 24: `AdminNav` component
+
+**Files:**
+- Create: `components/admin/AdminNav.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/admin/AdminNav.tsx
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Mail } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export function AdminNav({ communitySlug }: { communitySlug: string }) {
+  const pathname = usePathname();
+  const items = [
+    { href: `/${communitySlug}/admin/emails`, label: 'Emails', icon: Mail },
+  ];
+
+  return (
+    <nav className="w-full sm:w-56 shrink-0 border-b sm:border-b-0 sm:border-r bg-muted/20">
+      <ul className="flex sm:flex-col p-2 gap-1">
+        {items.map((item) => {
+          const active = pathname.startsWith(item.href);
+          const Icon = item.icon;
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className={cn(
+                  'flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
+                  active ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+                )}
+              >
+                <Icon className="h-4 w-4" />
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/admin/AdminNav.tsx
+git commit -m "feat(broadcasts): add AdminNav sidebar component"
+```
+
+---
+
+### Task 25: `/admin/layout.tsx` — owner gate
+
+**Files:**
+- Create: `app/[communitySlug]/admin/layout.tsx`
+
+- [ ] **Step 1: Write the layout**
+
+```tsx
+// app/[communitySlug]/admin/layout.tsx
+import { redirect } from 'next/navigation';
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { AdminNav } from '@/components/admin/AdminNav';
+
+export default async function AdminLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { communitySlug: string };
+}) {
+  const session = await getSession();
+  if (!session) redirect('/auth/login');
+
+  const community = await queryOne<{ id: string; created_by: string; name: string; is_broadcast_vip: boolean }>`
+    SELECT id, created_by, name, is_broadcast_vip FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) redirect(`/${params.communitySlug}`);
+  if (community.created_by !== session.user.id) redirect(`/${params.communitySlug}`);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+      <h1 className="text-2xl font-bold mb-6">Admin · {community.name}</h1>
+      <div className="flex flex-col sm:flex-row gap-6">
+        <AdminNav communitySlug={params.communitySlug} />
+        <main className="flex-1 min-w-0">{children}</main>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/[communitySlug]/admin/layout.tsx
+git commit -m "feat(broadcasts): add admin layout with owner gate"
+```
+
+---
+
+### Task 26: `/admin/page.tsx` — redirect
+
+**Files:**
+- Create: `app/[communitySlug]/admin/page.tsx`
+
+- [ ] **Step 1: Write the page**
+
+```tsx
+// app/[communitySlug]/admin/page.tsx
+import { redirect } from 'next/navigation';
+
+export default function AdminIndex({ params }: { params: { communitySlug: string } }) {
+  redirect(`/${params.communitySlug}/admin/emails`);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/[communitySlug]/admin/page.tsx
+git commit -m "feat(broadcasts): redirect admin index to emails"
+```
+
+---
+
+### Task 27: `/admin/emails/page.tsx` — list page
+
+**Files:**
+- Create: `app/[communitySlug]/admin/emails/page.tsx`
+
+- [ ] **Step 1: Write the page**
+
+```tsx
+// app/[communitySlug]/admin/emails/page.tsx
+import Link from 'next/link';
+import { queryOne, query } from '@/lib/db';
+import { getQuota } from '@/lib/broadcasts/quota';
+import { Button } from '@/components/ui/button';
+import { QuotaBadge } from '@/components/emails/QuotaBadge';
+import { BroadcastHistoryList, BroadcastHistoryItem } from '@/components/emails/BroadcastHistoryList';
+
+export default async function EmailsListPage({ params }: { params: { communitySlug: string } }) {
+  const community = await queryOne<{ id: string }>`
+    SELECT id FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return null;
+
+  const [quota, broadcasts] = await Promise.all([
+    getQuota(community.id),
+    query<BroadcastHistoryItem>`
+      SELECT id, subject, recipient_count, status, sent_at, created_at::text AS created_at
+      FROM email_broadcasts
+      WHERE community_id = ${community.id}
+      ORDER BY created_at DESC
+      LIMIT 100
+    `,
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold">Emails</h2>
+          <QuotaBadge tier={quota.tier} used={quota.used} limit={quota.limit} />
+        </div>
+        <Button asChild>
+          <Link href={`/${params.communitySlug}/admin/emails/new`}>+ New email</Link>
+        </Button>
+      </div>
+      <BroadcastHistoryList broadcasts={broadcasts} communitySlug={params.communitySlug} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/[communitySlug]/admin/emails/page.tsx
+git commit -m "feat(broadcasts): add emails list page"
+```
+
+---
+
+### Task 28: `/admin/emails/new/page.tsx` — composer page
+
+**Files:**
+- Create: `app/[communitySlug]/admin/emails/new/page.tsx`
+
+- [ ] **Step 1: Write the page**
+
+```tsx
+// app/[communitySlug]/admin/emails/new/page.tsx
+import { getSession } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+import { getQuota } from '@/lib/broadcasts/quota';
+import { getActiveRecipientsForCommunity } from '@/lib/broadcasts/recipients';
+import { EmailComposer } from '@/components/emails/EmailComposer';
+
+export default async function NewEmailPage({ params }: { params: { communitySlug: string } }) {
+  const session = await getSession();
+  if (!session) return null;
+
+  const community = await queryOne<{ id: string; name: string }>`
+    SELECT id, name FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return null;
+
+  const [quota, recipients] = await Promise.all([
+    getQuota(community.id),
+    getActiveRecipientsForCommunity(community.id),
+  ]);
+
+  return (
+    <EmailComposer
+      communityId={community.id}
+      communitySlug={params.communitySlug}
+      communityName={community.name}
+      ownerEmail={session.user.email}
+      activeMemberCount={recipients.length}
+      quota={quota}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/[communitySlug]/admin/emails/new/page.tsx
+git commit -m "feat(broadcasts): add new email page"
+```
+
+---
+
+### Task 29: `/admin/emails/[broadcastId]/page.tsx` — detail page
+
+**Files:**
+- Create: `app/[communitySlug]/admin/emails/[broadcastId]/page.tsx`
+
+- [ ] **Step 1: Write the page**
+
+```tsx
+// app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
+import Link from 'next/link';
+import { queryOne } from '@/lib/db';
+import { Button } from '@/components/ui/button';
+
+interface BroadcastRow {
+  id: string;
+  subject: string;
+  html_content: string;
+  preview_text: string | null;
+  recipient_count: number;
+  status: 'pending' | 'sending' | 'sent' | 'partial_failure' | 'failed';
+  error_message: string | null;
+  sent_at: string | null;
+  created_at: string;
+}
+
+export default async function BroadcastDetailPage({
+  params,
+}: {
+  params: { communitySlug: string; broadcastId: string };
+}) {
+  const community = await queryOne<{ id: string }>`
+    SELECT id FROM communities WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return null;
+
+  const broadcast = await queryOne<BroadcastRow>`
+    SELECT * FROM email_broadcasts
+    WHERE id = ${params.broadcastId} AND community_id = ${community.id}
+  `;
+  if (!broadcast) return <p>Broadcast not found.</p>;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">{broadcast.subject}</h2>
+          <p className="text-sm text-muted-foreground">
+            {broadcast.sent_at ? `Sent ${new Date(broadcast.sent_at).toLocaleString()}` : 'Not sent'}
+            {' · '}
+            {broadcast.recipient_count} recipients · {broadcast.status}
+          </p>
+          {broadcast.error_message && (
+            <p className="text-sm text-rose-600 mt-2">Error: {broadcast.error_message}</p>
+          )}
+        </div>
+        <Button variant="outline" asChild>
+          <Link href={`/${params.communitySlug}/admin/emails`}>Back</Link>
+        </Button>
+      </div>
+
+      <div className="border rounded-lg p-6 bg-white">
+        <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: broadcast.html_content }} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/[communitySlug]/admin/emails/[broadcastId]/page.tsx
+git commit -m "feat(broadcasts): add broadcast detail page"
+```
+
+---
+
+### Task 30: Add "Admin" tab to community navbar (owner-only)
+
+**Files:**
+- Modify: the community navbar component (find exact path in Step 1)
+
+- [ ] **Step 1: Find the community navbar**
+
+Run: `grep -Rl "Classroom\|Calendar\|Private lessons" components/ app/` (via Grep tool)
+Expected: Likely `components/CommunityNavbar.tsx` or similar. Read the file to understand existing tab structure.
+
+- [ ] **Step 2: Add the Admin tab conditionally**
+
+The navbar takes a community and current user. Where the existing tabs (Classroom, Calendar, Private lessons) are rendered, add at the end:
+
+```tsx
+{community.created_by === currentUserId && (
+  <NavItem href={`/${community.slug}/admin`} label="Admin" icon={ShieldCheck} />
+)}
+```
+
+Use whatever `NavItem` component or tab-rendering pattern the existing navbar uses. Import `ShieldCheck` from `lucide-react` (or similar gear/admin icon).
+
+- [ ] **Step 3: Manual test**
+
+Run dev server (in a worktree, per project convention): start dev server, navigate to a community you own, verify the "Admin" tab appears. Log out or switch to a non-owner account and verify it's hidden.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add <navbar file path>
+git commit -m "feat(broadcasts): add owner-only Admin tab to community navbar"
+```
+
+---
+
+## Phase 5 — E2E, component smoke tests, rollout
+
+### Task 31: Component smoke test — `QuotaBadge`
+
+**Files:**
+- Create: `__tests__/components/emails/QuotaBadge.test.tsx`
+
+- [ ] **Step 1: Write the test**
+
+```tsx
+// __tests__/components/emails/QuotaBadge.test.tsx
+import { render, screen } from '@testing-library/react';
+import { QuotaBadge } from '@/components/emails/QuotaBadge';
+
+describe('QuotaBadge', () => {
+  it('shows VIP pill when tier is vip', () => {
+    render(<QuotaBadge tier="vip" used={5} limit={null} />);
+    expect(screen.getByText(/VIP/)).toBeInTheDocument();
+  });
+
+  it('shows used/limit when tier is free', () => {
+    render(<QuotaBadge tier="free" used={3} limit={10} />);
+    expect(screen.getByText(/3 \/ 10/)).toBeInTheDocument();
+  });
+
+  it('uses amber style when free tier is at limit', () => {
+    const { container } = render(<QuotaBadge tier="free" used={10} limit={10} />);
+    expect(container.firstChild).toHaveClass('bg-amber-100');
+  });
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `bun test __tests__/components/emails/QuotaBadge.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/components/emails/QuotaBadge.test.tsx
+git commit -m "test(broadcasts): QuotaBadge smoke test"
+```
+
+---
+
+### Task 32: Playwright E2E smoke — full send flow
+
+**Files:**
+- Create: `e2e/community-broadcasts.spec.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+// e2e/community-broadcasts.spec.ts
+import { test, expect } from '@playwright/test';
+
+// NOTE: Assumes a seeded owner account and a community slug 'e2e-community' in the test environment.
+// Uses Resend's `delivered@resend.dev` test address via a one-off recipient seed before the run.
+
+test('owner can compose and send a test broadcast', async ({ page }) => {
+  // Sign in as owner (reuse existing auth helper or login flow)
+  await page.goto('/auth/login');
+  await page.getByLabel('Email').fill(process.env.E2E_OWNER_EMAIL!);
+  await page.getByLabel('Password').fill(process.env.E2E_OWNER_PASSWORD!);
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await expect(page).toHaveURL(/\//);
+
+  await page.goto('/e2e-community/admin/emails');
+  await expect(page.getByRole('heading', { name: 'Emails' })).toBeVisible();
+
+  await page.getByRole('link', { name: /new email/i }).click();
+  await page.getByLabel('Subject').fill('E2E smoke subject');
+  await page.locator('[contenteditable="true"]').click();
+  await page.keyboard.type('Hello from the E2E test.');
+
+  // Send test to self (no DB write, goes to owner email)
+  await page.getByRole('button', { name: /send test to me/i }).click();
+  await expect(page.getByText(/test sent to/i)).toBeVisible({ timeout: 10_000 });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun run test:e2e community-broadcasts.spec.ts`
+Expected: PASS (requires the seeded owner + community in the E2E environment; if not yet seeded, add to your e2e fixtures per existing pattern in `e2e/`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/community-broadcasts.spec.ts
+git commit -m "test(broadcasts): e2e smoke test for compose + test-send"
+```
+
+---
+
+### Task 33: Kill-switch env flag for phased rollout
+
+**Files:**
+- Modify: `components/admin/AdminNav.tsx`
+- Modify: the community navbar (from Task 30)
+- Modify: `app/[communitySlug]/admin/layout.tsx`
+
+- [ ] **Step 1: Add env check**
+
+Create the env var `NEXT_PUBLIC_BROADCASTS_ENABLED` (default `false`). When `false` AND community is not VIP, hide the Admin tab and redirect `/admin/*` to the community root.
+
+Edit `app/[communitySlug]/admin/layout.tsx`:
+
+Replace the post-session/community checks block with:
+```ts
+const featureEnabled = process.env.NEXT_PUBLIC_BROADCASTS_ENABLED === 'true';
+if (!featureEnabled && !community.is_broadcast_vip) {
+  redirect(`/${params.communitySlug}`);
+}
+```
+
+Edit the community navbar (from Task 30): wrap the Admin tab render with the same check:
+```tsx
+{community.created_by === currentUserId
+  && (process.env.NEXT_PUBLIC_BROADCASTS_ENABLED === 'true' || community.is_broadcast_vip)
+  && <NavItem … />}
+```
+
+- [ ] **Step 2: Document env var**
+
+Add to `.env.example` (or the closest equivalent — check if one exists, if not skip):
+```
+# Community Broadcasts feature flag. Set "true" to enable for all communities.
+NEXT_PUBLIC_BROADCASTS_ENABLED=false
+# Stripe Price ID for €10/month unlimited broadcasts (create in Stripe Dashboard)
+STRIPE_BROADCAST_PRICE_ID=price_...
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/[communitySlug]/admin/layout.tsx components/admin/AdminNav.tsx <navbar file> .env.example
+git commit -m "feat(broadcasts): add kill-switch env flag for phased rollout"
+```
+
+---
+
+### Task 34: Manual QA checklist + rollout notes
+
+**Files:**
+- Create: (none — this task runs the manual QA checklist documented in the spec's "Manual QA before launch" section and reports results to the user)
+
+- [ ] **Step 1: Configure Stripe**
+
+- Create a Stripe product in the Dashboard called "Community Broadcasts — Unlimited" with a recurring €10/month price.
+- Copy the price ID into `STRIPE_BROADCAST_PRICE_ID` env var on preprod AND production.
+- Ensure the existing Stripe webhook endpoint URL is subscribed to `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`.
+
+- [ ] **Step 2: Mark one community as VIP for soft launch**
+
+Run on preprod:
+```sql
+UPDATE communities SET is_broadcast_vip = true WHERE slug = '<friendly-community-slug>';
+```
+
+- [ ] **Step 3: Run the manual QA checklist from the spec**
+
+Walk through every bullet in the "Manual QA before launch" section of `docs/superpowers/specs/2026-04-14-community-broadcasts-design.md`:
+- Plain text, headings, inline image, links, bold/italic/lists — in Gmail web + iOS, Apple Mail, Outlook web
+- Unsubscribe link → member correctly opted out of `teacher_broadcast`
+- Send to `bounced@resend.dev` → broadcast marked `partial_failure`
+- Stripe Checkout flow end-to-end in test mode
+- VIP toggle → badge + bypass behavior
+
+- [ ] **Step 4: Enable for production**
+
+Only after all QA passes:
+- Set `NEXT_PUBLIC_BROADCASTS_ENABLED=true` in prod env.
+- Upgrade Resend to Pro tier.
+- Deploy.
+
+- [ ] **Step 5: Commit rollout notes**
+
+Nothing to commit from this task directly — but if you captured anything worth documenting (e.g., a bug found during QA + fix), commit that as a separate change.
+
+---
+
+## Self-review
+
+- **Spec coverage** — all spec requirements addressed:
+  - Quota (free/paid/VIP) → Task 7
+  - €10/mo subscription → Tasks 9, 16, 17
+  - Broadcast send with batching + retries → Task 8
+  - Recipient filtering with opt-out respect → Tasks 6, 11
+  - Email template → Task 10
+  - Inline B2 image upload → Task 18
+  - Admin UI + navbar → Tasks 24–30
+  - VIP admin toggle → DB column in Task 3; used throughout
+  - Phased rollout kill switch → Task 33
+  - Manual QA checklist → Task 34
+- **Placeholder scan** — no TBDs, TODOs, or "similar to Task N" shortcuts. Task 34 intentionally runs the existing manual QA checklist in the spec rather than duplicating it here.
+- **Type consistency** — `BroadcastRecipient`, `Quota`, `CanSendResult`, `RunBroadcastInput`/`RunBroadcastResult` are each defined once and reused consistently across consuming tasks.
+- **Known ambiguity** — Task 17 references "the existing `switch (event.type)` or if-chain" because the webhook file is 100+ lines and evolves. The task tells the engineer to read the file first and add alongside existing logic. Acceptable, since the handler functions themselves are fully specified and safe (they no-op on irrelevant metadata).
+
+---
+
+Plan complete.

--- a/docs/superpowers/specs/2026-04-14-community-broadcasts-design.md
+++ b/docs/superpowers/specs/2026-04-14-community-broadcasts-design.md
@@ -1,0 +1,451 @@
+# Community Broadcasts — Design Spec
+
+**Date:** 2026-04-14
+**Status:** Draft — awaiting user review
+**Author:** Brainstormed with Claude
+
+## Summary
+
+Let community owners send rich-text emails (broadcasts) to all active members of their community, using the existing Resend integration. Owners get 10 free broadcasts per calendar month. Beyond that, a €10/month per-community Stripe subscription unlocks unlimited sending (with a 200/month anti-abuse soft cap). A platform-admin "VIP" flag per community bypasses quota and billing entirely.
+
+## Goals
+
+- Give community owners a first-party way to reach their members (replaces the need for external tools like Mailchimp).
+- Keep the UX simple: compose → send, no scheduling, no segmentation, no analytics in v1.
+- Turn email into a revenue line via the €10/month tier.
+- Build on existing infrastructure: Resend, Tiptap, B2 storage, Stripe, the existing email preferences system.
+
+## Non-goals (v1)
+
+- Scheduling broadcasts for later.
+- Recipient segmentation beyond "all active members".
+- One-to-one teacher→student messaging.
+- Attachments (PDFs, files). Inline images only.
+- In-app open/click analytics (Resend dashboard covers this).
+- Drafts auto-save.
+- A/B testing.
+- Resend-to-failures action.
+- Per-recipient delivery status table (`email_broadcast_recipients`).
+
+---
+
+## User stories
+
+**As a community owner:**
+- I can open an "Admin" section of my community, click "Emails", and compose a rich-text email with headings, lists, links, and inline images.
+- I can send that email as a single broadcast to all currently active members of my community.
+- I can see how many of my 10 free broadcasts I've used this month, and upgrade to the €10/month unlimited tier when I run out.
+- I can view a history of broadcasts I've sent, with status (sent / partial failure / failed) and recipient count.
+- I can send a test broadcast to myself before sending to members.
+
+**As a community member:**
+- I receive broadcasts in my email inbox with the community's name as the sender.
+- I can unsubscribe from teacher broadcasts specifically, without unsubscribing from booking receipts or other transactional emails.
+
+**As a platform admin (the dance-hub operator):**
+- I can mark a community as VIP, giving it unlimited free broadcasts.
+- VIP status is visible to the community owner as a badge.
+- I can monitor broadcast volume per community (via SQL query, no dashboard in v1).
+
+## Success criteria
+
+- An owner can compose and send a broadcast end-to-end in under 2 minutes.
+- Quota counter decrements correctly and resets on the 1st of the month.
+- Stripe upgrade flow successfully converts a quota-exhausted owner to paid.
+- Members who opted out of `teacher_broadcast` don't receive broadcasts.
+- Broadcasts arrive in member inboxes within ~30 seconds of send.
+
+---
+
+## Decisions (from brainstorming)
+
+| Topic | Decision |
+|---|---|
+| Who sends | Community owner only (`community.created_by`) |
+| Recipients | All currently-active members of the community |
+| Sending mode | Broadcast only (one email → many recipients). No one-to-one. |
+| Quota unit | 1 broadcast = 1 quota unit (regardless of recipient count) |
+| Free tier | 10 broadcasts / calendar month, resets on the 1st |
+| Paid tier | €10 / month per community, unlimited with a 200/month soft cap |
+| VIP | Per-community flag, admin-only toggle, bypasses quota + billing, visible badge |
+| Editor | Tiptap (same stack as threads), new `EmailEditor` variant with email-appropriate toolbar |
+| Images | Inline images only, uploaded to Backblaze B2 via existing `lib/storage*` |
+| Unsubscribe | New `teacher_broadcast` preference key in the existing email preferences system |
+| Sender identity | From: `{Community name} <community@dance-hub.io>`, Reply-To: owner's email |
+| Billing | Stripe platform subscription (not Stripe Connect) |
+| Send mechanism | Resend Batch API, chunks of 100, 250ms throttle to stay under 5 req/sec |
+| Scheduling | Send now only. No scheduled send in v1. |
+| Entry point | New owner-only "Admin" tab in community navbar → `/[communitySlug]/admin/emails` |
+| Billing gate for quota | Active subscription OR VIP OR under 10/month |
+
+---
+
+## Data model
+
+### New table: `email_broadcasts`
+
+Audit trail + source of truth for quota counting.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `community_id` | uuid FK → communities | ON DELETE CASCADE |
+| `sender_user_id` | uuid FK → profiles | Owner at time of send |
+| `subject` | text NOT NULL | |
+| `html_content` | text NOT NULL | Final HTML as sent (wrapped in `base-layout.tsx`) |
+| `editor_json` | jsonb NOT NULL | Tiptap doc — enables duplicate/re-edit later |
+| `preview_text` | text | Email preheader, optional |
+| `recipient_count` | int NOT NULL | Number of recipients at send time |
+| `status` | text NOT NULL | `pending` / `sending` / `sent` / `partial_failure` / `failed` |
+| `resend_batch_ids` | text[] | Resend IDs for debugging |
+| `error_message` | text | Populated on failure |
+| `sent_at` | timestamptz | Null until send completes |
+| `created_at` | timestamptz NOT NULL default now() | Used for monthly quota counting |
+
+**Indexes:**
+- `(community_id, created_at DESC)` — quota queries + history list
+
+### New table: `community_broadcast_subscriptions`
+
+Stripe subscription state for the €10/month unlimited tier, per community.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `community_id` | uuid FK → communities UNIQUE | One subscription per community |
+| `stripe_customer_id` | text NOT NULL | |
+| `stripe_subscription_id` | text NOT NULL | |
+| `status` | text NOT NULL | `active` / `past_due` / `canceled` / `incomplete` |
+| `current_period_end` | timestamptz | |
+| `created_at` | timestamptz NOT NULL default now() | |
+| `updated_at` | timestamptz NOT NULL default now() | |
+
+**Indexes:**
+- `(stripe_subscription_id)` — webhook lookups
+
+### New column on `communities`
+
+- `is_broadcast_vip` boolean NOT NULL default false — admin toggle; bypasses quota + billing.
+
+### New email preference key
+
+Add `teacher_broadcast` to the existing preferences system (used by `lib/resend/check-preferences.ts`). **Default: opted-in** — members expect community newsletters when they join a community.
+
+### Quota calculation
+
+No counter table — compute on the fly:
+
+```sql
+SELECT count(*) FROM email_broadcasts
+WHERE community_id = :id
+  AND created_at >= date_trunc('month', now())
+  AND status IN ('sent', 'sending', 'partial_failure');
+```
+
+Always consistent, no drift, cheap with the `(community_id, created_at)` index.
+
+---
+
+## Architecture
+
+### Module layout
+
+```
+app/
+  [communitySlug]/
+    admin/
+      layout.tsx                 # owner-only gate, admin sub-nav
+      page.tsx                   # redirects to ./emails for v1
+      emails/
+        page.tsx                 # list of past broadcasts + "New broadcast" button
+        new/page.tsx             # composer
+        [broadcastId]/page.tsx   # view a past broadcast (read-only)
+  api/
+    communities/[communityId]/
+      broadcasts/
+        route.ts                 # POST (send), GET (list)
+        [broadcastId]/route.ts   # GET one
+        quota/route.ts           # GET current quota + billing state
+        subscription/route.ts    # POST (checkout session), DELETE (cancel)
+    webhooks/stripe/route.ts     # extend to handle broadcast subscription events
+
+components/
+  admin/
+    AdminNav.tsx                 # sub-nav inside /admin
+  emails/
+    EmailComposer.tsx            # top-level compose UI
+    EmailEditor.tsx              # Tiptap variant for email
+    QuotaBadge.tsx               # "3 of 10 used" / "VIP" / "Unlimited"
+    UpgradeDialog.tsx            # Stripe checkout flow when quota exhausted
+    BroadcastHistoryList.tsx
+
+lib/
+  broadcasts/
+    quota.ts                     # getQuota(), checkCanSend() — the gate
+    sender.ts                    # runBroadcast() — batch send orchestration
+    recipients.ts                # getActiveRecipientsForCommunity()
+    billing.ts                   # Stripe checkout + subscription helpers
+  resend/
+    templates/marketing/
+      broadcast.tsx              # React Email template wrapping editor HTML
+```
+
+### Send flow (happy path)
+
+```
+Owner clicks "Send now"
+  ↓
+POST /api/communities/:id/broadcasts
+  ↓
+Auth: requester must be community owner (community.created_by)
+  ↓
+checkCanSend(communityId):
+  - If is_broadcast_vip → allow
+  - Else if active subscription:
+      → allow if < 200/month (soft cap)
+      → else 429 with reason: "soft_cap_reached"
+  - Else count broadcasts this calendar month (status in sent/sending/partial_failure):
+      → allow if < 10
+      → else 402 with reason: "quota_exhausted"
+  ↓
+Insert email_broadcasts row (status: "sending")  ← row counts against quota immediately, prevents race condition
+  ↓
+Fetch active recipients:
+  - members of community with active subscription/membership status
+  - opted-in to teacher_broadcast preference
+  ↓
+If recipients empty → update status to "failed", return 422 "no_recipients"
+  ↓
+Render final HTML:
+  - Wrap editor HTML in base-layout.tsx
+  - Per-recipient: inject unsubscribe link + preferences link
+  ↓
+Chunk recipients into batches of 100
+  ↓
+For each batch:
+  try resend.batch.send([...])  # up to 3 retries with backoff on failure
+  wait 250ms  # stay under 5 req/sec
+  ↓
+Update email_broadcasts:
+  status: "sent" | "partial_failure" | "failed"
+  resend_batch_ids
+  sent_at: now()
+  ↓
+Return 200 { broadcastId, recipientCount, status }
+```
+
+### Stripe subscription flow
+
+```
+Owner clicks "Upgrade" in the composer or quota banner
+  ↓
+POST /api/communities/:id/broadcasts/subscription
+  → create Stripe Checkout Session
+  → metadata: { communityId, ownerId }
+  → success_url: back to composer
+  ↓
+Redirect owner to Stripe Checkout
+  ↓
+Stripe webhook: checkout.session.completed
+  → insert community_broadcast_subscriptions row with status "active"
+  ↓
+Ongoing Stripe webhooks:
+  - customer.subscription.updated → update status + current_period_end
+  - customer.subscription.deleted → status = "canceled"
+  - invoice.payment_failed → status = "past_due"
+```
+
+`past_due` is treated as free tier (10/month quota applies) with a banner in the UI asking the owner to update payment.
+
+---
+
+## Error handling
+
+| Scenario | Behavior |
+|---|---|
+| Non-owner calls API | 403 |
+| Quota exhausted (free tier) | 402, `reason: "quota_exhausted"` — UI shows upgrade dialog |
+| Soft cap hit (paid tier) | 429, `reason: "soft_cap_reached"` — UI asks owner to contact support |
+| Empty recipient list | 422, broadcast row marked `status = failed`. Not counted against quota (quota query only counts `sent` / `sending` / `partial_failure`). |
+| Resend batch call fails | Up to 3 retries per batch with exponential backoff |
+| Some batches fail after retries | Broadcast marked `partial_failure`, `error_message` populated, toast tells owner how many failed. No auto-retry in v1. |
+| Stripe subscription past_due | Treat as free tier, show banner in UI |
+| Concurrent send at quota edge | Insert-then-count pattern: quota query includes the current row being inserted, so the second request sees N+1 and is rejected |
+| Server crashes mid-send | Row left in `sending` state. **Known risk — cleanup cron is a follow-up.** |
+
+---
+
+## UI
+
+### Navigation
+
+New "Admin" tab in the community navbar, rendered only when `community.created_by === currentUserId`:
+
+```
+Community | Classroom | Calendar | Private lessons | [Admin]
+```
+
+`/admin` redirects to `/admin/emails` in v1. Admin page has a left sidebar for sub-sections so we can add more owner tools later (members management, analytics, etc.).
+
+### `/admin/emails` — list page
+
+- Header: page title + `[+ New email]` button.
+- Quota row: `Quota: 3 / 10 this month` with inline `[Upgrade →]` when applicable. Shows `VIP · Unlimited` or `Unlimited (Pro)` instead when relevant.
+- Below: list of past broadcasts, most recent first. Each row shows subject, sent date, recipient count, status badge. Clicking opens the broadcast detail.
+
+### `/admin/emails/new` — composer
+
+Two-column layout on desktop (editor left, side panel right), stacked on mobile:
+
+- **Left column:**
+  - Subject input (required)
+  - Preview text input (optional — shows as preheader in inbox)
+  - Toolbar: B, I, H1, H2, bullet list, ordered list, link, image, align left/center/right, clear formatting
+  - Tiptap editor area (min height ~400px)
+- **Right column (side panel):**
+  - Recipient count: "147 active members"
+  - Sending from: `{Community name} <community@dance-hub.io>`
+  - Reply-to: owner's email
+  - Quota status: `3 of 10 used` (or VIP / Unlimited)
+  - `[Send test to me]` — sends only to owner, bypasses quota, subject prefixed `[TEST]`
+  - `[Send now]` — primary action
+
+### `/admin/emails/[broadcastId]` — detail page
+
+Read-only view: subject, recipient count, sent timestamp, status, rendered HTML preview. No edit/resend/duplicate in v1.
+
+### `EmailEditor` — Tiptap config
+
+Extends the shared Tiptap pattern (`components/Editor.tsx`) with an email-tuned toolbar.
+
+**Included:**
+- Bold, italic, underline
+- H1, H2
+- Bullet + ordered lists
+- Links (popover URL input)
+- Images: file picker → client-side resize (max 800px wide) → upload to B2 via `lib/storage-client` → insert `<img src="...">` at cursor
+- Text alignment (left/center/right) via `@tiptap/extension-text-align`
+- Clear formatting
+
+**Deliberately omitted** (cause email-client rendering issues): tables, code blocks, colors, fonts, video embeds.
+
+Editor HTML is wrapped in `base-layout.tsx` at send time so styling is consistent with other marketing emails and members get the dance-hub header/footer + unsubscribe link.
+
+### Upgrade flow
+
+When an owner has used 10/10 broadcasts:
+- `[Send now]` is disabled and replaced with `[Upgrade to send →]`.
+- Click opens a dialog: "You've sent 10 emails this month. Upgrade to unlimited for €10/month."
+- `[Subscribe]` button → Stripe Checkout.
+- On return (success), composer reloads with unlimited status. Editor content is preserved in local storage across the redirect.
+
+### VIP badge
+
+Green pill: `VIP · Unlimited`. Non-dismissible, shown on the list page quota row.
+
+### Loading / error states
+
+- Send button while sending: `Sending... (batch 2/3)`.
+- On failure: toast with error message, composer state preserved.
+- On partial failure: toast "Sent to 145 of 147 members. 2 failed delivery." linked to broadcast detail.
+
+---
+
+## Testing strategy
+
+### Unit tests (Jest)
+
+- `lib/broadcasts/quota.ts`: `getQuota()` and `checkCanSend()` across all states (free under limit, free at limit, paid active, paid past_due, VIP). Cover calendar-month boundary (Mar 31 broadcast doesn't count toward April).
+- `lib/broadcasts/recipients.ts`: filters cancelled members, opt-outs, members of other communities. Returns empty list gracefully.
+- `lib/broadcasts/billing.ts`: checkout session creation, subscription state transitions from fake Stripe webhook events.
+
+### API tests (Jest, `test:api`)
+
+- POST happy path.
+- Non-owner → 403.
+- Quota exhausted → 402 with correct reason.
+- Concurrent sends at quota edge — only one succeeds.
+- Resend batch failure → partial_failure status.
+- Empty recipient list → 422, quota not consumed.
+- Stripe webhook: `checkout.session.completed` creates subscription row; `customer.subscription.deleted` marks it canceled.
+
+### Component tests (Jest, `test:components`)
+
+- `EmailEditor` toolbar actions produce expected Tiptap transactions.
+- `QuotaBadge` renders correctly for each state.
+- `UpgradeDialog` disabled send → click fires checkout.
+
+### E2E (Playwright) — one smoke test
+
+- Sign in as owner → Admin → Emails → New → compose → send test → assert success toast. Use Resend test addresses (`delivered@resend.dev`, `bounced@resend.dev`).
+
+### Not tested in v1
+
+- Cross-client email rendering (manual QA only for v1).
+- Load testing.
+
+### Manual QA before launch
+
+- Plain text, with headings, inline images, links, bold/italic/lists — each in Gmail web, Gmail iOS, Apple Mail, Outlook web.
+- Unsubscribe link correctly opts member out of `teacher_broadcast`.
+- Send to `bounced@resend.dev` → broadcast marked `partial_failure`.
+- Stripe test mode: subscribe → verify unlimited → cancel → verify quota re-applies.
+- VIP toggle → verify badge + bypass.
+
+---
+
+## Rollout plan
+
+### Phase 0 — migrations & kill switch
+- Ship DB migrations + new email preference key.
+- Add env-based kill switch so the feature can be disabled in prod without a rollback.
+
+### Phase 1 — VIP-only soft launch
+- Admin tab hidden unless `is_broadcast_vip = true`.
+- Mark 1–2 friendly communities as VIP.
+- Watch Resend dashboard — free tier is 100 emails/day, a 150-member broadcast is ~50% of daily budget.
+
+### Phase 2 — general availability
+- Remove VIP gate. Feature visible for all community owners.
+- Announce in-app.
+- **Upgrade to Resend Pro ($20/month)** when either: first paying customer converts, or daily volume exceeds ~70 emails/day consistently.
+
+---
+
+## Monitoring
+
+- Log every broadcast send: community_id, recipient_count, status, duration, batch count.
+- Ad-hoc SQL: broadcasts per community per month, to watch who approaches the 200/month soft cap.
+- Stripe subscription events (existing log stream).
+- Resend dashboard for delivery metrics.
+
+---
+
+## Known risks
+
+1. **Resend free-tier daily cap (100/day).** Feature will fail on busy days once owners start using it. Mitigation: upgrade to Resend Pro before GA (Phase 2).
+2. **Single send-loop failure.** If the API route crashes mid-send, broadcast row left in `sending` state. Mitigation (follow-up): cleanup cron that marks stuck rows `failed` after N minutes.
+3. **Inline images on B2.** If B2 URLs are reorganized later, historical sent emails will have broken images. Mitigation: don't reorganize B2 image paths after sending; consider a dedicated `email-assets/` prefix that's never touched.
+4. **€10/month margin vs Resend Pro cost.** Break-even is 2 paying communities. Until then, this feature is an infra-cost expansion.
+
+---
+
+## Future work (not v1)
+
+- Scheduled sends (requires background worker).
+- `email_broadcast_recipients` table + Resend webhooks for in-app open/click analytics.
+- Re-send to failed recipients.
+- Drafts (auto-save + list).
+- Duplicate-from-past-broadcast.
+- Segmentation (active vs. cancelled, by date joined, by purchase history).
+- Size-based pricing tiers (€10 for ≤200 members, €25 for ≤1000, etc.).
+- Migrate the community settings modal into the new admin panel.
+- Per-community subdomains for sender reputation isolation.
+
+---
+
+## Open questions
+
+- Exact "Admin" tab icon and position order in the navbar — finalize during implementation.
+- Exact 200/month soft cap number — revisit after 2–3 months of real data.
+- Whether to surface "send to self as test" inside the composer or as a separate menu action — finalize during implementation.

--- a/lib/broadcasts/auth.ts
+++ b/lib/broadcasts/auth.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { getSession, type Session } from '@/lib/auth-session';
+import { queryOne } from '@/lib/db';
+
+export interface BroadcastCommunity {
+  id: string;
+  name: string;
+  slug: string;
+  created_by: string;
+  is_broadcast_vip: boolean;
+}
+
+export type AuthzResult =
+  | { ok: true; session: Session; community: BroadcastCommunity }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Shared gate for every broadcast-related API route:
+ * - requires an authenticated session
+ * - requires the user to be the community owner
+ * - enforces the NEXT_PUBLIC_BROADCASTS_ENABLED kill-switch, with VIP bypass
+ *
+ * Returns either the resolved community + session, or a ready-to-return
+ * NextResponse to abort the request with the appropriate status.
+ */
+export async function authorizeBroadcastAccess(
+  communitySlug: string
+): Promise<AuthzResult> {
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  const community = await queryOne<BroadcastCommunity>`
+    SELECT id, name, slug, created_by, is_broadcast_vip
+    FROM communities
+    WHERE slug = ${communitySlug}
+  `;
+  if (!community) {
+    return { ok: false, response: NextResponse.json({ error: 'Not found' }, { status: 404 }) };
+  }
+  if (community.created_by !== session.user.id) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  const featureEnabled = process.env.NEXT_PUBLIC_BROADCASTS_ENABLED === 'true';
+  if (!featureEnabled && !community.is_broadcast_vip) {
+    // Respond 404 (rather than 403) to avoid revealing the feature exists on
+    // this deployment to clients for whom it is gated off.
+    return { ok: false, response: NextResponse.json({ error: 'Not found' }, { status: 404 }) };
+  }
+
+  return { ok: true, session, community };
+}

--- a/lib/broadcasts/billing.ts
+++ b/lib/broadcasts/billing.ts
@@ -1,0 +1,85 @@
+import { stripe } from '@/lib/stripe';
+import { sql } from '@/lib/db';
+import { BROADCAST_PRICE_ID_ENV } from './constants';
+
+export interface CreateCheckoutSessionInput {
+  communityId: string;
+  communitySlug: string;
+  ownerEmail: string;
+  returnUrl: string;
+}
+
+export interface CreateCheckoutSessionResult {
+  checkoutUrl: string;
+  sessionId: string;
+}
+
+export async function createBroadcastCheckoutSession(
+  input: CreateCheckoutSessionInput
+): Promise<CreateCheckoutSessionResult> {
+  const priceId = process.env[BROADCAST_PRICE_ID_ENV];
+  if (!priceId) throw new Error(`Missing ${BROADCAST_PRICE_ID_ENV}`);
+
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://dance-hub.io';
+  const successUrl = `${baseUrl}/${input.communitySlug}/admin/emails?subscription=success`;
+  const cancelUrl = `${baseUrl}/${input.communitySlug}/admin/emails?subscription=cancelled`;
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    customer_email: input.ownerEmail,
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    metadata: {
+      communityId: input.communityId,
+      purpose: 'broadcast_subscription',
+    },
+    subscription_data: {
+      metadata: {
+        communityId: input.communityId,
+        purpose: 'broadcast_subscription',
+      },
+    },
+  });
+
+  if (!session.url) throw new Error('Stripe did not return a checkout URL');
+  return { checkoutUrl: session.url, sessionId: session.id };
+}
+
+export interface UpsertSubscriptionInput {
+  communityId: string;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string;
+  status: 'active' | 'past_due' | 'canceled' | 'incomplete';
+  currentPeriodEnd: Date | null;
+}
+
+export async function upsertBroadcastSubscription(input: UpsertSubscriptionInput): Promise<void> {
+  await sql`
+    INSERT INTO community_broadcast_subscriptions
+      (community_id, stripe_customer_id, stripe_subscription_id, status, current_period_end)
+    VALUES
+      (${input.communityId}, ${input.stripeCustomerId}, ${input.stripeSubscriptionId},
+       ${input.status}, ${input.currentPeriodEnd})
+    ON CONFLICT (community_id) DO UPDATE SET
+      stripe_customer_id = EXCLUDED.stripe_customer_id,
+      stripe_subscription_id = EXCLUDED.stripe_subscription_id,
+      status = EXCLUDED.status,
+      current_period_end = EXCLUDED.current_period_end,
+      updated_at = now()
+  `;
+}
+
+export async function markBroadcastSubscriptionStatus(
+  stripeSubscriptionId: string,
+  status: UpsertSubscriptionInput['status'],
+  currentPeriodEnd: Date | null
+): Promise<void> {
+  await sql`
+    UPDATE community_broadcast_subscriptions
+    SET status = ${status},
+        current_period_end = ${currentPeriodEnd},
+        updated_at = now()
+    WHERE stripe_subscription_id = ${stripeSubscriptionId}
+  `;
+}

--- a/lib/broadcasts/constants.ts
+++ b/lib/broadcasts/constants.ts
@@ -1,0 +1,12 @@
+// lib/broadcasts/constants.ts
+
+export const FREE_QUOTA_PER_MONTH = 10;
+export const PAID_SOFT_CAP_PER_MONTH = 200;
+export const BATCH_SIZE = 100;          // Resend batch API: max 100 emails per call
+export const BATCH_DELAY_MS = 250;      // ~4 req/sec, stays under Resend's 5 req/sec team cap
+export const MAX_BATCH_RETRIES = 3;
+
+export const BROADCAST_FROM_ADDRESS = 'community@dance-hub.io';
+
+// Stripe — the €10/month price must be created in Stripe Dashboard, ID set here via env
+export const BROADCAST_PRICE_ID_ENV = 'STRIPE_BROADCAST_PRICE_ID';

--- a/lib/broadcasts/quota.ts
+++ b/lib/broadcasts/quota.ts
@@ -1,0 +1,61 @@
+import { queryOne } from '@/lib/db';
+import { FREE_QUOTA_PER_MONTH, PAID_SOFT_CAP_PER_MONTH } from './constants';
+
+export type QuotaTier = 'vip' | 'paid' | 'free';
+
+export interface Quota {
+  tier: QuotaTier;
+  used: number;
+  /** Null when unlimited (VIP). */
+  limit: number | null;
+}
+
+export type CanSendResult =
+  | { allowed: true }
+  | { allowed: false; reason: 'quota_exhausted' | 'soft_cap_reached'; quota: Quota };
+
+async function getUsedThisMonth(communityId: string): Promise<number> {
+  const row = await queryOne<{ count: number }>`
+    SELECT COUNT(*)::int AS count
+    FROM email_broadcasts
+    WHERE community_id = ${communityId}
+      AND created_at >= date_trunc('month', now())
+      AND status IN ('sent', 'sending', 'partial_failure')
+  `;
+  return row?.count ?? 0;
+}
+
+export async function getQuota(communityId: string): Promise<Quota> {
+  const community = await queryOne<{ is_broadcast_vip: boolean }>`
+    SELECT is_broadcast_vip FROM communities WHERE id = ${communityId}
+  `;
+
+  const subscription = await queryOne<{ status: string }>`
+    SELECT status
+    FROM community_broadcast_subscriptions
+    WHERE community_id = ${communityId}
+  `;
+
+  const used = await getUsedThisMonth(communityId);
+
+  if (community?.is_broadcast_vip) {
+    return { tier: 'vip', used, limit: null };
+  }
+
+  if (subscription?.status === 'active') {
+    return { tier: 'paid', used, limit: PAID_SOFT_CAP_PER_MONTH };
+  }
+
+  return { tier: 'free', used, limit: FREE_QUOTA_PER_MONTH };
+}
+
+export async function checkCanSend(communityId: string): Promise<CanSendResult> {
+  const quota = await getQuota(communityId);
+  if (quota.limit === null) return { allowed: true };
+  if (quota.used < quota.limit) return { allowed: true };
+  return {
+    allowed: false,
+    reason: quota.tier === 'paid' ? 'soft_cap_reached' : 'quota_exhausted',
+    quota,
+  };
+}

--- a/lib/broadcasts/recipients.ts
+++ b/lib/broadcasts/recipients.ts
@@ -28,7 +28,10 @@ export async function getActiveRecipientsForCommunity(
     LEFT JOIN email_preferences ep ON ep.email = p.email
     WHERE m.community_id = ${communityId}
       AND m.status = 'active'
-      AND (m.subscription_status = 'active' OR m.subscription_status IS NULL)
+      AND (
+        m.subscription_status IS NULL
+        OR m.subscription_status NOT IN ('canceled', 'unpaid', 'past_due', 'incomplete', 'incomplete_expired')
+      )
       AND (ep.teacher_broadcast IS DISTINCT FROM false)
       AND (ep.unsubscribed_all IS DISTINCT FROM true)
       AND p.email IS NOT NULL

--- a/lib/broadcasts/recipients.ts
+++ b/lib/broadcasts/recipients.ts
@@ -1,0 +1,43 @@
+import { query } from '@/lib/db';
+
+export interface BroadcastRecipient {
+  userId: string;
+  email: string;
+  displayName: string;
+  unsubscribeToken: string | null;
+}
+
+interface RecipientRow {
+  user_id: string;
+  email: string;
+  full_name: string | null;
+  unsubscribe_token: string | null;
+}
+
+export async function getActiveRecipientsForCommunity(
+  communityId: string
+): Promise<BroadcastRecipient[]> {
+  const rows = await query<RecipientRow>`
+    SELECT
+      m.user_id,
+      p.email,
+      p.full_name,
+      ep.unsubscribe_token
+    FROM community_members m
+    JOIN profiles p ON p.id = m.user_id
+    LEFT JOIN email_preferences ep ON ep.email = p.email
+    WHERE m.community_id = ${communityId}
+      AND m.status = 'active'
+      AND (m.subscription_status = 'active' OR m.subscription_status IS NULL)
+      AND (ep.teacher_broadcast IS DISTINCT FROM false)
+      AND (ep.unsubscribed_all IS DISTINCT FROM true)
+      AND p.email IS NOT NULL
+  `;
+
+  return rows.map((row) => ({
+    userId: row.user_id,
+    email: row.email,
+    displayName: row.full_name ?? 'there',
+    unsubscribeToken: row.unsubscribe_token,
+  }));
+}

--- a/lib/broadcasts/recipients.ts
+++ b/lib/broadcasts/recipients.ts
@@ -24,7 +24,7 @@ export async function getActiveRecipientsForCommunity(
       p.full_name,
       ep.unsubscribe_token
     FROM community_members m
-    JOIN profiles p ON p.id = m.user_id
+    JOIN profiles p ON p.auth_user_id = m.user_id
     LEFT JOIN email_preferences ep ON ep.email = p.email
     WHERE m.community_id = ${communityId}
       AND m.status = 'active'

--- a/lib/broadcasts/sender.ts
+++ b/lib/broadcasts/sender.ts
@@ -1,0 +1,125 @@
+import { Resend } from 'resend';
+import type { BroadcastRecipient } from './recipients';
+import {
+  BATCH_SIZE,
+  BATCH_DELAY_MS,
+  MAX_BATCH_RETRIES,
+  BROADCAST_FROM_ADDRESS,
+} from './constants';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export interface RunBroadcastInput {
+  broadcastId: string;
+  subject: string;
+  htmlContent: string;
+  previewText?: string;
+  recipients: BroadcastRecipient[];
+  fromName: string;
+  replyTo: string;
+}
+
+export interface RunBroadcastResult {
+  status: 'sent' | 'partial_failure' | 'failed';
+  resendBatchIds: string[];
+  errorMessage?: string;
+  successfulCount: number;
+  failedCount: number;
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size));
+  return chunks;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function buildUnsubscribeUrl(token: string | null): string {
+  const base = process.env.NEXT_PUBLIC_SITE_URL || 'https://dance-hub.io';
+  if (!token) return `${base}/settings/email-preferences`;
+  return `${base}/api/email/unsubscribe?token=${encodeURIComponent(token)}&type=teacher_broadcast`;
+}
+
+function personalizeHtml(html: string, recipient: BroadcastRecipient): string {
+  return html
+    .replace(/{{unsubscribeUrl}}/g, buildUnsubscribeUrl(recipient.unsubscribeToken))
+    .replace(/{{displayName}}/g, recipient.displayName);
+}
+
+async function sendBatchWithRetry(
+  batch: BroadcastRecipient[],
+  subject: string,
+  htmlContent: string,
+  fromName: string,
+  replyTo: string,
+  previewText?: string
+): Promise<{ batchId: string | null; error?: Error }> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt < MAX_BATCH_RETRIES; attempt++) {
+    try {
+      const emails = batch.map((r) => ({
+        from: `${fromName} <${BROADCAST_FROM_ADDRESS}>`,
+        to: r.email,
+        replyTo,
+        subject,
+        html: personalizeHtml(htmlContent, r),
+        headers: previewText ? { 'X-Preview': previewText } : undefined,
+        tags: [{ name: 'category', value: 'teacher_broadcast' }],
+      }));
+      const result = await resend.batch.send(emails);
+      const firstId =
+        (result as { data?: { data?: Array<{ id: string }> } })?.data?.data?.[0]?.id ?? null;
+      return { batchId: firstId };
+    } catch (err) {
+      lastError = err as Error;
+      if (attempt < MAX_BATCH_RETRIES - 1) {
+        await sleep(BATCH_DELAY_MS * Math.pow(2, attempt));
+      }
+    }
+  }
+  return { batchId: null, error: lastError };
+}
+
+export async function runBroadcast(input: RunBroadcastInput): Promise<RunBroadcastResult> {
+  const { recipients, subject, htmlContent, fromName, replyTo, previewText } = input;
+  const chunks = chunk(recipients, BATCH_SIZE);
+
+  const batchIds: string[] = [];
+  const errors: Error[] = [];
+  let successfulCount = 0;
+  let failedCount = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const batch = chunks[i];
+    const { batchId, error } = await sendBatchWithRetry(
+      batch,
+      subject,
+      htmlContent,
+      fromName,
+      replyTo,
+      previewText,
+    );
+    if (batchId) {
+      batchIds.push(batchId);
+      successfulCount += batch.length;
+    } else {
+      if (error) errors.push(error);
+      failedCount += batch.length;
+    }
+    if (i < chunks.length - 1) await sleep(BATCH_DELAY_MS);
+  }
+
+  let status: RunBroadcastResult['status'];
+  if (failedCount === 0) status = 'sent';
+  else if (successfulCount === 0) status = 'failed';
+  else status = 'partial_failure';
+
+  return {
+    status,
+    resendBatchIds: batchIds,
+    errorMessage: errors.length > 0 ? errors.map((e) => e.message).join('; ') : undefined,
+    successfulCount,
+    failedCount,
+  };
+}

--- a/lib/broadcasts/sender.ts
+++ b/lib/broadcasts/sender.ts
@@ -1,4 +1,6 @@
 import { Resend } from 'resend';
+import { render } from '@react-email/components';
+import React from 'react';
 import type { BroadcastRecipient } from './recipients';
 import {
   BATCH_SIZE,
@@ -6,8 +8,14 @@ import {
   MAX_BATCH_RETRIES,
   BROADCAST_FROM_ADDRESS,
 } from './constants';
+import { BroadcastEmail } from '@/lib/resend/templates/marketing/broadcast';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
+
+// Internal-only placeholders — chosen so they cannot collide with text an owner
+// could write in the editor. Replaced per-recipient just before sending.
+const UNSUBSCRIBE_PLACEHOLDER = '__DH_BROADCAST_UNSUBSCRIBE_URL__';
+const DISPLAY_NAME_PLACEHOLDER = '__DH_BROADCAST_DISPLAY_NAME__';
 
 export interface RunBroadcastInput {
   broadcastId: string;
@@ -41,16 +49,42 @@ function buildUnsubscribeUrl(token: string | null): string {
   return `${base}/api/email/unsubscribe?token=${encodeURIComponent(token)}&type=teacher_broadcast`;
 }
 
-function personalizeHtml(html: string, recipient: BroadcastRecipient): string {
+function personalize(html: string, recipient: BroadcastRecipient): string {
   return html
-    .replace(/{{unsubscribeUrl}}/g, buildUnsubscribeUrl(recipient.unsubscribeToken))
-    .replace(/{{displayName}}/g, recipient.displayName);
+    .split(UNSUBSCRIBE_PLACEHOLDER)
+    .join(buildUnsubscribeUrl(recipient.unsubscribeToken))
+    .split(DISPLAY_NAME_PLACEHOLDER)
+    .join(recipient.displayName);
+}
+
+/**
+ * Render the full broadcast HTML once with placeholder tokens for per-recipient
+ * substitution. Wraps the editor HTML in BaseLayout (which carries the
+ * unsubscribe + preferences footer — required for CAN-SPAM / GDPR compliance).
+ */
+async function renderTemplate(
+  communityName: string,
+  subject: string,
+  bodyHtml: string,
+  previewText?: string
+): Promise<string> {
+  // Inject placeholder tokens into the footer unsubscribe links via the
+  // existing BaseLayout footer. BroadcastEmail passes these through.
+  return render(
+    React.createElement(BroadcastEmail, {
+      communityName,
+      subject,
+      bodyHtml,
+      previewText,
+      unsubscribePlaceholder: UNSUBSCRIBE_PLACEHOLDER,
+    })
+  );
 }
 
 async function sendBatchWithRetry(
   batch: BroadcastRecipient[],
   subject: string,
-  htmlContent: string,
+  templatedHtml: string,
   fromName: string,
   replyTo: string,
   previewText?: string
@@ -63,7 +97,7 @@ async function sendBatchWithRetry(
         to: r.email,
         replyTo,
         subject,
-        html: personalizeHtml(htmlContent, r),
+        html: personalize(templatedHtml, r),
         headers: previewText ? { 'X-Preview': previewText } : undefined,
         tags: [{ name: 'category', value: 'teacher_broadcast' }],
       }));
@@ -83,6 +117,8 @@ async function sendBatchWithRetry(
 
 export async function runBroadcast(input: RunBroadcastInput): Promise<RunBroadcastResult> {
   const { recipients, subject, htmlContent, fromName, replyTo, previewText } = input;
+
+  const templatedHtml = await renderTemplate(fromName, subject, htmlContent, previewText);
   const chunks = chunk(recipients, BATCH_SIZE);
 
   const batchIds: string[] = [];
@@ -95,10 +131,10 @@ export async function runBroadcast(input: RunBroadcastInput): Promise<RunBroadca
     const { batchId, error } = await sendBatchWithRetry(
       batch,
       subject,
-      htmlContent,
+      templatedHtml,
       fromName,
       replyTo,
-      previewText,
+      previewText
     );
     if (batchId) {
       batchIds.push(batchId);

--- a/lib/resend/check-preferences.ts
+++ b/lib/resend/check-preferences.ts
@@ -14,7 +14,8 @@ export type EmailCategory =
   | 'course_announcements'
   | 'lesson_reminders'
   | 'community_updates'
-  | 'weekly_digest';
+  | 'weekly_digest'
+  | 'teacher_broadcast';
 
 interface EmailPreferences {
   email: string;
@@ -25,6 +26,7 @@ interface EmailPreferences {
   lesson_reminders: boolean | null;
   community_updates: boolean | null;
   weekly_digest: boolean | null;
+  teacher_broadcast: boolean | null;
 }
 
 interface ProfileId {
@@ -54,7 +56,8 @@ export async function canSendEmail(
         course_announcements,
         lesson_reminders,
         community_updates,
-        weekly_digest
+        weekly_digest,
+        teacher_broadcast
       FROM email_preferences
       WHERE email = ${userEmail}
     `;
@@ -83,6 +86,8 @@ export async function canSendEmail(
         return preferences.community_updates ?? true;
       case 'weekly_digest':
         return preferences.weekly_digest ?? false;
+      case 'teacher_broadcast':
+        return preferences.teacher_broadcast ?? true;
       default:
         return true;
     }

--- a/lib/resend/templates/base-layout.tsx
+++ b/lib/resend/templates/base-layout.tsx
@@ -17,12 +17,17 @@ interface BaseLayoutProps {
   preview: string;
   children: React.ReactNode;
   footer?: EmailFooterProps;
+  /** When true, omit the DanceHub logo at the top. Used for broadcasts
+   *  where the community is the sender and the platform retreats to a
+   *  small signature in a custom footer. */
+  hideLogo?: boolean;
 }
 
 export const BaseLayout: React.FC<BaseLayoutProps> = ({
   preview,
   children,
   footer,
+  hideLogo = false,
 }) => {
   return (
     <Html>
@@ -32,13 +37,15 @@ export const BaseLayout: React.FC<BaseLayoutProps> = ({
         <Container style={EMAIL_STYLES.container}>
           <Section style={EMAIL_STYLES.card}>
             {/* Logo */}
-            <Img
-              src="https://dance-hub.io/Logo.png"
-              width="150"
-              height="50"
-              alt="DanceHub"
-              style={{ marginBottom: '24px' }}
-            />
+            {!hideLogo && (
+              <Img
+                src="https://dance-hub.io/Logo.png"
+                width="150"
+                height="50"
+                alt="DanceHub"
+                style={{ marginBottom: '24px' }}
+              />
+            )}
             
             {/* Main Content */}
             {children}

--- a/lib/resend/templates/marketing/broadcast.tsx
+++ b/lib/resend/templates/marketing/broadcast.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Section, Text } from '@react-email/components';
+import { BaseLayout } from '../base-layout';
+
+interface BroadcastEmailProps {
+  communityName: string;
+  subject: string;
+  bodyHtml: string;
+  previewText?: string;
+}
+
+/**
+ * Broadcast email template. The bodyHtml placeholders ({{unsubscribeUrl}},
+ * {{displayName}}) are replaced per-recipient at send time by sender.ts.
+ */
+export const BroadcastEmail: React.FC<BroadcastEmailProps> = ({
+  communityName,
+  subject,
+  bodyHtml,
+  previewText,
+}) => (
+  <BaseLayout
+    preview={previewText ?? subject}
+    footer={{
+      showUnsubscribe: true,
+      unsubscribeUrl: '{{unsubscribeUrl}}',
+      preferencesUrl: '{{unsubscribeUrl}}',
+    }}
+  >
+    <Section>
+      <Text style={{ fontSize: '13px', color: '#6b7280', marginBottom: '16px' }}>
+        A message from {communityName}
+      </Text>
+      <div dangerouslySetInnerHTML={{ __html: bodyHtml }} />
+    </Section>
+  </BaseLayout>
+);

--- a/lib/resend/templates/marketing/broadcast.tsx
+++ b/lib/resend/templates/marketing/broadcast.tsx
@@ -31,11 +31,6 @@ export const BroadcastEmail: React.FC<BroadcastEmailProps> = ({
 }) => (
   <BaseLayout preview={previewText ?? subject}>
     <Section>
-      <Text
-        style={{ fontSize: '13px', color: EMAIL_COLORS.textLight, marginBottom: '16px' }}
-      >
-        A message from {communityName}
-      </Text>
       <div dangerouslySetInnerHTML={{ __html: bodyHtml }} />
     </Section>
 

--- a/lib/resend/templates/marketing/broadcast.tsx
+++ b/lib/resend/templates/marketing/broadcast.tsx
@@ -7,24 +7,27 @@ interface BroadcastEmailProps {
   subject: string;
   bodyHtml: string;
   previewText?: string;
+  /**
+   * Sender.ts renders this template once with a placeholder token for the
+   * unsubscribe link, then string-replaces the token per recipient before
+   * sending. Keeps rendering to O(1) instead of O(recipients).
+   */
+  unsubscribePlaceholder: string;
 }
 
-/**
- * Broadcast email template. The bodyHtml placeholders ({{unsubscribeUrl}},
- * {{displayName}}) are replaced per-recipient at send time by sender.ts.
- */
 export const BroadcastEmail: React.FC<BroadcastEmailProps> = ({
   communityName,
   subject,
   bodyHtml,
   previewText,
+  unsubscribePlaceholder,
 }) => (
   <BaseLayout
     preview={previewText ?? subject}
     footer={{
       showUnsubscribe: true,
-      unsubscribeUrl: '{{unsubscribeUrl}}',
-      preferencesUrl: '{{unsubscribeUrl}}',
+      unsubscribeUrl: unsubscribePlaceholder,
+      preferencesUrl: unsubscribePlaceholder,
     }}
   >
     <Section>

--- a/lib/resend/templates/marketing/broadcast.tsx
+++ b/lib/resend/templates/marketing/broadcast.tsx
@@ -29,7 +29,7 @@ export const BroadcastEmail: React.FC<BroadcastEmailProps> = ({
   previewText,
   unsubscribePlaceholder,
 }) => (
-  <BaseLayout preview={previewText ?? subject}>
+  <BaseLayout preview={previewText ?? subject} hideLogo>
     <Section>
       <div dangerouslySetInnerHTML={{ __html: bodyHtml }} />
     </Section>

--- a/lib/resend/templates/marketing/broadcast.tsx
+++ b/lib/resend/templates/marketing/broadcast.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Section, Text } from '@react-email/components';
+import { Section, Text, Link, Hr } from '@react-email/components';
 import { BaseLayout } from '../base-layout';
+import { EMAIL_COLORS, EMAIL_STYLES } from '..';
 
 interface BroadcastEmailProps {
   communityName: string;
@@ -15,6 +16,12 @@ interface BroadcastEmailProps {
   unsubscribePlaceholder: string;
 }
 
+/**
+ * Broadcast email template. Uses a *community-first* footer — the community
+ * name is the primary identity, with DanceHub as a small "powered by" line.
+ * This differs from other transactional emails (auth, bookings), where
+ * DanceHub is itself the sender and the full BaseLayout footer is appropriate.
+ */
 export const BroadcastEmail: React.FC<BroadcastEmailProps> = ({
   communityName,
   subject,
@@ -22,19 +29,62 @@ export const BroadcastEmail: React.FC<BroadcastEmailProps> = ({
   previewText,
   unsubscribePlaceholder,
 }) => (
-  <BaseLayout
-    preview={previewText ?? subject}
-    footer={{
-      showUnsubscribe: true,
-      unsubscribeUrl: unsubscribePlaceholder,
-      preferencesUrl: unsubscribePlaceholder,
-    }}
-  >
+  <BaseLayout preview={previewText ?? subject}>
     <Section>
-      <Text style={{ fontSize: '13px', color: '#6b7280', marginBottom: '16px' }}>
+      <Text
+        style={{ fontSize: '13px', color: EMAIL_COLORS.textLight, marginBottom: '16px' }}
+      >
         A message from {communityName}
       </Text>
       <div dangerouslySetInnerHTML={{ __html: bodyHtml }} />
+    </Section>
+
+    {/* Community-first footer */}
+    <Hr
+      style={{
+        marginTop: '40px',
+        marginBottom: '20px',
+        border: 'none',
+        borderTop: `1px solid ${EMAIL_COLORS.border}`,
+      }}
+    />
+    <Section style={{ textAlign: 'center' as const }}>
+      <Text
+        style={{
+          fontSize: '13px',
+          color: EMAIL_COLORS.textLight,
+          marginBottom: '12px',
+          lineHeight: '1.5',
+        }}
+      >
+        You&apos;re receiving this because you&apos;re a member of{' '}
+        <strong style={{ color: EMAIL_COLORS.text }}>{communityName}</strong>.
+      </Text>
+      <Text style={{ fontSize: '12px', color: EMAIL_COLORS.textLight, marginBottom: '24px' }}>
+        <Link href={unsubscribePlaceholder} style={EMAIL_STYLES.link}>
+          Manage preferences
+        </Link>
+        {' · '}
+        <Link href={unsubscribePlaceholder} style={EMAIL_STYLES.link}>
+          Unsubscribe
+        </Link>
+      </Text>
+      <Text
+        style={{
+          fontSize: '11px',
+          color: EMAIL_COLORS.textLight,
+          opacity: 0.7,
+          marginTop: '16px',
+        }}
+      >
+        Powered by{' '}
+        <Link
+          href="https://dance-hub.io"
+          style={{ color: EMAIL_COLORS.textLight, textDecoration: 'none' }}
+        >
+          DanceHub
+        </Link>
+      </Text>
     </Section>
   </BaseLayout>
 );

--- a/lib/resend/templates/marketing/broadcast.tsx
+++ b/lib/resend/templates/marketing/broadcast.tsx
@@ -46,36 +46,42 @@ export const BroadcastEmail: React.FC<BroadcastEmailProps> = ({
     <Section style={{ textAlign: 'center' as const }}>
       <Text
         style={{
-          fontSize: '13px',
+          fontSize: '11px',
           color: EMAIL_COLORS.textLight,
-          marginBottom: '12px',
+          marginBottom: '8px',
           lineHeight: '1.5',
         }}
       >
         You&apos;re receiving this because you&apos;re a member of{' '}
         <strong style={{ color: EMAIL_COLORS.text }}>{communityName}</strong>.
       </Text>
-      <Text style={{ fontSize: '12px', color: EMAIL_COLORS.textLight, marginBottom: '24px' }}>
-        <Link href={unsubscribePlaceholder} style={EMAIL_STYLES.link}>
+      <Text
+        style={{
+          fontSize: '11px',
+          color: EMAIL_COLORS.textLight,
+          marginBottom: '20px',
+        }}
+      >
+        <Link href={unsubscribePlaceholder} style={{ ...EMAIL_STYLES.link, fontSize: '11px' }}>
           Manage preferences
         </Link>
         {' · '}
-        <Link href={unsubscribePlaceholder} style={EMAIL_STYLES.link}>
+        <Link href={unsubscribePlaceholder} style={{ ...EMAIL_STYLES.link, fontSize: '11px' }}>
           Unsubscribe
         </Link>
       </Text>
       <Text
         style={{
-          fontSize: '11px',
+          fontSize: '10px',
           color: EMAIL_COLORS.textLight,
           opacity: 0.7,
-          marginTop: '16px',
+          marginTop: '12px',
         }}
       >
         Powered by{' '}
         <Link
           href="https://dance-hub.io"
-          style={{ color: EMAIL_COLORS.textLight, textDecoration: 'none' }}
+          style={{ color: EMAIL_COLORS.textLight, textDecoration: 'none', fontSize: '10px' }}
         >
           DanceHub
         </Link>

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "@stripe/stripe-js": "^4.9.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.47.12",
+    "@tiptap/extension-image": "^2.9.1",
+    "@tiptap/extension-link": "^2.9.1",
     "@tiptap/extension-placeholder": "^2.11.0",
     "@tiptap/extension-text-align": "^2.9.1",
     "@tiptap/extension-text-style": "^2.11.2",

--- a/supabase/migrations/2026-04-14_add_is_broadcast_vip.sql
+++ b/supabase/migrations/2026-04-14_add_is_broadcast_vip.sql
@@ -1,0 +1,7 @@
+-- supabase/migrations/2026-04-14_add_is_broadcast_vip.sql
+
+ALTER TABLE communities
+  ADD COLUMN is_broadcast_vip boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN communities.is_broadcast_vip IS
+  'Platform-admin-toggleable flag. When true, this community bypasses broadcast quota and billing checks.';

--- a/supabase/migrations/2026-04-14_create_community_broadcast_subscriptions.sql
+++ b/supabase/migrations/2026-04-14_create_community_broadcast_subscriptions.sql
@@ -1,0 +1,19 @@
+-- supabase/migrations/2026-04-14_create_community_broadcast_subscriptions.sql
+
+CREATE TABLE community_broadcast_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  community_id uuid NOT NULL UNIQUE REFERENCES communities(id) ON DELETE CASCADE,
+  stripe_customer_id text NOT NULL,
+  stripe_subscription_id text NOT NULL,
+  status text NOT NULL
+    CHECK (status IN ('active', 'past_due', 'canceled', 'incomplete')),
+  current_period_end timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_community_broadcast_subscriptions_stripe_sub
+  ON community_broadcast_subscriptions (stripe_subscription_id);
+
+COMMENT ON TABLE community_broadcast_subscriptions IS
+  'Stripe subscription state for the €10/month unlimited broadcast tier, one row per community.';

--- a/supabase/migrations/2026-04-14_create_email_broadcasts.sql
+++ b/supabase/migrations/2026-04-14_create_email_broadcasts.sql
@@ -1,0 +1,24 @@
+-- supabase/migrations/2026-04-14_create_email_broadcasts.sql
+
+CREATE TABLE email_broadcasts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  community_id uuid NOT NULL REFERENCES communities(id) ON DELETE CASCADE,
+  sender_user_id uuid NOT NULL REFERENCES profiles(id),
+  subject text NOT NULL,
+  html_content text NOT NULL,
+  editor_json jsonb NOT NULL,
+  preview_text text,
+  recipient_count integer NOT NULL DEFAULT 0,
+  status text NOT NULL
+    CHECK (status IN ('pending', 'sending', 'sent', 'partial_failure', 'failed')),
+  resend_batch_ids text[] NOT NULL DEFAULT '{}',
+  error_message text,
+  sent_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_email_broadcasts_community_created
+  ON email_broadcasts (community_id, created_at DESC);
+
+COMMENT ON TABLE email_broadcasts IS
+  'Audit trail of community broadcast emails. Also the source of truth for monthly quota counting.';

--- a/supabase/migrations/2026-04-14_ensure_email_preferences_schema.sql
+++ b/supabase/migrations/2026-04-14_ensure_email_preferences_schema.sql
@@ -1,0 +1,116 @@
+-- supabase/migrations/2026-04-14_ensure_email_preferences_schema.sql
+--
+-- Ensure email_preferences + email_events exist (porting from Supabase-era
+-- migration that referenced auth.users and was never applied to Neon).
+-- Also adds the teacher_broadcast column needed by the Community Broadcasts feature.
+--
+-- All operations are guarded with IF NOT EXISTS / ADD COLUMN IF NOT EXISTS /
+-- CREATE OR REPLACE so this migration is safe to apply to environments where
+-- the schema already exists (e.g., if the same migration is later run on prod).
+
+-- ============================================================================
+-- email_preferences
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS email_preferences (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  email VARCHAR(255) NOT NULL,
+  transactional_emails BOOLEAN DEFAULT true NOT NULL,
+  marketing_emails BOOLEAN DEFAULT true,
+  course_announcements BOOLEAN DEFAULT true,
+  lesson_reminders BOOLEAN DEFAULT true,
+  community_updates BOOLEAN DEFAULT true,
+  weekly_digest BOOLEAN DEFAULT false,
+  unsubscribe_token VARCHAR(255) UNIQUE DEFAULT encode(gen_random_bytes(32), 'hex'),
+  unsubscribed_all BOOLEAN DEFAULT false,
+  unsubscribed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_preferences_user_id ON email_preferences(user_id);
+CREATE INDEX IF NOT EXISTS idx_email_preferences_email ON email_preferences(email);
+CREATE INDEX IF NOT EXISTS idx_email_preferences_unsubscribe_token ON email_preferences(unsubscribe_token);
+
+-- The broadcasts feature's opt-out column. Safe to re-run.
+ALTER TABLE email_preferences ADD COLUMN IF NOT EXISTS teacher_broadcast BOOLEAN DEFAULT true NOT NULL;
+
+COMMENT ON TABLE email_preferences IS
+  'User email notification preferences and unsubscribe tokens.';
+COMMENT ON COLUMN email_preferences.teacher_broadcast IS
+  'Whether this user accepts teacher/community-owner newsletter broadcasts. Default true — members opt in by joining a community.';
+
+-- ============================================================================
+-- email_events
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS email_events (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES profiles(id) ON DELETE SET NULL,
+  email VARCHAR(255) NOT NULL,
+  event_type VARCHAR(50) NOT NULL,
+  email_type VARCHAR(50) NOT NULL,
+  subject VARCHAR(500),
+  resend_email_id VARCHAR(255),
+  metadata JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_events_user_id ON email_events(user_id);
+CREATE INDEX IF NOT EXISTS idx_email_events_email ON email_events(email);
+CREATE INDEX IF NOT EXISTS idx_email_events_event_type ON email_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_email_events_email_type ON email_events(email_type);
+CREATE INDEX IF NOT EXISTS idx_email_events_created_at ON email_events(created_at);
+
+COMMENT ON TABLE email_events IS
+  'Audit trail of outbound emails (sent/delivered/opened/clicked/bounced/failed).';
+
+-- ============================================================================
+-- updated_at trigger for email_preferences
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION update_email_preferences_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_email_preferences_updated_at ON email_preferences;
+CREATE TRIGGER update_email_preferences_updated_at
+  BEFORE UPDATE ON email_preferences
+  FOR EACH ROW
+  EXECUTE FUNCTION update_email_preferences_updated_at();
+
+-- ============================================================================
+-- Auto-create email_preferences row when a profile is inserted
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION create_email_preferences_for_profile()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.email IS NOT NULL THEN
+    INSERT INTO email_preferences (user_id, email)
+    VALUES (NEW.id, NEW.email)
+    ON CONFLICT (user_id) DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS create_email_preferences_on_profile_insert ON profiles;
+CREATE TRIGGER create_email_preferences_on_profile_insert
+  AFTER INSERT ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION create_email_preferences_for_profile();
+
+-- ============================================================================
+-- Backfill for existing profiles that don't yet have preferences
+-- ============================================================================
+
+INSERT INTO email_preferences (user_id, email)
+SELECT id, email FROM profiles WHERE email IS NOT NULL
+ON CONFLICT (user_id) DO NOTHING;


### PR DESCRIPTION
## Summary

Lets community owners send rich-text email broadcasts to their active members via Resend. Free quota of 10/month per community, €10/month Stripe subscription for unlimited, admin-togglable `is_broadcast_vip` flag bypasses both.

Entry point: a new owner-only **Admin** tab in the community navbar → `/admin/emails` — composer, archive, and broadcast detail pages.

**Behind a kill-switch.** `NEXT_PUBLIC_BROADCASTS_ENABLED` defaults to `false`. Until it's flipped on prod, the Admin tab is hidden, the `/admin/*` routes redirect to the community home, and the API endpoints return 404. Communities marked `is_broadcast_vip=true` bypass the flag (pilot/gift access).

## What's inside

**Database (4 migrations):**
- `email_broadcasts` — audit trail + quota source
- `community_broadcast_subscriptions` — Stripe subscription state per community
- `communities.is_broadcast_vip` — admin-toggleable VIP flag
- `ensure_email_preferences_schema` — idempotent; creates `email_preferences` + `email_events` if missing (also fixes a pre-existing prod bug where unsubscribe links were broken because the table was never ported from Supabase)

**Core lib (`lib/broadcasts/`):**
- `quota.ts` — tier resolution + send-gate
- `recipients.ts` — filters members on status + opt-outs (joins via `profiles.auth_user_id = community_members.user_id`)
- `sender.ts` — batched Resend send with 250ms throttle + 3x retry; wraps body in the `BroadcastEmail` React Email template for a community-first footer
- `billing.ts` — Stripe Checkout + subscription upsert helpers
- `auth.ts` — shared authorize helper (owner + kill-switch + VIP) used by every route

**API routes:**
- `POST/GET /api/community/[slug]/broadcasts` — send + list (top-level try/catch marks stuck rows `failed`)
- `GET /api/community/[slug]/broadcasts/[id]`
- `GET /api/community/[slug]/broadcasts/quota`
- `POST /api/community/[slug]/broadcasts/test` — send to self
- `POST/DELETE /api/community/[slug]/broadcasts/subscription`
- `POST /api/upload/broadcast-image` — inline image upload to B2
- `app/api/webhooks/stripe/route.ts` — extended with broadcast subscription events

**UI:**
- `components/emails/EmailEditor.tsx` — Tiptap composer (bold/italic/headings/lists/links/align + image upload), with `javascript:`/`data:`/`vbscript:` URL validation
- `components/emails/EmailComposer.tsx` — borderless serif subject, narrative side panel
- `components/emails/BroadcastHistoryList.tsx` — editorial archive list
- `components/emails/QuotaBadge.tsx`, `UpgradeDialog.tsx`
- `components/admin/AdminNav.tsx`
- `app/[communitySlug]/admin/{layout,page,emails/...}.tsx` — admin section under the community chrome (nav + sidebar)
- `components/CommunityNavbar.tsx` — adds the owner-only Admin tab (behind the kill-switch)

**Email template:**
- `lib/resend/templates/marketing/broadcast.tsx` — community-first footer ("You're receiving this because you're a member of X · Manage preferences · Unsubscribe · Powered by DanceHub"), DanceHub logo hidden at top

**Tests:** 36 pass. Unit tests for `quota`, `recipients`, `sender`, `billing`. API tests for every broadcast route. Component test for `QuotaBadge`.

## Rollout

Safe to merge with the flag off on prod — nothing visible to users.

### Pre-enable checklist

1. Run migrations against prod (`main`) Neon branch (all idempotent)
2. Create the Stripe product + set `STRIPE_BROADCAST_PRICE_ID` in prod env
3. Verify Stripe webhook subscribes to `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`
4. (Optional) Mark pilot communities VIP: \`UPDATE communities SET is_broadcast_vip = true WHERE slug = '...'\`
5. Flip \`NEXT_PUBLIC_BROADCASTS_ENABLED=true\` on prod env
6. Deploy, smoke-test with a real broadcast from your own community

## Known follow-ups (not blocking)

- Test-send endpoint has no per-minute rate limit
- No cleanup cron for stuck \`sending\` rows (unlikely but possible)
- Stripe checkout creates fresh customers; reuse existing \`stripe_customer_id\` where possible
- Broadcast checkout webhook redelivery could resurrect a deleted subscription
- Tests mock at the boundary — don't catch SQL join regressions (previous UUID join bugs slipped through this way)

## Test plan

- [x] 36 unit/API/component tests pass
- [x] Manually verified on preprod (`https://preprod.dance-hub.io`) end-to-end: compose → test send → real send to 2 recipients
- [x] Footer renders community-first, includes working unsubscribe link

🤖 Generated with [Claude Code](https://claude.com/claude-code)