### PR TITLE
feat(mobile): course modals as bottom sheets

### DIFF
--- a/components/CreateCourseModal.tsx
+++ b/components/CreateCourseModal.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+} from "@/components/ui/responsive-dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -88,14 +95,14 @@ export default function CreateCourseModal({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>Create Course</DialogTitle>
-          <DialogDescription>
+    <ResponsiveDialog open={isOpen} onOpenChange={onClose}>
+      <ResponsiveDialogContent className="sm:max-w-[425px]">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Create Course</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
             Enter the details for the new course.
-          </DialogDescription>
-        </DialogHeader>
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4 py-4">
             <div className="grid grid-cols-1 gap-4">
@@ -155,24 +162,24 @@ export default function CreateCourseModal({
               </div>
             </div>
           </div>
-          <DialogFooter>
-            <Button 
-              type="button" 
-              variant="outline" 
+          <ResponsiveDialogFooter>
+            <Button
+              type="button"
+              variant="outline"
               onClick={onClose}
               disabled={isSubmitting}
             >
               Cancel
             </Button>
-            <Button 
+            <Button
               type="submit"
               disabled={isSubmitting || !title.trim() || !description.trim()}
             >
               {isSubmitting ? 'Creating...' : 'Create Course'}
             </Button>
-          </DialogFooter>
+          </ResponsiveDialogFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   );
 } 

--- a/components/EditCourseModal.tsx
+++ b/components/EditCourseModal.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+} from "@/components/ui/responsive-dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -75,14 +82,14 @@ export default function EditCourseModal({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>Edit Course</DialogTitle>
-          <DialogDescription>
+    <ResponsiveDialog open={isOpen} onOpenChange={onClose}>
+      <ResponsiveDialogContent className="sm:max-w-[425px]">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Edit Course</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
             Update your course details.
-          </DialogDescription>
-        </DialogHeader>
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4 py-4">
             <div className="grid grid-cols-1 gap-2">
@@ -144,24 +151,24 @@ export default function EditCourseModal({
               />
             </div>
           </div>
-          <DialogFooter>
-            <Button 
-              type="button" 
-              variant="outline" 
+          <ResponsiveDialogFooter>
+            <Button
+              type="button"
+              variant="outline"
               onClick={onClose}
               disabled={isSubmitting}
             >
               Cancel
             </Button>
-            <Button 
+            <Button
               type="submit"
               disabled={isSubmitting || !title.trim() || !description.trim()}
             >
               {isSubmitting ? 'Saving...' : 'Save Changes'}
             </Button>
-          </DialogFooter>
+          </ResponsiveDialogFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   );
 } 


### PR DESCRIPTION
## Summary
- Wraps EditCourseModal + CreateCourseModal in ResponsiveDialog so they render as bottom sheets on mobile and centered Dialogs on desktop
- Pure primitive swap — form logic, validation, image dropzone, submit handlers untouched

## Test plan
- [x] Mobile: Create Course slides up from bottom, full fields reachable, image dropzone works, submit creates course
- [x] Mobile: Edit Course opens as bottom sheet, changes persist
- [x] Desktop: pixel-identical centered dialog
- [x] Preprod smoke-tested on iPhone (preprod.dance-hub.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)