### PR TITLE
fix(classroom): re-render listing after editing course details

### DIFF
--- a/app/[communitySlug]/classroom/[courseSlug]/CourseDetailClient.tsx
+++ b/app/[communitySlug]/classroom/[courseSlug]/CourseDetailClient.tsx
@@ -863,6 +863,7 @@ export default function CourseDetailClient({
       toast.success("Course updated successfully");
       setIsEditingCourse(false);
       mutateCourse();
+      router.refresh();
     } catch (error) {
       console.error("Error updating course:", error);
       toast.error("Error updating course");


### PR DESCRIPTION
## Summary
- After editing a course on the detail page, the classroom listing showed the stale name until hard-refresh
- Adds router.refresh() in handleUpdateCourse so Next re-runs the already-dynamic RSC

## Test plan
- [x] Preprod: edit course name, go back to /classroom, updated name shows without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)