### PR TITLE
fix(mobile): Manage Private Lessons modal + nested edit/schedule surfaces

### DIFF
--- a/components/CreatePrivateLessonModal.tsx
+++ b/components/CreatePrivateLessonModal.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -159,13 +164,13 @@ export default function CreatePrivateLessonModal({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>
+    <ResponsiveDialog open={isOpen} onOpenChange={onClose}>
+      <ResponsiveDialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>
             {editingLesson ? 'Edit Private Lesson' : 'Create Private Lesson'}
-          </DialogTitle>
-        </DialogHeader>
+          </ResponsiveDialogTitle>
+        </ResponsiveDialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Basic Information */}
@@ -342,7 +347,7 @@ export default function CreatePrivateLessonModal({
             </Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   );
-} 
+}

--- a/components/PrivateLessonManagementModal.tsx
+++ b/components/PrivateLessonManagementModal.tsx
@@ -325,9 +325,9 @@ export default function PrivateLessonManagementModal({
         ) : (
           <div className="space-y-4">
             {Array.isArray(privateLessons) ? privateLessons.map((lesson) => (
-              <div key={lesson.id} className="bg-card rounded-2xl p-6 border border-border/50 hover:border-primary/20 transition-all duration-200">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
+              <div key={lesson.id} className="bg-card rounded-2xl p-4 sm:p-6 border border-border/50 hover:border-primary/20 transition-all duration-200">
+                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                  <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-3 mb-2">
                       <h4 className="font-display font-semibold text-lg text-foreground">{lesson.title}</h4>
                       <Badge
@@ -374,7 +374,7 @@ export default function PrivateLessonManagementModal({
                     )}
                   </div>
 
-                  <div className="flex items-center gap-2 ml-4">
+                  <div className="flex flex-wrap items-center gap-2 sm:ml-4 sm:shrink-0">
                     <Button
                       variant="outline"
                       size="sm"
@@ -430,9 +430,9 @@ export default function PrivateLessonManagementModal({
         ) : (
           <div className="space-y-4">
             {Array.isArray(lessonBookings) ? lessonBookings.map((booking) => (
-              <div key={booking.id} className="bg-card rounded-2xl p-6 border border-border/50 hover:border-primary/20 transition-all duration-200">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
+              <div key={booking.id} className="bg-card rounded-2xl p-4 sm:p-6 border border-border/50 hover:border-primary/20 transition-all duration-200">
+                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                  <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-3 mb-3">
                       <h4 className="font-display font-semibold text-lg text-foreground">{booking.lesson_title}</h4>
                       <Badge
@@ -485,7 +485,7 @@ export default function PrivateLessonManagementModal({
                     )}
                   </div>
 
-                  <div className="flex flex-col gap-2 ml-4">
+                  <div className="flex flex-wrap sm:flex-col gap-2 sm:ml-4 sm:shrink-0">
                     {booking.payment_status === 'succeeded' && booking.scheduled_at && (
                       <Button
                         onClick={() => handleJoinVideoSession(booking)}
@@ -558,11 +558,11 @@ export default function PrivateLessonManagementModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-6xl transform overflow-hidden rounded-3xl bg-background p-6 text-left align-middle shadow-xl transition-all border border-border/50">
-                <div className="flex items-center justify-between mb-6">
+              <Dialog.Panel className="w-full max-w-6xl transform overflow-hidden rounded-3xl bg-background p-4 sm:p-6 text-left align-middle shadow-xl transition-all border border-border/50">
+                <div className="flex items-center justify-between mb-4 sm:mb-6">
                   <Dialog.Title
                     as="h3"
-                    className="font-display text-xl font-semibold text-foreground"
+                    className="font-display text-lg sm:text-xl font-semibold text-foreground"
                   >
                     Manage Private Lessons
                   </Dialog.Title>
@@ -570,14 +570,14 @@ export default function PrivateLessonManagementModal({
                     variant="ghost"
                     size="sm"
                     onClick={onClose}
-                    className="rounded-full h-10 w-10 p-0 hover:bg-muted"
+                    className="rounded-full h-10 w-10 p-0 hover:bg-muted shrink-0"
                   >
                     <X className="h-5 w-5" />
                   </Button>
                 </div>
 
                 {/* Tabs Navigation */}
-                <div className="flex gap-2 mb-6">
+                <div className="flex gap-2 mb-4 sm:mb-6">
                   <button
                     onClick={() => setActiveTab('details')}
                     className={cn(
@@ -605,7 +605,7 @@ export default function PrivateLessonManagementModal({
                 </div>
 
                 {/* Tab Content */}
-                <div className="max-h-[600px] overflow-y-auto pr-2">
+                <div className="max-h-[70vh] sm:max-h-[600px] min-w-0 overflow-y-auto overflow-x-hidden sm:pr-2">
                   {activeTab === 'details' && renderDetailsTab()}
                   {activeTab === 'schedule' && renderScheduleTab()}
                 </div>

--- a/components/TeacherCalendarAvailability.tsx
+++ b/components/TeacherCalendarAvailability.tsx
@@ -5,7 +5,12 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from '@/components/ui/responsive-dialog';
 import { Badge } from '@/components/ui/badge';
 import { ChevronLeft, ChevronRight, Plus, Clock, X, Calendar } from 'lucide-react';
 import { toast } from 'react-hot-toast';
@@ -216,24 +221,24 @@ export default function TeacherCalendarAvailability({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold flex items-center gap-2">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <h3 className="text-base sm:text-lg font-semibold flex items-center gap-2">
           <Calendar className="h-5 w-5" />
           Teaching Availability Calendar
         </h3>
-        <div className="text-sm text-gray-600">
+        <div className="text-xs sm:text-sm text-gray-600">
           Click on dates to set your availability
         </div>
       </div>
 
       {/* Calendar Header */}
       <Card>
-        <CardHeader className="pb-4">
+        <CardHeader className="pb-3 sm:pb-4 px-3 sm:px-6 pt-3 sm:pt-6">
           <div className="flex items-center justify-between">
             <Button variant="outline" size="sm" onClick={handlePrevMonth}>
               <ChevronLeft className="h-4 w-4" />
             </Button>
-            <CardTitle className="text-xl">
+            <CardTitle className="text-base sm:text-xl">
               {currentDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
             </CardTitle>
             <Button variant="outline" size="sm" onClick={handleNextMonth}>
@@ -241,12 +246,13 @@ export default function TeacherCalendarAvailability({
             </Button>
           </div>
         </CardHeader>
-        <CardContent>
+        <CardContent className="px-2 sm:px-6 pb-3 sm:pb-6">
           {/* Days of week header */}
           <div className="grid grid-cols-7 gap-1 mb-2">
             {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(day => (
-              <div key={day} className="text-center text-sm font-medium text-gray-500 py-2">
-                {day}
+              <div key={day} className="text-center text-xs sm:text-sm font-medium text-gray-500 py-2">
+                <span className="sm:hidden">{day.charAt(0)}</span>
+                <span className="hidden sm:inline">{day}</span>
               </div>
             ))}
           </div>
@@ -265,7 +271,7 @@ export default function TeacherCalendarAvailability({
                   key={index}
                   onClick={() => handleDateClick(date)}
                   className={`
-                    relative min-h-[80px] p-1 border rounded-lg cursor-pointer transition-all
+                    relative min-h-[48px] sm:min-h-[80px] p-1 border rounded-lg cursor-pointer transition-all
                     ${!isCurrentMonthDay ? 'text-gray-400 bg-gray-50' : ''}
                     ${isPast ? 'cursor-not-allowed opacity-50' : ''}
                     ${isTodayDate ? 'border-blue-500 bg-blue-50' : 'border-gray-200'}
@@ -273,23 +279,30 @@ export default function TeacherCalendarAvailability({
                     ${!isPast && isCurrentMonthDay ? 'hover:bg-blue-50 hover:border-blue-300' : ''}
                   `}
                 >
-                  <div className="text-sm font-medium">
+                  <div className="text-xs sm:text-sm font-medium">
                     {date.getDate()}
                   </div>
-                  
+
                   {hasAvailability && (
-                    <div className="mt-1 space-y-1">
-                      {dayAvailability.slots.slice(0, 2).map((slot, slotIndex) => (
-                        <div key={slotIndex} className="text-xs bg-green-100 text-green-800 px-1 py-0.5 rounded truncate">
-                          {formatTime(slot.start_time)}
-                        </div>
-                      ))}
-                      {dayAvailability.slots.length > 2 && (
-                        <div className="text-xs text-green-600 font-medium">
-                          +{dayAvailability.slots.length - 2} more
-                        </div>
-                      )}
-                    </div>
+                    <>
+                      {/* Mobile: just a dot under the day number — cells are too narrow for time chips */}
+                      <div className="sm:hidden mt-1 flex justify-center">
+                        <div className="h-1.5 w-1.5 rounded-full bg-green-500" aria-label={`${dayAvailability.slots.length} slot${dayAvailability.slots.length !== 1 ? 's' : ''}`} />
+                      </div>
+                      {/* Desktop: show first two time chips + counter */}
+                      <div className="hidden sm:block mt-1 space-y-1">
+                        {dayAvailability.slots.slice(0, 2).map((slot, slotIndex) => (
+                          <div key={slotIndex} className="text-xs bg-green-100 text-green-800 px-1 py-0.5 rounded truncate">
+                            {formatTime(slot.start_time)}
+                          </div>
+                        ))}
+                        {dayAvailability.slots.length > 2 && (
+                          <div className="text-xs text-green-600 font-medium">
+                            +{dayAvailability.slots.length - 2} more
+                          </div>
+                        )}
+                      </div>
+                    </>
                   )}
                 </div>
               );
@@ -299,18 +312,18 @@ export default function TeacherCalendarAvailability({
       </Card>
 
       {/* Day Availability Dialog */}
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>
-              Set Availability for {selectedDate && formatDateString(selectedDate).toLocaleDateString('en-US', { 
-                weekday: 'long', 
-                year: 'numeric', 
-                month: 'long', 
-                day: 'numeric' 
+      <ResponsiveDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <ResponsiveDialogContent className="max-w-md">
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle>
+              Set Availability for {selectedDate && formatDateString(selectedDate).toLocaleDateString('en-US', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
               })}
-            </DialogTitle>
-          </DialogHeader>
+            </ResponsiveDialogTitle>
+          </ResponsiveDialogHeader>
 
           <div className="space-y-6">
             {/* Add New Slot Form */}
@@ -374,8 +387,8 @@ export default function TeacherCalendarAvailability({
               </div>
             )}
           </div>
-        </DialogContent>
-      </Dialog>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Stops Manage Private Lessons modal from overflowing on narrow screens (lesson/booking cards stack + action rows wrap)
- Converts Edit Private Lesson form to a bottom sheet on mobile via ResponsiveDialog
- Same treatment for the per-day availability picker inside the Schedule tab
- Tightens the month calendar grid on mobile (single-letter day labels, 48px cell height, availability shown as a dot instead of unreadable time chips)

## Test plan
- [x] Manage modal: cards readable end-to-end, action buttons wrap under text column on mobile
- [x] Edit Private Lesson: opens as bottom sheet, form submits, desktop pixel-identical
- [x] Schedule tab: whole month fits on iPhone SE, days with availability show a green dot
- [x] Day availability picker: opens as bottom sheet, add/delete slots work

🤖 Generated with [Claude Code](https://claude.com/claude-code)