### PR TITLE
feat(mobile): calendar day view + live class bottom sheets + overlap validation

### DIFF
--- a/app/api/community/[communitySlug]/live-classes/[classId]/route.ts
+++ b/app/api/community/[communitySlug]/live-classes/[classId]/route.ts
@@ -13,6 +13,8 @@ interface LiveClass {
   livekit_room_name: string | null;
   enable_recording: boolean;
   status: string;
+  scheduled_start_time: string;
+  duration_minutes: number;
 }
 
 interface LiveClassWithDetails {
@@ -123,7 +125,7 @@ export async function PUT(
 
     // Get the live class to check ownership
     const liveClass = await queryOne<LiveClass>`
-      SELECT teacher_id, livekit_room_name, enable_recording, status
+      SELECT teacher_id, livekit_room_name, enable_recording, status, scheduled_start_time, duration_minutes
       FROM live_classes
       WHERE id = ${params.classId}
         AND community_id = ${community.id}
@@ -146,6 +148,41 @@ export async function PUT(
 
     const body = await request.json();
     const { title, description, scheduled_start_time, duration_minutes, status, enable_recording } = body;
+
+    // If time or duration is changing, re-check for overlap with this teacher's
+    // other scheduled/live classes. Exclude this class from the check, and treat
+    // a transition to 'cancelled'/'ended' as harmless (those free up a slot).
+    const nextStatus = status ?? liveClass.status;
+    if (
+      (scheduled_start_time || duration_minutes) &&
+      nextStatus !== 'cancelled' &&
+      nextStatus !== 'ended'
+    ) {
+      const effectiveStart = new Date(scheduled_start_time ?? liveClass.scheduled_start_time);
+      const effectiveDuration = duration_minutes
+        ? parseInt(duration_minutes)
+        : liveClass.duration_minutes;
+      const effectiveEnd = new Date(effectiveStart.getTime() + effectiveDuration * 60000);
+      const conflict = await queryOne<{ id: string; title: string; scheduled_start_time: string }>`
+        SELECT id, title, scheduled_start_time
+        FROM live_classes
+        WHERE community_id = ${community.id}
+          AND teacher_id = ${liveClass.teacher_id}
+          AND id != ${params.classId}
+          AND status NOT IN ('cancelled', 'ended')
+          AND scheduled_start_time < ${effectiveEnd.toISOString()}::timestamptz
+          AND (scheduled_start_time + (duration_minutes || ' minutes')::interval) > ${effectiveStart.toISOString()}::timestamptz
+        LIMIT 1
+      `;
+      if (conflict) {
+        return NextResponse.json(
+          {
+            error: `This time overlaps with "${conflict.title}" scheduled at ${new Date(conflict.scheduled_start_time).toLocaleString()}. Pick a different time.`,
+          },
+          { status: 409 }
+        );
+      }
+    }
 
     // Update the live class using COALESCE for partial updates
     const updatedClass = await queryOne<UpdatedLiveClass>`

--- a/app/api/community/[communitySlug]/live-classes/route.ts
+++ b/app/api/community/[communitySlug]/live-classes/route.ts
@@ -143,6 +143,31 @@ export async function POST(
       );
     }
 
+    // Reject if this teacher already has a non-cancelled / non-ended class
+    // whose time window overlaps the new one. Two windows overlap iff
+    // newStart < existingEnd && newEnd > existingStart.
+    const newDurationMin = parseInt(duration_minutes);
+    const newStart = new Date(scheduled_start_time);
+    const newEnd = new Date(newStart.getTime() + newDurationMin * 60000);
+    const conflict = await queryOne<{ id: string; title: string; scheduled_start_time: string }>`
+      SELECT id, title, scheduled_start_time
+      FROM live_classes
+      WHERE community_id = ${community.id}
+        AND teacher_id = ${user.id}
+        AND status NOT IN ('cancelled', 'ended')
+        AND scheduled_start_time < ${newEnd.toISOString()}::timestamptz
+        AND (scheduled_start_time + (duration_minutes || ' minutes')::interval) > ${newStart.toISOString()}::timestamptz
+      LIMIT 1
+    `;
+    if (conflict) {
+      return NextResponse.json(
+        {
+          error: `This time overlaps with "${conflict.title}" scheduled at ${new Date(conflict.scheduled_start_time).toLocaleString()}. Pick a different time.`,
+        },
+        { status: 409 }
+      );
+    }
+
     // Create the live class
     const liveClass = await queryOne<LiveClass>`
       INSERT INTO live_classes (

--- a/components/LiveClassCard.tsx
+++ b/components/LiveClassCard.tsx
@@ -4,6 +4,7 @@ import { format, parseISO } from "date-fns";
 import { PlayIcon, ClockIcon } from "@heroicons/react/24/solid";
 import { useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 
 interface LiveClass {
   id: string;
@@ -27,6 +28,10 @@ interface LiveClassCardProps {
 export default function LiveClassCard({ liveClass, communitySlug, onClick }: LiveClassCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number } | null>(null);
+  // Skip the hover tooltip on touch devices — tap fires a synthetic
+  // mouseenter that briefly flashes the tooltip before the click handler
+  // opens the details bottom sheet.
+  const isMobile = useIsMobile();
   const startTime = parseISO(liveClass.scheduled_start_time);
   const endTime = new Date(startTime.getTime() + liveClass.duration_minutes * 60000);
   // A scheduled class whose end time has elapsed without going live/ending
@@ -60,7 +65,7 @@ export default function LiveClassCard({ liveClass, communitySlug, onClick }: Liv
 
   // Place the tooltip just below the card using its viewport rect.
   const showTooltip = () => {
-    if (!cardRef.current) return;
+    if (isMobile || !cardRef.current) return;
     const r = cardRef.current.getBoundingClientRect();
     setTooltipPos({ top: r.bottom + 4, left: r.left });
   };

--- a/components/LiveClassDetailsModal.tsx
+++ b/components/LiveClassDetailsModal.tsx
@@ -21,6 +21,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
 
@@ -55,6 +64,7 @@ export default function LiveClassDetailsModal({
   onEdit,
   onDeleted,
 }: LiveClassDetailsModalProps) {
+  const isMobile = useIsMobile();
   const startTime = parseISO(liveClass.scheduled_start_time);
   const endTime = new Date(startTime.getTime() + liveClass.duration_minutes * 60000);
   // Scheduled-but-already-elapsed = effectively past.
@@ -208,27 +218,57 @@ export default function LiveClassDetailsModal({
         </ResponsiveDialogContent>
       </ResponsiveDialog>
 
-      <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete this live class?</AlertDialogTitle>
-            <AlertDialogDescription>
-              &ldquo;{liveClass.title}&rdquo; will be removed from the calendar.
-              This can&apos;t be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={deleting}
-              className="bg-red-600 hover:bg-red-700"
-            >
-              {deleting ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {isMobile ? (
+        <Sheet open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+          <SheetContent side="bottom" className="rounded-t-2xl pb-safe">
+            <SheetHeader className="text-left">
+              <SheetTitle>Delete this live class?</SheetTitle>
+              <SheetDescription>
+                &ldquo;{liveClass.title}&rdquo; will be removed from the calendar.
+                This can&apos;t be undone.
+              </SheetDescription>
+            </SheetHeader>
+            <SheetFooter className="mt-4 flex-col-reverse gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setConfirmDeleteOpen(false)}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="bg-red-600 hover:bg-red-700 text-white"
+              >
+                {deleting ? 'Deleting...' : 'Delete'}
+              </Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      ) : (
+        <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this live class?</AlertDialogTitle>
+              <AlertDialogDescription>
+                &ldquo;{liveClass.title}&rdquo; will be removed from the calendar.
+                This can&apos;t be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDelete}
+                disabled={deleting}
+                className="bg-red-600 hover:bg-red-700"
+              >
+                {deleting ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
     </>
   );
 }

--- a/components/LiveClassDetailsModal.tsx
+++ b/components/LiveClassDetailsModal.tsx
@@ -118,7 +118,7 @@ export default function LiveClassDetailsModal({
   return (
     <>
       <Dialog open={true} onOpenChange={onClose}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Live Class Details</DialogTitle>
           </DialogHeader>

--- a/components/LiveClassDetailsModal.tsx
+++ b/components/LiveClassDetailsModal.tsx
@@ -6,11 +6,11 @@ import { ClockIcon, CalendarIcon, VideoCameraIcon, PencilSquareIcon, TrashIcon }
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -117,11 +117,11 @@ export default function LiveClassDetailsModal({
 
   return (
     <>
-      <Dialog open={true} onOpenChange={onClose}>
-        <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Live Class Details</DialogTitle>
-          </DialogHeader>
+      <ResponsiveDialog open={true} onOpenChange={onClose}>
+        <ResponsiveDialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle>Live Class Details</ResponsiveDialogTitle>
+          </ResponsiveDialogHeader>
 
           <div className="space-y-4">
             <div className="flex items-center justify-between">
@@ -205,8 +205,8 @@ export default function LiveClassDetailsModal({
               )}
             </div>
           </div>
-        </DialogContent>
-      </Dialog>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
 
       <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
         <AlertDialogContent>

--- a/components/LiveClassModal.tsx
+++ b/components/LiveClassModal.tsx
@@ -8,11 +8,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog";
 import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "react-hot-toast";
 
@@ -138,13 +138,13 @@ export default function LiveClassModal({
   };
 
   return (
-    <Dialog open={true} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>
+    <ResponsiveDialog open={true} onOpenChange={onClose}>
+      <ResponsiveDialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>
             {isEdit ? "Edit Live Class" : "Schedule Live Class"}
-          </DialogTitle>
-        </DialogHeader>
+          </ResponsiveDialogTitle>
+        </ResponsiveDialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
@@ -249,7 +249,7 @@ export default function LiveClassModal({
             </Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   );
 }

--- a/components/WeekCalendar.tsx
+++ b/components/WeekCalendar.tsx
@@ -213,7 +213,6 @@ export default function WeekCalendar({ communityId, communitySlug, isTeacher, in
           visibleHours={visibleHours}
           isTeacher={isTeacher}
           communitySlug={communitySlug}
-          onTimeSlotClick={handleTimeSlotClick}
           onClassClick={(lc) => setSelectedClass(lc)}
         />
       ) : (

--- a/components/WeekCalendar.tsx
+++ b/components/WeekCalendar.tsx
@@ -6,9 +6,11 @@ import { format, addDays, startOfWeek, endOfWeek, isSameDay, parseISO } from "da
 import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import LiveClassModal from "./LiveClassModal";
 import LiveClassCard from "./LiveClassCard";
 import LiveClassDetailsModal from "./LiveClassDetailsModal";
+import WeekCalendarDay from "./WeekCalendarDay";
 
 interface LiveClass {
   id: string;
@@ -39,6 +41,7 @@ const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", 
 
 export default function WeekCalendar({ communityId, communitySlug, isTeacher, initialClasses }: WeekCalendarProps) {
   const router = useRouter();
+  const isMobile = useIsMobile();
   const [currentWeek, setCurrentWeek] = useState(new Date());
   const [liveClasses, setLiveClasses] = useState<LiveClass[]>(initialClasses ?? []);
   const [loading, setLoading] = useState(!initialClasses);
@@ -163,41 +166,58 @@ export default function WeekCalendar({ communityId, communitySlug, isTeacher, in
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4 sm:space-y-6">
       {/* Week Navigation */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-4">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 sm:gap-4 min-w-0">
           <Button
             variant="outline"
             size="sm"
             onClick={() => navigateWeek('prev')}
+            aria-label="Previous week"
+            className="shrink-0"
           >
             <ChevronLeftIcon className="h-4 w-4" />
           </Button>
-          <h2 className="text-xl font-semibold text-gray-900">
+          <h2 className="text-base sm:text-xl font-semibold text-gray-900 truncate">
             {format(weekStart, 'MMM d')} - {format(weekEnd, 'MMM d, yyyy')}
           </h2>
           <Button
             variant="outline"
             size="sm"
             onClick={() => navigateWeek('next')}
+            aria-label="Next week"
+            className="shrink-0"
           >
             <ChevronRightIcon className="h-4 w-4" />
           </Button>
         </div>
-        
+
         {isTeacher && (
           <Button
             onClick={() => setShowCreateModal(true)}
-            className="flex items-center space-x-2"
+            className="flex items-center gap-2 shrink-0"
+            aria-label="Schedule class"
           >
             <PlusIcon className="h-4 w-4" />
-            <span>Schedule Class</span>
+            <span className="hidden sm:inline">Schedule Class</span>
           </Button>
         )}
       </div>
 
-      {/* Calendar Grid */}
+      {/* Mobile: day view (day-picker strip + selected-day timeline) */}
+      {isMobile ? (
+        <WeekCalendarDay
+          weekStart={weekStart}
+          liveClasses={liveClasses}
+          visibleHours={visibleHours}
+          isTeacher={isTeacher}
+          communitySlug={communitySlug}
+          onTimeSlotClick={handleTimeSlotClick}
+          onClassClick={(lc) => setSelectedClass(lc)}
+        />
+      ) : (
+      /* Desktop: the original week grid */
       <Card className="shadow-sm">
         <CardContent className="p-0 overflow-x-auto">
           <div className="min-w-[800px]">
@@ -308,6 +328,7 @@ export default function WeekCalendar({ communityId, communitySlug, isTeacher, in
           </div>
         </CardContent>
       </Card>
+      )}
 
       {/* Create Live Class Modal */}
       {showCreateModal && (

--- a/components/WeekCalendarDay.tsx
+++ b/components/WeekCalendarDay.tsx
@@ -25,7 +25,6 @@ interface WeekCalendarDayProps {
   visibleHours: number[];
   isTeacher: boolean;
   communitySlug: string;
-  onTimeSlotClick: (day: Date, hour: number, minutes?: number) => void;
   onClassClick: (liveClass: LiveClass) => void;
 }
 
@@ -38,7 +37,6 @@ export default function WeekCalendarDay({
   visibleHours,
   isTeacher,
   communitySlug,
-  onTimeSlotClick,
   onClassClick,
 }: WeekCalendarDayProps) {
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
@@ -109,17 +107,19 @@ export default function WeekCalendarDay({
         {format(selectedDay, 'EEEE, MMMM d')}
       </h3>
 
-      {/* Empty state for students on a day with no classes — skip the timeline
-          entirely since they can't schedule anything. Teachers always see the
-          timeline so they can tap free slots to add a class. */}
-      {selectedDayClasses.length === 0 && !isTeacher ? (
+      {/* Empty state — nobody taps slots to schedule on mobile, so we show a
+          friendlier placeholder instead of a dozen empty time rows. Teachers
+          use the Schedule Class button in the header. */}
+      {selectedDayClasses.length === 0 ? (
         <Card>
           <CardContent className="py-8 text-center">
             <p className="text-sm text-muted-foreground">
               No classes scheduled on {format(selectedDay, 'EEEE')}.
             </p>
             <p className="text-xs text-muted-foreground mt-1">
-              Check other days in this week.
+              {isTeacher
+                ? 'Use Schedule Class to add one.'
+                : 'Check other days in this week.'}
             </p>
           </CardContent>
         </Card>
@@ -155,35 +155,22 @@ export default function WeekCalendarDay({
                       </span>
                     </div>
 
-                    {/* Slots column (full remaining width) */}
+                    {/* Slots column (full remaining width). Read-only on
+                        mobile — teachers use the Schedule Class button in
+                        the header to open the modal, so half-hour slots are
+                        purely visual ruling. */}
                     <div className="flex-1 relative">
                       <div className="flex flex-col h-full">
-                        {HALF_HOURS.map((minutes) => {
-                          const slotTime = new Date(selectedDay);
-                          slotTime.setHours(hour, minutes, 0, 0);
-                          const isPastSlot = slotTime < new Date();
-                          return (
-                            <button
-                              key={minutes}
-                              type="button"
-                              disabled={!isTeacher || isPastSlot}
-                              onClick={() => {
-                                if (!isPastSlot) {
-                                  onTimeSlotClick(selectedDay, hour, minutes);
-                                }
-                              }}
-                              aria-label={`${format(slotTime, 'h:mm a')} slot`}
-                              className={cn(
-                                "flex-1 text-left w-full",
-                                minutes === 30 &&
-                                  "border-t border-dashed border-gray-200",
-                                isTeacher && !isPastSlot
-                                  ? "active:bg-blue-50 cursor-pointer"
-                                  : "cursor-default",
-                              )}
-                            />
-                          );
-                        })}
+                        {HALF_HOURS.map((minutes) => (
+                          <div
+                            key={minutes}
+                            className={cn(
+                              "flex-1",
+                              minutes === 30 &&
+                                "border-t border-dashed border-gray-200",
+                            )}
+                          />
+                        ))}
                       </div>
 
                       {/* Classes overlaid — same absolute-positioned pattern as

--- a/components/WeekCalendarDay.tsx
+++ b/components/WeekCalendarDay.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { addDays, format, isSameDay, parseISO } from "date-fns";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import LiveClassCard from "./LiveClassCard";
+
+interface LiveClass {
+  id: string;
+  title: string;
+  description?: string | null;
+  scheduled_start_time: string;
+  duration_minutes: number;
+  teacher_name: string;
+  teacher_avatar_url?: string | null;
+  status: 'scheduled' | 'live' | 'ended' | 'cancelled';
+  is_currently_active: boolean;
+  is_starting_soon: boolean;
+}
+
+interface WeekCalendarDayProps {
+  weekStart: Date;
+  liveClasses: LiveClass[];
+  visibleHours: number[];
+  isTeacher: boolean;
+  communitySlug: string;
+  onTimeSlotClick: (day: Date, hour: number, minutes?: number) => void;
+  onClassClick: (liveClass: LiveClass) => void;
+}
+
+const DAY_LETTERS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+const HALF_HOURS = [0, 30];
+
+export default function WeekCalendarDay({
+  weekStart,
+  liveClasses,
+  visibleHours,
+  isTeacher,
+  communitySlug,
+  onTimeSlotClick,
+  onClassClick,
+}: WeekCalendarDayProps) {
+  const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+  // Default selection: today if it lives in the current week, otherwise Sunday.
+  // Reset whenever the week changes (via prev/next).
+  const pickDefault = () => {
+    const today = new Date();
+    return weekDays.find((d) => isSameDay(d, today)) ?? weekDays[0];
+  };
+  const [selectedDay, setSelectedDay] = useState<Date>(pickDefault);
+
+  useEffect(() => {
+    setSelectedDay(pickDefault());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [weekStart.toISOString()]);
+
+  const classesForDay = (day: Date) =>
+    liveClasses.filter((lc) => isSameDay(parseISO(lc.scheduled_start_time), day));
+
+  const selectedDayClasses = classesForDay(selectedDay);
+
+  return (
+    <div className="space-y-4">
+      {/* Day-picker strip: 7 equal tiles, today highlighted, dot when a day has classes */}
+      <div className="grid grid-cols-7 gap-1">
+        {weekDays.map((day, i) => {
+          const isSelected = isSameDay(day, selectedDay);
+          const isToday = isSameDay(day, new Date());
+          const hasClasses = classesForDay(day).length > 0;
+          return (
+            <button
+              key={day.toISOString()}
+              type="button"
+              onClick={() => setSelectedDay(day)}
+              className={cn(
+                "flex flex-col items-center py-2 rounded-lg transition-colors",
+                isSelected
+                  ? "bg-primary text-primary-foreground"
+                  : isToday
+                    ? "border border-primary/40 text-foreground"
+                    : "text-foreground hover:bg-muted",
+              )}
+            >
+              <span className="text-[10px] font-medium opacity-80">
+                {DAY_LETTERS[i]}
+              </span>
+              <span className="text-base font-semibold leading-none mt-1">
+                {format(day, 'd')}
+              </span>
+              <span
+                className={cn(
+                  "mt-1 h-1 w-1 rounded-full",
+                  hasClasses
+                    ? isSelected
+                      ? "bg-white"
+                      : "bg-emerald-500"
+                    : "bg-transparent",
+                )}
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Selected day header */}
+      <h3 className="text-base font-semibold text-gray-900">
+        {format(selectedDay, 'EEEE, MMMM d')}
+      </h3>
+
+      {/* Empty state for students on a day with no classes — skip the timeline
+          entirely since they can't schedule anything. Teachers always see the
+          timeline so they can tap free slots to add a class. */}
+      {selectedDayClasses.length === 0 && !isTeacher ? (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No classes scheduled on {format(selectedDay, 'EEEE')}.
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Check other days in this week.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <div className="divide-y divide-gray-100">
+              {visibleHours.map((hour) => {
+                const hourClasses = selectedDayClasses.filter(
+                  (lc) => parseISO(lc.scheduled_start_time).getHours() === hour,
+                );
+                const hourEnd = new Date(selectedDay);
+                hourEnd.setHours(hour, 59, 59, 999);
+                const isPastHour = hourEnd < new Date();
+                const isToday = isSameDay(selectedDay, new Date());
+
+                return (
+                  <div
+                    key={hour}
+                    className={cn(
+                      "flex min-h-[64px]",
+                      isPastHour
+                        ? "bg-gray-50/30"
+                        : isToday
+                          ? "bg-blue-50/20"
+                          : "bg-white",
+                    )}
+                  >
+                    {/* Time label column */}
+                    <div className="w-14 shrink-0 px-2 py-2 text-xs text-gray-500 bg-gray-50/50 border-r border-gray-200 flex items-start">
+                      <span className="font-medium">
+                        {format(new Date().setHours(hour, 0, 0, 0), 'h a')}
+                      </span>
+                    </div>
+
+                    {/* Slots column (full remaining width) */}
+                    <div className="flex-1 relative">
+                      <div className="flex flex-col h-full">
+                        {HALF_HOURS.map((minutes) => {
+                          const slotTime = new Date(selectedDay);
+                          slotTime.setHours(hour, minutes, 0, 0);
+                          const isPastSlot = slotTime < new Date();
+                          return (
+                            <button
+                              key={minutes}
+                              type="button"
+                              disabled={!isTeacher || isPastSlot}
+                              onClick={() => {
+                                if (!isPastSlot) {
+                                  onTimeSlotClick(selectedDay, hour, minutes);
+                                }
+                              }}
+                              aria-label={`${format(slotTime, 'h:mm a')} slot`}
+                              className={cn(
+                                "flex-1 text-left w-full",
+                                minutes === 30 &&
+                                  "border-t border-dashed border-gray-200",
+                                isTeacher && !isPastSlot
+                                  ? "active:bg-blue-50 cursor-pointer"
+                                  : "cursor-default",
+                              )}
+                            />
+                          );
+                        })}
+                      </div>
+
+                      {/* Classes overlaid — same absolute-positioned pattern as
+                          the desktop grid so LiveClassCard owns its own styling. */}
+                      <div className="absolute inset-0 px-2 py-1 pointer-events-none">
+                        {hourClasses.map((lc) => (
+                          <div key={lc.id} className="pointer-events-auto">
+                            <LiveClassCard
+                              liveClass={lc}
+                              communitySlug={communitySlug}
+                              onClick={() => onClassClick(lc)}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Day view for calendar on mobile** — day-picker strip (today preselected, dot under days with classes), full-width timeline below; desktop week grid untouched
- **Live class modals as bottom sheets** — Schedule/Edit form, Details modal, and delete confirm all slide up from the bottom on mobile
- **Tooltip fix** — LiveClassCard tooltip no longer flashes before the details sheet opens on tap
- **Overlap validation** — create/update live-class API rejects times that overlap the same teacher's other scheduled/live classes (409)
- **Slot tap-to-create removed on mobile** — teachers use the Schedule Class button in the header; slots are read-only ruling

## Test plan
- [x] Mobile: calendar shows day view, today preselected, dots on days with classes
- [x] Mobile: tap class card → details sheet (no tooltip flash) → edit → tap delete → confirm sheet
- [x] Mobile: Schedule Class header button opens the form sheet; saving + overlapping time returns friendly error
- [x] Desktop: week grid pixel-identical
- [x] API: overlapping create/update returns 409 with conflict details; cancelled/ended classes free their slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)