### PR TITLE
style(threads): remove non-functional Sorted by oldest hint

### DIFF
--- a/components/ThreadView.tsx
+++ b/components/ThreadView.tsx
@@ -758,9 +758,6 @@ export default function ThreadView({
                 <MessageSquare className="h-4 w-4" />
                 <span>{thread.comments_count} comments</span>
               </div>
-              <div className="ml-auto text-xs text-muted-foreground">
-                Sorted by oldest
-              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Drop the static "Sorted by oldest" label from the ThreadView reactions row — sort wasn't wired up and the tease read as broken.

Validated on preprod (https://preprod.dance-hub.io).

## Test plan
- [ ] Open a thread modal — reactions row shows just the like + comment pills, no trailing label

🤖 Generated with [Claude Code](https://claude.com/claude-code)