### PR TITLE
feat(admin): redesign community admin dashboard

### DIFF
--- a/__tests__/lib/admin-dashboard/activity-feed.test.ts
+++ b/__tests__/lib/admin-dashboard/activity-feed.test.ts
@@ -1,0 +1,39 @@
+import { mergeActivityEvents } from '@/lib/admin-dashboard/activity-feed';
+import type { ActivityEvent } from '@/lib/admin-dashboard/types';
+
+const make = (overrides: Partial<ActivityEvent>): ActivityEvent =>
+  ({
+    type: 'join',
+    at: new Date(2026, 3, 1),
+    userId: 'u1',
+    displayName: 'X',
+    avatarUrl: null,
+    ...overrides,
+  } as ActivityEvent);
+
+describe('mergeActivityEvents', () => {
+  it('merges multiple lists, sorts DESC by at, caps at limit', () => {
+    const a: ActivityEvent[] = [
+      make({ at: new Date('2026-04-10T09:00:00Z'), userId: 'a1' }),
+      make({ at: new Date('2026-04-05T09:00:00Z'), userId: 'a2' }),
+    ];
+    const b: ActivityEvent[] = [
+      make({ at: new Date('2026-04-12T09:00:00Z'), userId: 'b1', type: 'cancel' }),
+      make({ at: new Date('2026-04-08T09:00:00Z'), userId: 'b2', type: 'cancel' }),
+    ];
+    const result = mergeActivityEvents([a, b], 3);
+    expect(result.map((e) => e.userId)).toEqual(['b1', 'a1', 'b2']);
+  });
+
+  it('returns empty array when all inputs empty', () => {
+    expect(mergeActivityEvents([[], [], []], 10)).toEqual([]);
+  });
+
+  it('preserves stable order between same-timestamp events', () => {
+    const t = new Date('2026-04-12T09:00:00Z');
+    const a: ActivityEvent[] = [make({ at: t, userId: 'a1' })];
+    const b: ActivityEvent[] = [make({ at: t, userId: 'b1' })];
+    const result = mergeActivityEvents([a, b], 10);
+    expect(result.map((e) => e.userId)).toEqual(['a1', 'b1']);
+  });
+});

--- a/__tests__/lib/admin-dashboard/activity-feed.test.ts
+++ b/__tests__/lib/admin-dashboard/activity-feed.test.ts
@@ -1,5 +1,14 @@
-import { mergeActivityEvents } from '@/lib/admin-dashboard/activity-feed';
+import { mergeActivityEvents, getRecentFailedPayments } from '@/lib/admin-dashboard/activity-feed';
 import type { ActivityEvent } from '@/lib/admin-dashboard/types';
+
+const mockChargesList = jest.fn();
+const mockAccountsRetrieve = jest.fn();
+jest.mock('@/lib/stripe', () => ({
+  stripe: {
+    accounts: { retrieve: (...a: unknown[]) => mockAccountsRetrieve(...a) },
+    charges: { list: (...a: unknown[]) => mockChargesList(...a) },
+  },
+}));
 
 const make = (overrides: Partial<ActivityEvent>): ActivityEvent =>
   ({
@@ -35,5 +44,60 @@ describe('mergeActivityEvents', () => {
     const b: ActivityEvent[] = [make({ at: t, userId: 'b1' })];
     const result = mergeActivityEvents([a, b], 10);
     expect(result.map((e) => e.userId)).toEqual(['a1', 'b1']);
+  });
+});
+
+describe('getRecentFailedPayments', () => {
+  beforeEach(() => {
+    mockChargesList.mockReset();
+    mockAccountsRetrieve.mockReset();
+  });
+
+  it('returns [] when stripeAccountId is null', async () => {
+    const result = await getRecentFailedPayments(null);
+    expect(result).toEqual([]);
+    expect(mockChargesList).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when account is not charges_enabled', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: false });
+    const result = await getRecentFailedPayments('acct_x');
+    expect(result).toEqual([]);
+  });
+
+  it('maps failed charges to ActivityEvent rows', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: true });
+    const t = new Date('2026-04-12T09:00:00Z');
+    mockChargesList.mockResolvedValueOnce({
+      data: [
+        {
+          status: 'failed',
+          amount: 1500,
+          created: Math.floor(t.getTime() / 1000),
+          billing_details: { name: 'Anna Test' },
+          metadata: { user_id: 'u1' },
+        },
+      ],
+    });
+    const result = await getRecentFailedPayments('acct_x');
+    expect(result).toEqual([
+      {
+        type: 'failed_payment',
+        at: t,
+        userId: 'u1',
+        displayName: 'Anna Test',
+        amount: 15,
+      },
+    ]);
+  });
+
+  it('falls back to "Unknown" displayName when billing_details.name is missing', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: true });
+    mockChargesList.mockResolvedValueOnce({
+      data: [{ status: 'failed', amount: 1000, created: 1700000000, billing_details: {}, metadata: {} }],
+    });
+    const result = await getRecentFailedPayments('acct_x');
+    expect(result[0].displayName).toBe('Unknown');
+    expect(result[0].userId).toBeNull();
   });
 });

--- a/__tests__/lib/admin-dashboard/stats.test.ts
+++ b/__tests__/lib/admin-dashboard/stats.test.ts
@@ -1,0 +1,42 @@
+import { getCalendarMonthRange, computeMoMGrowth } from '@/lib/admin-dashboard/stats';
+
+describe('getCalendarMonthRange', () => {
+  it('returns start of current month and start of next month with offset 0', () => {
+    const now = new Date(2026, 3, 15); // April 15, 2026
+    const { start, end } = getCalendarMonthRange(now, 0);
+    expect(start).toEqual(new Date(2026, 3, 1));
+    expect(end).toEqual(new Date(2026, 4, 1));
+  });
+
+  it('returns previous month with offset -1', () => {
+    const now = new Date(2026, 3, 15);
+    const { start, end } = getCalendarMonthRange(now, -1);
+    expect(start).toEqual(new Date(2026, 2, 1));
+    expect(end).toEqual(new Date(2026, 3, 1));
+  });
+
+  it('handles year boundary (January)', () => {
+    const now = new Date(2026, 0, 15);
+    const { start, end } = getCalendarMonthRange(now, -1);
+    expect(start).toEqual(new Date(2025, 11, 1));
+    expect(end).toEqual(new Date(2026, 0, 1));
+  });
+});
+
+describe('computeMoMGrowth', () => {
+  it('returns positive % when current > previous', () => {
+    expect(computeMoMGrowth(120, 100)).toBe(20);
+  });
+  it('returns negative % when current < previous', () => {
+    expect(computeMoMGrowth(75, 100)).toBe(-25);
+  });
+  it('returns 0 when both are 0', () => {
+    expect(computeMoMGrowth(0, 0)).toBe(0);
+  });
+  it('returns 100 when previous is 0 and current is non-zero', () => {
+    expect(computeMoMGrowth(50, 0)).toBe(100);
+  });
+  it('rounds to integer', () => {
+    expect(computeMoMGrowth(10.7, 10)).toBe(7);
+  });
+});

--- a/__tests__/lib/admin-dashboard/stats.test.ts
+++ b/__tests__/lib/admin-dashboard/stats.test.ts
@@ -1,4 +1,13 @@
-import { getCalendarMonthRange, computeMoMGrowth } from '@/lib/admin-dashboard/stats';
+import { getCalendarMonthRange, computeMoMGrowth, getMonthlyRevenue } from '@/lib/admin-dashboard/stats';
+
+const mockChargesList = jest.fn();
+const mockAccountsRetrieve = jest.fn();
+jest.mock('@/lib/stripe', () => ({
+  stripe: {
+    accounts: { retrieve: (...a: unknown[]) => mockAccountsRetrieve(...a) },
+    charges: { list: (...a: unknown[]) => mockChargesList(...a) },
+  },
+}));
 
 describe('getCalendarMonthRange', () => {
   it('returns start of current month and start of next month with offset 0', () => {
@@ -38,5 +47,46 @@ describe('computeMoMGrowth', () => {
   });
   it('rounds to integer', () => {
     expect(computeMoMGrowth(10.7, 10)).toBe(7);
+  });
+});
+
+describe('getMonthlyRevenue', () => {
+  beforeEach(() => {
+    mockChargesList.mockReset();
+    mockAccountsRetrieve.mockReset();
+  });
+
+  it('returns 0/0 when stripeAccountId is null', async () => {
+    const result = await getMonthlyRevenue(null, new Date(2026, 3, 15));
+    expect(result).toEqual({ monthlyRevenue: 0, revenueGrowth: 0 });
+    expect(mockAccountsRetrieve).not.toHaveBeenCalled();
+  });
+
+  it('returns 0/0 when account is not charges_enabled', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: false });
+    const result = await getMonthlyRevenue('acct_x', new Date(2026, 3, 15));
+    expect(result).toEqual({ monthlyRevenue: 0, revenueGrowth: 0 });
+  });
+
+  it('sums succeeded charges and computes MoM', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: true });
+    mockChargesList
+      .mockResolvedValueOnce({ data: [
+        { status: 'succeeded', amount: 5000 },
+        { status: 'succeeded', amount: 3000 },
+        { status: 'failed',    amount: 1000 },
+      ] })
+      .mockResolvedValueOnce({ data: [
+        { status: 'succeeded', amount: 4000 },
+      ] });
+    const result = await getMonthlyRevenue('acct_x', new Date(2026, 3, 15));
+    expect(result.monthlyRevenue).toBe(80);
+    expect(result.revenueGrowth).toBe(100);
+  });
+
+  it('falls back to 0/0 when accounts.retrieve throws', async () => {
+    mockAccountsRetrieve.mockRejectedValueOnce(new Error('stripe down'));
+    const result = await getMonthlyRevenue('acct_x', new Date(2026, 3, 15));
+    expect(result).toEqual({ monthlyRevenue: 0, revenueGrowth: 0 });
   });
 });

--- a/__tests__/lib/admin-dashboard/stats.test.ts
+++ b/__tests__/lib/admin-dashboard/stats.test.ts
@@ -1,4 +1,4 @@
-import { getCalendarMonthRange, computeMoMGrowth, getMonthlyRevenue } from '@/lib/admin-dashboard/stats';
+import { getCalendarMonthRange, computeMoMGrowth, getMonthlyRevenue, getRevenueChart6Months } from '@/lib/admin-dashboard/stats';
 
 const mockChargesList = jest.fn();
 const mockAccountsRetrieve = jest.fn();
@@ -88,5 +88,41 @@ describe('getMonthlyRevenue', () => {
     mockAccountsRetrieve.mockRejectedValueOnce(new Error('stripe down'));
     const result = await getMonthlyRevenue('acct_x', new Date(2026, 3, 15));
     expect(result).toEqual({ monthlyRevenue: 0, revenueGrowth: 0 });
+  });
+});
+
+describe('getRevenueChart6Months', () => {
+  beforeEach(() => {
+    mockChargesList.mockReset();
+    mockAccountsRetrieve.mockReset();
+  });
+
+  it('returns 6 zero points when stripeAccountId is null', async () => {
+    const result = await getRevenueChart6Months(null, new Date(2026, 3, 15));
+    expect(result).toHaveLength(6);
+    expect(result.every((p) => p.revenue === 0)).toBe(true);
+    expect(result[result.length - 1].month).toBe('2026-04');
+    expect(result[0].month).toBe('2025-11');
+  });
+
+  it('queries Stripe per month and sums succeeded charges', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: true });
+    for (let i = 0; i < 6; i++) {
+      mockChargesList.mockResolvedValueOnce({
+        data: [{ status: 'succeeded', amount: (i + 1) * 1000 }],
+      });
+    }
+    const result = await getRevenueChart6Months('acct_x', new Date(2026, 3, 15));
+    expect(result.map((p) => p.revenue)).toEqual([10, 20, 30, 40, 50, 60]);
+    expect(result.map((p) => p.month)).toEqual([
+      '2025-11', '2025-12', '2026-01', '2026-02', '2026-03', '2026-04',
+    ]);
+  });
+
+  it('returns zero points when account is not charges_enabled', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: false });
+    const result = await getRevenueChart6Months('acct_x', new Date(2026, 3, 15));
+    expect(result.every((p) => p.revenue === 0)).toBe(true);
+    expect(mockChargesList).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/admin-dashboard/stats.test.ts
+++ b/__tests__/lib/admin-dashboard/stats.test.ts
@@ -1,4 +1,4 @@
-import { getCalendarMonthRange, computeMoMGrowth, getMonthlyRevenue, getRevenueChart6Months } from '@/lib/admin-dashboard/stats';
+import { getCalendarMonthRange, computeMoMGrowth, getMonthlyRevenue, getRevenueChart6Months, buildMemberGrowthSeries } from '@/lib/admin-dashboard/stats';
 
 const mockChargesList = jest.fn();
 const mockAccountsRetrieve = jest.fn();
@@ -124,5 +124,61 @@ describe('getRevenueChart6Months', () => {
     const result = await getRevenueChart6Months('acct_x', new Date(2026, 3, 15));
     expect(result.every((p) => p.revenue === 0)).toBe(true);
     expect(mockChargesList).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildMemberGrowthSeries', () => {
+  it('produces a 90-day series ending at currentActive', () => {
+    const now = new Date(2026, 3, 15);
+    const series = buildMemberGrowthSeries({
+      now,
+      currentActiveCount: 10,
+      joins: [],
+      cancellations: [],
+    });
+    expect(series).toHaveLength(90);
+    expect(series[series.length - 1].count).toBe(10);
+    expect(series[0].count).toBe(10);
+  });
+
+  it('walks back: a join 30 days ago means the count was 1 lower before that day', () => {
+    const now = new Date(2026, 3, 15);
+    const joinedAt = new Date(2026, 2, 16);
+    const series = buildMemberGrowthSeries({
+      now,
+      currentActiveCount: 5,
+      joins: [{ at: joinedAt }],
+      cancellations: [],
+    });
+    expect(series[series.length - 1].count).toBe(5);
+    expect(series[series.length - 30].count).toBe(5);
+    expect(series[series.length - 31].count).toBe(4);
+    expect(series[0].count).toBe(4);
+  });
+
+  it('walks back: a cancellation 10 days ago means the count was 1 higher before that day', () => {
+    const now = new Date(2026, 3, 15);
+    const cancelledAt = new Date(2026, 3, 5);
+    const series = buildMemberGrowthSeries({
+      now,
+      currentActiveCount: 7,
+      joins: [],
+      cancellations: [{ at: cancelledAt }],
+    });
+    expect(series[series.length - 1].count).toBe(7);
+    expect(series[series.length - 10].count).toBe(7);
+    expect(series[series.length - 11].count).toBe(8);
+  });
+
+  it('clamps at 0 (never returns negative counts)', () => {
+    const now = new Date(2026, 3, 15);
+    const cancelledAt = new Date(2026, 3, 5);
+    const series = buildMemberGrowthSeries({
+      now,
+      currentActiveCount: 0,
+      joins: [],
+      cancellations: [{ at: cancelledAt }],
+    });
+    expect(series.every((p) => p.count >= 0)).toBe(true);
   });
 });

--- a/app/[communitySlug]/admin/page.tsx
+++ b/app/[communitySlug]/admin/page.tsx
@@ -146,7 +146,7 @@ export default async function AdminDashboardPage({
         p.avatar_url,
         cm.joined_at
       FROM community_members cm
-      LEFT JOIN profiles p ON cm.user_id = p.id
+      LEFT JOIN profiles p ON cm.user_id = p.auth_user_id
       WHERE cm.community_id = ${community.id}
         AND cm.user_id != ${community.created_by}
       ORDER BY cm.joined_at DESC
@@ -159,7 +159,7 @@ export default async function AdminDashboardPage({
         p.avatar_url,
         cm.cancelled_at
       FROM community_members cm
-      LEFT JOIN profiles p ON cm.user_id = p.id
+      LEFT JOIN profiles p ON cm.user_id = p.auth_user_id
       WHERE cm.community_id = ${community.id}
         AND cm.user_id != ${community.created_by}
         AND cm.status IN ('inactive','cancelled')

--- a/app/[communitySlug]/admin/page.tsx
+++ b/app/[communitySlug]/admin/page.tsx
@@ -140,21 +140,31 @@ export default async function AdminDashboardPage({
         AND cancelled_at >= ${ninetyDaysAgo.toISOString()}
     `,
     query<JoinEvent>`
-      SELECT user_id, formatted_display_name AS display_name, avatar_url, joined_at
-      FROM community_members_with_profiles
-      WHERE community_id = ${community.id}
-        AND user_id != ${community.created_by}
-      ORDER BY joined_at DESC
+      SELECT
+        cm.user_id,
+        COALESCE(p.display_name, p.full_name, 'Anonymous') AS display_name,
+        p.avatar_url,
+        cm.joined_at
+      FROM community_members cm
+      LEFT JOIN profiles p ON cm.user_id = p.id
+      WHERE cm.community_id = ${community.id}
+        AND cm.user_id != ${community.created_by}
+      ORDER BY cm.joined_at DESC
       LIMIT 10
     `,
     query<CancelEvent>`
-      SELECT user_id, formatted_display_name AS display_name, avatar_url, cancelled_at
-      FROM community_members_with_profiles
-      WHERE community_id = ${community.id}
-        AND user_id != ${community.created_by}
-        AND status IN ('inactive','cancelled')
-        AND cancelled_at IS NOT NULL
-      ORDER BY cancelled_at DESC
+      SELECT
+        cm.user_id,
+        COALESCE(p.display_name, p.full_name, 'Anonymous') AS display_name,
+        p.avatar_url,
+        cm.cancelled_at
+      FROM community_members cm
+      LEFT JOIN profiles p ON cm.user_id = p.id
+      WHERE cm.community_id = ${community.id}
+        AND cm.user_id != ${community.created_by}
+        AND cm.status IN ('inactive','cancelled')
+        AND cm.cancelled_at IS NOT NULL
+      ORDER BY cm.cancelled_at DESC
       LIMIT 10
     `,
     query<PostEvent>`

--- a/app/[communitySlug]/admin/page.tsx
+++ b/app/[communitySlug]/admin/page.tsx
@@ -25,7 +25,7 @@ type CommunityRow = {
   stripe_account_id: string | null;
 };
 
-type MembersCounts = { total: number; paying: number };
+type MembersCounts = { total: number };
 type CountRow = { count: number };
 type JoinEvent = { user_id: string; display_name: string | null; avatar_url: string | null; joined_at: Date };
 type CancelEvent = { user_id: string; display_name: string | null; avatar_url: string | null; cancelled_at: Date };
@@ -66,9 +66,7 @@ export default async function AdminDashboardPage({
     failedPayments,
   ] = await Promise.all([
     queryOne<MembersCounts>`
-      SELECT
-        COUNT(*) FILTER (WHERE status='active')::int AS total,
-        COUNT(*) FILTER (WHERE status='active' AND stripe_subscription_id IS NOT NULL)::int AS paying
+      SELECT COUNT(*) FILTER (WHERE status='active')::int AS total
       FROM community_members
       WHERE community_id = ${community.id}
         AND user_id != ${community.created_by}
@@ -178,7 +176,6 @@ export default async function AdminDashboardPage({
   ]);
 
   const membersTotal = membersCountsRow?.total ?? 0;
-  const membersPaying = membersCountsRow?.paying ?? 0;
   const newMembersThisMonth = newMembersThisMonthRow?.count ?? 0;
   const newMembersLastMonth = newMembersLastMonthRow?.count ?? 0;
   const cancellationsThisMonth = cancellationsThisMonthRow?.count ?? 0;
@@ -191,7 +188,6 @@ export default async function AdminDashboardPage({
     monthlyRevenue: revenue.monthlyRevenue,
     revenueGrowth: revenue.revenueGrowth,
     membersTotal,
-    membersPaying,
     newMembersThisMonth,
     newMembersGrowth: computeMoMGrowth(newMembersThisMonth, newMembersLastMonth),
     cancellationsThisMonth,

--- a/app/[communitySlug]/admin/page.tsx
+++ b/app/[communitySlug]/admin/page.tsx
@@ -1,72 +1,240 @@
-import { queryOne } from '@/lib/db';
+import { queryOne, query } from '@/lib/db';
+import {
+  getCalendarMonthRange,
+  getMonthlyRevenue,
+  getRevenueChart6Months,
+  buildMemberGrowthSeries,
+  computeMoMGrowth,
+} from '@/lib/admin-dashboard/stats';
+import {
+  mergeActivityEvents,
+  getRecentFailedPayments,
+} from '@/lib/admin-dashboard/activity-feed';
+import type { ActivityEvent } from '@/lib/admin-dashboard/types';
 import { DashboardKpis } from '@/components/admin/DashboardKpis';
+import { DashboardChart } from '@/components/admin/DashboardChart';
+import { DashboardActivityFeed } from '@/components/admin/DashboardActivityFeed';
 
 export const dynamic = 'force-dynamic';
 export const fetchCache = 'force-no-store';
+
+type CommunityRow = {
+  id: string;
+  created_by: string;
+  membership_enabled: boolean;
+  stripe_account_id: string | null;
+};
+
+type MembersCounts = { total: number; paying: number };
+type CountRow = { count: number };
+type JoinEvent = { user_id: string; display_name: string | null; avatar_url: string | null; joined_at: Date };
+type CancelEvent = { user_id: string; display_name: string | null; avatar_url: string | null; updated_at: Date };
+type PostEvent = { id: string; user_id: string; author_name: string | null; author_image: string | null; category_name: string | null; created_at: Date };
 
 export default async function AdminDashboardPage({
   params,
 }: {
   params: { communitySlug: string };
 }) {
-  const community = await queryOne<{ id: string; created_by: string }>`
-    SELECT id, created_by FROM communities WHERE slug = ${params.communitySlug}
+  const community = await queryOne<CommunityRow>`
+    SELECT id, created_by, membership_enabled, stripe_account_id
+    FROM communities
+    WHERE slug = ${params.communitySlug}
   `;
   if (!community) return null;
 
-  const thirtyDaysAgo = new Date();
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-  const thirtyDaysAgoIso = thirtyDaysAgo.toISOString();
+  const now = new Date();
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+  const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
 
-  const [totalMembersResult, newMembersResult, activeMembersResult, threadsResult] =
-    await Promise.all([
-      queryOne<{ count: number }>`
-        SELECT COUNT(*)::int AS count
-        FROM community_members
-        WHERE community_id = ${community.id}
-          AND user_id != ${community.created_by}
-      `,
-      queryOne<{ count: number }>`
-        SELECT COUNT(*)::int AS count
-        FROM community_members
-        WHERE community_id = ${community.id}
-          AND status = 'active'
-          AND joined_at >= ${thirtyDaysAgoIso}
-      `,
-      queryOne<{ count: number }>`
-        SELECT COUNT(*)::int AS count
-        FROM community_members
-        WHERE community_id = ${community.id}
-          AND status = 'active'
-      `,
-      queryOne<{ count: number }>`
-        SELECT COUNT(*)::int AS count
-        FROM threads
-        WHERE community_id = ${community.id}
-      `,
-    ]);
+  const [
+    membersCountsRow,
+    newMembersThisMonthRow,
+    newMembersLastMonthRow,
+    cancellationsThisMonthRow,
+    cancellationsLastMonthRow,
+    threadsRow,
+    commentsRow,
+    revenue,
+    revenueChart,
+    joinsLast90,
+    cancelsLast90,
+    recentJoinEvents,
+    recentCancelEvents,
+    recentPostEvents,
+    failedPayments,
+  ] = await Promise.all([
+    queryOne<MembersCounts>`
+      SELECT
+        COUNT(*) FILTER (WHERE status='active')::int AS total,
+        COUNT(*) FILTER (WHERE status='active' AND stripe_subscription_id IS NOT NULL)::int AS paying
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND joined_at >= ${thisMonth.start.toISOString()}
+        AND joined_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND joined_at >= ${lastMonth.start.toISOString()}
+        AND joined_at < ${lastMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+        AND updated_at >= ${thisMonth.start.toISOString()}
+        AND updated_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+        AND updated_at >= ${lastMonth.start.toISOString()}
+        AND updated_at < ${lastMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM threads
+      WHERE community_id = ${community.id}
+        AND created_at >= ${thisMonth.start.toISOString()}
+        AND created_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM comments c
+      JOIN threads t ON c.thread_id = t.id
+      WHERE t.community_id = ${community.id}
+        AND c.created_at >= ${thisMonth.start.toISOString()}
+        AND c.created_at < ${thisMonth.end.toISOString()}
+    `,
+    getMonthlyRevenue(community.stripe_account_id, now),
+    getRevenueChart6Months(community.stripe_account_id, now),
+    query<{ joined_at: Date }>`
+      SELECT joined_at
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND joined_at >= ${ninetyDaysAgo.toISOString()}
+    `,
+    query<{ updated_at: Date }>`
+      SELECT updated_at
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+        AND updated_at >= ${ninetyDaysAgo.toISOString()}
+    `,
+    query<JoinEvent>`
+      SELECT user_id, formatted_display_name AS display_name, avatar_url, joined_at
+      FROM community_members_with_profiles
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+      ORDER BY joined_at DESC
+      LIMIT 10
+    `,
+    query<CancelEvent>`
+      SELECT user_id, formatted_display_name AS display_name, avatar_url, updated_at
+      FROM community_members_with_profiles
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+      ORDER BY updated_at DESC
+      LIMIT 10
+    `,
+    query<PostEvent>`
+      SELECT id, user_id, author_name, author_image, category_name, created_at
+      FROM threads
+      WHERE community_id = ${community.id}
+      ORDER BY created_at DESC
+      LIMIT 10
+    `,
+    getRecentFailedPayments(community.stripe_account_id, now),
+  ]);
+
+  const membersTotal = membersCountsRow?.total ?? 0;
+  const membersPaying = membersCountsRow?.paying ?? 0;
+  const newMembersThisMonth = newMembersThisMonthRow?.count ?? 0;
+  const newMembersLastMonth = newMembersLastMonthRow?.count ?? 0;
+  const cancellationsThisMonth = cancellationsThisMonthRow?.count ?? 0;
+  const cancellationsLastMonth = cancellationsLastMonthRow?.count ?? 0;
+  const threadsThisMonth = threadsRow?.count ?? 0;
+  const commentsThisMonth = commentsRow?.count ?? 0;
 
   const stats = {
-    totalMembers: totalMembersResult?.count ?? 0,
-    activeMembers: activeMembersResult?.count ?? 0,
-    totalThreads: threadsResult?.count ?? 0,
-    newMembersThisMonth: newMembersResult?.count ?? 0,
-    // TODO: plumb live Stripe data for Monthly Revenue + MoM growth.
-    // The old modal's `/api/community/[slug]/stats` returns 0 for both too — the
-    // Stripe aggregation isn't wired up yet. Tracked as follow-up after this refactor.
-    monthlyRevenue: 0,
-    revenueGrowth: 0,
+    isPaid: community.membership_enabled,
+    monthlyRevenue: revenue.monthlyRevenue,
+    revenueGrowth: revenue.revenueGrowth,
+    membersTotal,
+    membersPaying,
+    newMembersThisMonth,
+    newMembersGrowth: computeMoMGrowth(newMembersThisMonth, newMembersLastMonth),
+    cancellationsThisMonth,
+    cancellationsLastMonth,
+    postsThreadsThisMonth: threadsThisMonth,
+    postsCommentsThisMonth: commentsThisMonth,
   };
 
+  const growth = buildMemberGrowthSeries({
+    now,
+    currentActiveCount: membersTotal,
+    joins: joinsLast90.map((r) => ({ at: new Date(r.joined_at) })),
+    cancellations: cancelsLast90.map((r) => ({ at: new Date(r.updated_at) })),
+  });
+
+  const joins: ActivityEvent[] = recentJoinEvents.map((r) => ({
+    type: 'join',
+    at: new Date(r.joined_at),
+    userId: r.user_id,
+    displayName: r.display_name ?? 'Anonymous',
+    avatarUrl: r.avatar_url,
+  }));
+  const cancels: ActivityEvent[] = recentCancelEvents.map((r) => ({
+    type: 'cancel',
+    at: new Date(r.updated_at),
+    userId: r.user_id,
+    displayName: r.display_name ?? 'Anonymous',
+    avatarUrl: r.avatar_url,
+  }));
+  const posts: ActivityEvent[] = recentPostEvents.map((r) => ({
+    type: 'post',
+    at: new Date(r.created_at),
+    userId: r.user_id,
+    displayName: r.author_name ?? 'Anonymous',
+    avatarUrl: r.author_image,
+    threadId: r.id,
+    categoryName: r.category_name,
+  }));
+
+  const events = mergeActivityEvents([joins, cancels, posts, failedPayments], 10);
+
   return (
-    <div className="animate-in fade-in slide-in-from-bottom-1 duration-500">
-      <header className="mb-10">
+    <div className="animate-in fade-in slide-in-from-bottom-1 duration-500 space-y-8">
+      <header>
         <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground">
           Dashboard
         </h1>
       </header>
 
       <DashboardKpis stats={stats} />
+
+      <DashboardChart isPaid={stats.isPaid} revenue={revenueChart} growth={growth} />
+
+      <DashboardActivityFeed events={events} communitySlug={params.communitySlug} />
     </div>
   );
 }

--- a/app/[communitySlug]/admin/page.tsx
+++ b/app/[communitySlug]/admin/page.tsx
@@ -28,7 +28,7 @@ type CommunityRow = {
 type MembersCounts = { total: number; paying: number };
 type CountRow = { count: number };
 type JoinEvent = { user_id: string; display_name: string | null; avatar_url: string | null; joined_at: Date };
-type CancelEvent = { user_id: string; display_name: string | null; avatar_url: string | null; updated_at: Date };
+type CancelEvent = { user_id: string; display_name: string | null; avatar_url: string | null; cancelled_at: Date };
 type PostEvent = { id: string; user_id: string; author_name: string | null; author_image: string | null; category_name: string | null; created_at: Date };
 
 export default async function AdminDashboardPage({
@@ -95,8 +95,8 @@ export default async function AdminDashboardPage({
       WHERE community_id = ${community.id}
         AND user_id != ${community.created_by}
         AND status IN ('inactive','cancelled')
-        AND updated_at >= ${thisMonth.start.toISOString()}
-        AND updated_at < ${thisMonth.end.toISOString()}
+        AND cancelled_at >= ${thisMonth.start.toISOString()}
+        AND cancelled_at < ${thisMonth.end.toISOString()}
     `,
     queryOne<CountRow>`
       SELECT COUNT(*)::int AS count
@@ -104,8 +104,8 @@ export default async function AdminDashboardPage({
       WHERE community_id = ${community.id}
         AND user_id != ${community.created_by}
         AND status IN ('inactive','cancelled')
-        AND updated_at >= ${lastMonth.start.toISOString()}
-        AND updated_at < ${lastMonth.end.toISOString()}
+        AND cancelled_at >= ${lastMonth.start.toISOString()}
+        AND cancelled_at < ${lastMonth.end.toISOString()}
     `,
     queryOne<CountRow>`
       SELECT COUNT(*)::int AS count
@@ -131,13 +131,13 @@ export default async function AdminDashboardPage({
         AND user_id != ${community.created_by}
         AND joined_at >= ${ninetyDaysAgo.toISOString()}
     `,
-    query<{ updated_at: Date }>`
-      SELECT updated_at
+    query<{ cancelled_at: Date }>`
+      SELECT cancelled_at
       FROM community_members
       WHERE community_id = ${community.id}
         AND user_id != ${community.created_by}
         AND status IN ('inactive','cancelled')
-        AND updated_at >= ${ninetyDaysAgo.toISOString()}
+        AND cancelled_at >= ${ninetyDaysAgo.toISOString()}
     `,
     query<JoinEvent>`
       SELECT user_id, formatted_display_name AS display_name, avatar_url, joined_at
@@ -148,12 +148,13 @@ export default async function AdminDashboardPage({
       LIMIT 10
     `,
     query<CancelEvent>`
-      SELECT user_id, formatted_display_name AS display_name, avatar_url, updated_at
+      SELECT user_id, formatted_display_name AS display_name, avatar_url, cancelled_at
       FROM community_members_with_profiles
       WHERE community_id = ${community.id}
         AND user_id != ${community.created_by}
         AND status IN ('inactive','cancelled')
-      ORDER BY updated_at DESC
+        AND cancelled_at IS NOT NULL
+      ORDER BY cancelled_at DESC
       LIMIT 10
     `,
     query<PostEvent>`
@@ -193,7 +194,7 @@ export default async function AdminDashboardPage({
     now,
     currentActiveCount: membersTotal,
     joins: joinsLast90.map((r) => ({ at: new Date(r.joined_at) })),
-    cancellations: cancelsLast90.map((r) => ({ at: new Date(r.updated_at) })),
+    cancellations: cancelsLast90.map((r) => ({ at: new Date(r.cancelled_at) })),
   });
 
   const joins: ActivityEvent[] = recentJoinEvents.map((r) => ({
@@ -205,7 +206,7 @@ export default async function AdminDashboardPage({
   }));
   const cancels: ActivityEvent[] = recentCancelEvents.map((r) => ({
     type: 'cancel',
-    at: new Date(r.updated_at),
+    at: new Date(r.cancelled_at),
     userId: r.user_id,
     displayName: r.display_name ?? 'Anonymous',
     avatarUrl: r.avatar_url,

--- a/app/api/cron/process-community-openings/route.ts
+++ b/app/api/cron/process-community-openings/route.ts
@@ -106,7 +106,8 @@ export async function GET(request: NextRequest) {
               // Update member to inactive
               await sql`
                 UPDATE community_members
-                SET status = 'inactive'
+                SET status = 'inactive',
+                    cancelled_at = NOW()
                 WHERE id = ${member.id}
               `;
 

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -798,7 +798,8 @@ export async function POST(request: Request) {
             await sql`
               UPDATE community_members
               SET
-                status = 'inactive'
+                status = 'inactive',
+                cancelled_at = NOW()
               WHERE community_id = ${subscription.metadata.community_id}
                 AND user_id = ${subscription.metadata.user_id}
             `;

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,7 @@
         "react-hook-form": "^7.53.1",
         "react-hot-toast": "^2.4.1",
         "react-icons": "^5.3.0",
+        "recharts": "^3.8.1",
         "resend": "^6.0.1",
         "sharp": "^0.34.5",
         "stripe": "17.5.0",
@@ -649,6 +650,8 @@
 
     "@react-types/shared": ["@react-types/shared@3.32.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-famxyD5emrGGpFuUlgOP6fVW2h/ZaF405G5KDi3zPHzyjAWys/8W6NAVJtNbkCkhedmvL0xOhvt8feGXyXaw5w=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
@@ -769,6 +772,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@stripe/react-stripe-js": ["@stripe/react-stripe-js@2.9.0", "", { "dependencies": { "prop-types": "^15.7.2" }, "peerDependencies": { "@stripe/stripe-js": "^1.44.1 || ^2.0.0 || ^3.0.0 || ^4.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-+/j2g6qKAKuWSurhgRMfdlIdKM+nVVJCy/wl0US2Ccodlqx0WqfIIBhUkeONkCG+V/b+bZzcj4QVa3E/rXtT4Q=="],
 
     "@stripe/stripe-js": ["@stripe/stripe-js@4.10.0", "", {}, "sha512-KrMOL+sH69htCIXCaZ4JluJ35bchuCCznyPyrbN8JXSGQfwBI1SuIEMZNwvy8L8ykj29t6sa5BAAiL7fNoLZ8A=="],
@@ -886,6 +891,24 @@
     "@types/canvas-confetti": ["@types/canvas-confetti@1.9.0", "", {}, "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg=="],
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
 
     "@types/dom-mediacapture-record": ["@types/dom-mediacapture-record@1.0.22", "", {}, "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw=="],
 
@@ -1179,6 +1202,28 @@
 
     "custom-media-element": ["custom-media-element@1.4.5", "", {}, "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
@@ -1196,6 +1241,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "dedent": ["dedent@1.7.1", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg=="],
 
@@ -1275,6 +1322,8 @@
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
 
+    "es-toolkit": ["es-toolkit@1.46.0", "", {}, "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
@@ -1318,6 +1367,8 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -1459,6 +1510,8 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
@@ -1472,6 +1525,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -1943,6 +1998,8 @@
 
     "react-promise-suspense": ["react-promise-suspense@0.3.4", "", { "dependencies": { "fast-deep-equal": "^2.0.1" } }, "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -1953,13 +2010,21 @@
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resend": ["resend@6.7.0", "", { "dependencies": { "svix": "1.84.1" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-2ZV0NDZsh4Gh+Nd1hvluZIitmGJ59O4+OxMufymG6Y8uz1Jgt2uS1seSENnkIUlmwg7/dwmfIJC9rAufByz7wA=="],
 
@@ -2117,6 +2182,8 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tippy.js": ["tippy.js@6.3.7", "", { "dependencies": { "@popperjs/core": "^2.9.0" } }, "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ=="],
@@ -2194,6 +2261,8 @@
     "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
@@ -2346,6 +2415,8 @@
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@supabase/realtime-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -12,11 +12,12 @@ export function AdminNav({
 }) {
   const pathname = usePathname();
   const items = [
-    { href: `/${communitySlug}/admin/general`, label: 'General' },
-    { href: `/${communitySlug}/admin/members`, label: 'Members' },
-    { href: `/${communitySlug}/admin/subscriptions`, label: 'Subscriptions' },
-    { href: `/${communitySlug}/admin/thread-categories`, label: 'Thread Categories' },
-    { href: `/${communitySlug}/admin/emails`, label: 'Broadcasts' },
+    { href: `/${communitySlug}/admin`,                   label: 'Dashboard',         exact: true  },
+    { href: `/${communitySlug}/admin/general`,           label: 'General',           exact: false },
+    { href: `/${communitySlug}/admin/members`,           label: 'Members',           exact: false },
+    { href: `/${communitySlug}/admin/subscriptions`,     label: 'Subscriptions',     exact: false },
+    { href: `/${communitySlug}/admin/thread-categories`, label: 'Thread Categories', exact: false },
+    { href: `/${communitySlug}/admin/emails`,            label: 'Broadcasts',        exact: false },
   ];
 
   return (
@@ -26,7 +27,7 @@ export function AdminNav({
       </p>
       <ul className="flex md:flex-col gap-0.5 overflow-x-auto scrollbar-hide md:overflow-visible -mx-1 px-1 pb-1 md:pb-0 md:mx-0 md:px-0">
         {items.map((item) => {
-          const active = pathname.startsWith(item.href);
+          const active = item.exact ? pathname === item.href : pathname.startsWith(item.href);
           return (
             <li key={item.href} className="shrink-0 md:shrink">
               <Link

--- a/components/admin/DashboardActivityFeed.tsx
+++ b/components/admin/DashboardActivityFeed.tsx
@@ -1,0 +1,87 @@
+import { formatDistanceToNow } from 'date-fns';
+import Link from 'next/link';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { UserPlus, UserMinus, MessageSquare, AlertTriangle } from 'lucide-react';
+import type { ActivityEvent } from '@/lib/admin-dashboard/types';
+
+export function DashboardActivityFeed({
+  events,
+  communitySlug,
+}: {
+  events: ActivityEvent[];
+  communitySlug: string;
+}) {
+  if (events.length === 0) {
+    return (
+      <div className="bg-card rounded-2xl border border-border/50 p-6">
+        <h2 className="font-display text-lg font-semibold mb-4">Recent activity</h2>
+        <p className="text-sm text-muted-foreground text-center py-8">No recent activity yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-2xl border border-border/50 p-6">
+      <h2 className="font-display text-lg font-semibold mb-4">Recent activity</h2>
+      <ul className="space-y-3">
+        {events.map((e, i) => (
+          <ActivityRow key={`${e.type}-${e.at.getTime()}-${i}`} event={e} communitySlug={communitySlug} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ActivityRow({ event, communitySlug }: { event: ActivityEvent; communitySlug: string }) {
+  if (event.type === 'failed_payment') {
+    return (
+      <li className="flex items-start gap-3 p-3 rounded-xl bg-amber-50/40 border border-amber-200/40">
+        <div className="h-9 w-9 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+          <AlertTriangle className="h-4 w-4 text-amber-700" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm">
+            <span className="font-medium">{event.displayName}</span>'s payment of €{event.amount.toFixed(2)} failed
+          </p>
+          <p className="text-xs text-muted-foreground">{formatDistanceToNow(event.at, { addSuffix: true })}</p>
+        </div>
+        <Link
+          href={`/${communitySlug}/admin/members`}
+          className="text-xs font-medium text-primary hover:underline self-center"
+        >
+          Resolve
+        </Link>
+      </li>
+    );
+  }
+
+  const icon =
+    event.type === 'join' ? <UserPlus className="h-4 w-4 text-primary" /> :
+    event.type === 'cancel' ? <UserMinus className="h-4 w-4 text-muted-foreground" /> :
+    <MessageSquare className="h-4 w-4 text-primary" />;
+
+  const verb =
+    event.type === 'join' ? 'joined' :
+    event.type === 'cancel' ? 'cancelled' :
+    `posted${event.type === 'post' && event.categoryName ? ` in ${event.categoryName}` : ''}`;
+
+  return (
+    <li className="flex items-start gap-3">
+      <Avatar className="h-9 w-9 flex-shrink-0">
+        {event.avatarUrl ? <AvatarImage src={event.avatarUrl} alt={event.displayName} /> : null}
+        <AvatarFallback className="bg-primary/10 text-primary text-xs">
+          {event.displayName[0]?.toUpperCase() ?? '?'}
+        </AvatarFallback>
+      </Avatar>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm">
+          <span className="font-medium">{event.displayName}</span> {verb}
+        </p>
+        <p className="text-xs text-muted-foreground">{formatDistanceToNow(event.at, { addSuffix: true })}</p>
+      </div>
+      <div className="hidden sm:flex h-9 w-9 rounded-full bg-muted/50 items-center justify-center flex-shrink-0">
+        {icon}
+      </div>
+    </li>
+  );
+}

--- a/components/admin/DashboardChart.tsx
+++ b/components/admin/DashboardChart.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+import type { RevenuePoint, GrowthPoint } from '@/lib/admin-dashboard/types';
+
+export function DashboardChart({
+  isPaid,
+  revenue,
+  growth,
+}: {
+  isPaid: boolean;
+  revenue: RevenuePoint[];
+  growth: GrowthPoint[];
+}) {
+  const hasGrowthData = growth.some((p) => p.count > 0);
+  const hasRevenueData = revenue.some((p) => p.revenue > 0);
+
+  if (!isPaid) {
+    return (
+      <div className="bg-card rounded-2xl border border-border/50 p-6">
+        <h2 className="font-display text-lg font-semibold mb-4">Member growth (last 90 days)</h2>
+        {hasGrowthData ? <GrowthChart data={growth} /> : <EmptyState />}
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-2xl border border-border/50 p-6">
+      <Tabs defaultValue="revenue">
+        <TabsList className="mb-4">
+          <TabsTrigger value="revenue">Revenue</TabsTrigger>
+          <TabsTrigger value="members">Members</TabsTrigger>
+        </TabsList>
+        <TabsContent value="revenue">
+          {hasRevenueData ? <RevenueChart data={revenue} /> : <EmptyState />}
+        </TabsContent>
+        <TabsContent value="members">
+          {hasGrowthData ? <GrowthChart data={growth} /> : <EmptyState />}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function RevenueChart({ data }: { data: RevenuePoint[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-border/40" />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} className="text-xs" />
+        <YAxis tickLine={false} axisLine={false} className="text-xs" tickFormatter={(v) => `€${v}`} />
+        <Tooltip
+          formatter={(v) => [`€${Number(v).toFixed(2)}`, 'Revenue'] as [string, string]}
+        />
+        <Bar dataKey="revenue" radius={[6, 6, 0, 0]} className="fill-primary" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function GrowthChart({ data }: { data: GrowthPoint[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <LineChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-border/40" />
+        <XAxis dataKey="date" tickLine={false} axisLine={false} className="text-xs" interval={14} />
+        <YAxis tickLine={false} axisLine={false} className="text-xs" allowDecimals={false} />
+        <Tooltip />
+        <Line type="monotone" dataKey="count" strokeWidth={2} dot={false} className="stroke-primary" />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="h-[240px] flex items-center justify-center text-sm text-muted-foreground">
+      Not enough data yet
+    </div>
+  );
+}

--- a/components/admin/DashboardKpis.tsx
+++ b/components/admin/DashboardKpis.tsx
@@ -1,80 +1,132 @@
-import { Users, TrendingUp, DollarSign, MessageSquare, BarChart3 } from 'lucide-react';
+import { Users, TrendingUp, TrendingDown, DollarSign, MessageSquare, UserMinus } from 'lucide-react';
 
-interface DashboardKpisProps {
-  stats: {
-    totalMembers: number;
-    activeMembers: number;
-    totalThreads: number;
-    monthlyRevenue: number;
-    newMembersThisMonth: number;
-    revenueGrowth: number;
-  };
+export interface DashboardStats {
+  isPaid: boolean;
+  monthlyRevenue: number;
+  revenueGrowth: number;
+  membersTotal: number;
+  membersPaying: number;
+  newMembersThisMonth: number;
+  newMembersGrowth: number;
+  cancellationsThisMonth: number;
+  cancellationsLastMonth: number;
+  postsThreadsThisMonth: number;
+  postsCommentsThisMonth: number;
 }
 
-export function DashboardKpis({ stats }: DashboardKpisProps) {
+export function DashboardKpis({ stats }: { stats: DashboardStats }) {
+  const tiles: React.ReactNode[] = [];
+
+  if (stats.isPaid) {
+    tiles.push(
+      <Tile
+        key="revenue"
+        label="Revenue this month"
+        value={`€${stats.monthlyRevenue.toFixed(2)}`}
+        sublineNumber={stats.revenueGrowth}
+        sublineSuffix="vs last month"
+        icon={<DollarSign className="h-5 w-5 text-secondary" />}
+        iconBg="bg-secondary/20"
+      />
+    );
+  }
+
+  tiles.push(
+    <Tile
+      key="members"
+      label="Members"
+      value={stats.membersTotal.toString()}
+      sublineText={stats.isPaid ? `${stats.membersPaying} paying` : undefined}
+      icon={<Users className="h-5 w-5 text-primary" />}
+      iconBg="bg-primary/10"
+    />
+  );
+
+  tiles.push(
+    <Tile
+      key="new"
+      label="New members this month"
+      value={stats.newMembersThisMonth.toString()}
+      sublineNumber={stats.newMembersGrowth}
+      sublineSuffix="vs last month"
+      icon={<TrendingUp className="h-5 w-5 text-primary" />}
+      iconBg="bg-primary/10"
+    />
+  );
+
+  if (stats.isPaid) {
+    tiles.push(
+      <Tile
+        key="cancellations"
+        label="Cancellations this month"
+        value={stats.cancellationsThisMonth.toString()}
+        sublineText={`${stats.cancellationsLastMonth} last month`}
+        icon={<UserMinus className="h-5 w-5 text-secondary" />}
+        iconBg="bg-secondary/20"
+      />
+    );
+  }
+
+  tiles.push(
+    <Tile
+      key="posts"
+      label="Posts this month"
+      value={`${stats.postsThreadsThisMonth} threads`}
+      sublineText={`${stats.postsCommentsThisMonth} replies`}
+      icon={<MessageSquare className="h-5 w-5 text-accent" />}
+      iconBg="bg-accent/20"
+    />
+  );
+
   return (
-    <div className="space-y-6">
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="bg-card rounded-2xl p-6 border-2 border-transparent hover:border-primary/20 hover:shadow-lg transition-all duration-300 ease-out space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-muted-foreground">Total Members</h3>
-            <div className="h-10 w-10 rounded-xl bg-primary/10 flex items-center justify-center">
-              <Users className="h-5 w-5 text-primary" />
-            </div>
-          </div>
-          <p className="font-display text-3xl font-bold text-foreground">
-            {stats.totalMembers}
-          </p>
-          <p className="text-sm text-primary font-medium">
-            <TrendingUp className="h-4 w-4 inline mr-1" />+
-            {stats.newMembersThisMonth} this month
-          </p>
-        </div>
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {tiles}
+    </div>
+  );
+}
 
-        <div className="bg-card rounded-2xl p-6 border-2 border-transparent hover:border-primary/20 hover:shadow-lg transition-all duration-300 ease-out space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-muted-foreground">Monthly Revenue</h3>
-            <div className="h-10 w-10 rounded-xl bg-secondary/20 flex items-center justify-center">
-              <DollarSign className="h-5 w-5 text-secondary" />
-            </div>
-          </div>
-          <p className="font-display text-3xl font-bold text-foreground">
-            €{stats.monthlyRevenue.toFixed(2)}
-          </p>
-          <p className="text-sm text-primary font-medium">
-            <TrendingUp className="h-4 w-4 inline mr-1" />
-            {stats.revenueGrowth >= 0 ? '+' : ''}
-            {stats.revenueGrowth}% this month
-          </p>
-        </div>
+function Tile({
+  label,
+  value,
+  sublineNumber,
+  sublineSuffix,
+  sublineText,
+  icon,
+  iconBg,
+}: {
+  label: string;
+  value: string;
+  sublineNumber?: number;
+  sublineSuffix?: string;
+  sublineText?: string;
+  icon: React.ReactNode;
+  iconBg: string;
+}) {
+  const showNumber = typeof sublineNumber === 'number';
+  const isPositive = showNumber && (sublineNumber as number) >= 0;
 
-        <div className="bg-card rounded-2xl p-6 border-2 border-transparent hover:border-primary/20 hover:shadow-lg transition-all duration-300 ease-out space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-muted-foreground">Total Threads</h3>
-            <div className="h-10 w-10 rounded-xl bg-accent/20 flex items-center justify-center">
-              <MessageSquare className="h-5 w-5 text-accent" />
-            </div>
-          </div>
-          <p className="font-display text-3xl font-bold text-foreground">
-            {stats.totalThreads}
-          </p>
-          <p className="text-sm text-muted-foreground">Across all categories</p>
-        </div>
-
-        <div className="bg-card rounded-2xl p-6 border-2 border-transparent hover:border-primary/20 hover:shadow-lg transition-all duration-300 ease-out space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-muted-foreground">Active Members</h3>
-            <div className="h-10 w-10 rounded-xl bg-primary/10 flex items-center justify-center">
-              <BarChart3 className="h-5 w-5 text-primary" />
-            </div>
-          </div>
-          <p className="font-display text-3xl font-bold text-foreground">
-            {stats.activeMembers}
-          </p>
-          <p className="text-sm text-muted-foreground">Current active memberships</p>
+  return (
+    <div className="bg-card rounded-2xl p-6 border-2 border-transparent hover:border-primary/20 hover:shadow-lg transition-all duration-300 ease-out space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-muted-foreground">{label}</h3>
+        <div className={`h-10 w-10 rounded-xl ${iconBg} flex items-center justify-center`}>
+          {icon}
         </div>
       </div>
+      <p className="font-display text-3xl font-bold text-foreground">{value}</p>
+      {showNumber ? (
+        <p className={`text-sm font-medium ${isPositive ? 'text-primary' : 'text-destructive'}`}>
+          {isPositive ? (
+            <TrendingUp className="h-4 w-4 inline mr-1" />
+          ) : (
+            <TrendingDown className="h-4 w-4 inline mr-1" />
+          )}
+          {isPositive ? '+' : ''}
+          {sublineNumber}% {sublineSuffix}
+        </p>
+      ) : sublineText ? (
+        <p className="text-sm text-muted-foreground">{sublineText}</p>
+      ) : null}
     </div>
   );
 }

--- a/components/admin/DashboardKpis.tsx
+++ b/components/admin/DashboardKpis.tsx
@@ -5,7 +5,6 @@ export interface DashboardStats {
   monthlyRevenue: number;
   revenueGrowth: number;
   membersTotal: number;
-  membersPaying: number;
   newMembersThisMonth: number;
   newMembersGrowth: number;
   cancellationsThisMonth: number;
@@ -36,7 +35,6 @@ export function DashboardKpis({ stats }: { stats: DashboardStats }) {
       key="members"
       label="Members"
       value={stats.membersTotal.toString()}
-      sublineText={stats.isPaid ? `${stats.membersPaying} paying` : undefined}
       icon={<Users className="h-5 w-5 text-primary" />}
       iconBg="bg-primary/10"
     />

--- a/docs/superpowers/plans/2026-04-27-admin-dashboard-redesign.md
+++ b/docs/superpowers/plans/2026-04-27-admin-dashboard-redesign.md
@@ -1,0 +1,1785 @@
+# Admin Dashboard Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken 4-tile KPI grid at `/[communitySlug]/admin/page.tsx` with an adaptive 5-tile overview, a tabbed Recharts card (revenue 6m / member growth 90d), and a 10-event recent-activity feed. Add a Dashboard link to AdminNav.
+
+**Architecture:** Server component orchestrates data; pure helpers in `lib/admin-dashboard/` compute stats and activity events (Postgres + Stripe). Tiles and feed are server-rendered; the chart is the only client island. Adaptive to free vs paid communities via `community.membership_enabled`. Reference spec: `docs/superpowers/specs/2026-04-27-admin-dashboard-redesign-design.md`.
+
+**Tech Stack:** Next.js 14 App Router · TypeScript · Tailwind · Postgres via `@/lib/db` (`queryOne`, `query`, tagged-template SQL) · Stripe Connect via `@/lib/stripe` · Recharts (new dep) · Jest + @testing-library/react.
+
+**Working environment:** All edits + builds happen in the preprod worktree at `/home/debian/apps/dance-hub-preprod` (current branch `feat/admin-dashboard-redesign`). NEVER `bun run build` in `/home/debian/apps/dance-hub` — pm2 serves prod from there.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `package.json` | modify | Add `recharts` dependency |
+| `components/admin/AdminNav.tsx` | modify | Add Dashboard link as first item; fix active matching for the index path |
+| `lib/admin-dashboard/stats.ts` | create | Pure helpers: month range, MoM math, revenue (current + chart), member growth series |
+| `lib/admin-dashboard/activity-feed.ts` | create | Build + merge event lists (joins, cancellations, posts, failed payments) |
+| `lib/admin-dashboard/types.ts` | create | Shared types: `Tile`, `RevenuePoint`, `GrowthPoint`, `ActivityEvent` |
+| `__tests__/lib/admin-dashboard/stats.test.ts` | create | Unit tests for stats helpers |
+| `__tests__/lib/admin-dashboard/activity-feed.test.ts` | create | Unit tests for activity-feed helpers |
+| `components/admin/DashboardKpis.tsx` | rewrite | Adaptive 5-tile grid (paid) / 3-tile (free); server-renderable |
+| `components/admin/DashboardChart.tsx` | create | Client island, Recharts + Tabs (Revenue 6m / Members 90d) |
+| `components/admin/DashboardActivityFeed.tsx` | create | Server component, renders the merged event list with plain-language rows |
+| `app/[communitySlug]/admin/page.tsx` | rewrite | Orchestrate community + stats + feed in a single Promise.all; render the three sections |
+
+Out of scope (follow-up): delete dead `app/api/community/[communitySlug]/stripe-revenue/route.ts` and `app/api/community/[communitySlug]/stats/route.ts` — leaving them for a separate cleanup PR.
+
+---
+
+## Task 1: Add Recharts dependency
+
+**Files:**
+- Modify: `package.json`, `bun.lockb`
+
+- [ ] **Step 1: Install recharts**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bun add recharts
+```
+
+Expected: `package.json` adds `"recharts"` under `dependencies` (version 2.x.x); `bun.lockb` updated.
+
+- [ ] **Step 2: Verify it imports**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -i recharts
+```
+
+Expected: no output (no recharts errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add package.json bun.lockb && git commit -m "chore: add recharts for admin dashboard charts
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add Dashboard nav link
+
+**Files:**
+- Modify: `components/admin/AdminNav.tsx`
+
+The current nav doesn't include Dashboard, and active matching uses `startsWith()` — which would always match for the index path `/${slug}/admin`. We add Dashboard first and switch to exact match for that one item.
+
+- [ ] **Step 1: Update nav items + active matching**
+
+Replace the body of `AdminNav` with:
+
+```tsx
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+export function AdminNav({
+  communitySlug,
+  communityName,
+}: {
+  communitySlug: string;
+  communityName: string;
+}) {
+  const pathname = usePathname();
+  const items = [
+    { href: `/${communitySlug}/admin`,                   label: 'Dashboard',       exact: true  },
+    { href: `/${communitySlug}/admin/general`,           label: 'General',         exact: false },
+    { href: `/${communitySlug}/admin/members`,           label: 'Members',         exact: false },
+    { href: `/${communitySlug}/admin/subscriptions`,     label: 'Subscriptions',   exact: false },
+    { href: `/${communitySlug}/admin/thread-categories`, label: 'Thread Categories', exact: false },
+    { href: `/${communitySlug}/admin/emails`,            label: 'Broadcasts',      exact: false },
+  ];
+
+  return (
+    <nav className="w-full md:w-48 md:shrink-0">
+      <p className="hidden md:block text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-3 pl-1">
+        {communityName}
+      </p>
+      <ul className="flex md:flex-col gap-0.5 overflow-x-auto scrollbar-hide md:overflow-visible -mx-1 px-1 pb-1 md:pb-0 md:mx-0 md:px-0">
+        {items.map((item) => {
+          const active = item.exact ? pathname === item.href : pathname.startsWith(item.href);
+          return (
+            <li key={item.href} className="shrink-0 md:shrink">
+              <Link
+                href={item.href}
+                className={cn(
+                  'group flex items-center gap-2 pl-3 pr-3 py-2 text-sm transition-colors relative whitespace-nowrap rounded-md md:rounded-none min-h-[44px] md:min-h-0',
+                  active
+                    ? 'text-foreground font-medium bg-muted md:bg-transparent'
+                    : 'text-muted-foreground hover:text-foreground md:hover:bg-transparent'
+                )}
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    'hidden md:block absolute left-0 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full transition-all',
+                    active
+                      ? 'bg-primary opacity-100'
+                      : 'bg-primary/0 opacity-0 group-hover:opacity-40'
+                  )}
+                />
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "AdminNav|admin/page" | head -5
+```
+
+Expected: no output (file is clean).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add components/admin/AdminNav.tsx && git commit -m "feat(admin): add Dashboard link to admin nav
+
+Switch active-state matching to exact for the Dashboard root so it
+doesn't always read as active while on subpages.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Stats helpers — month range + MoM growth (TDD)
+
+**Files:**
+- Create: `lib/admin-dashboard/types.ts`
+- Create: `lib/admin-dashboard/stats.ts`
+- Create: `__tests__/lib/admin-dashboard/stats.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/lib/admin-dashboard/stats.test.ts`:
+
+```ts
+import { getCalendarMonthRange, computeMoMGrowth } from '@/lib/admin-dashboard/stats';
+
+describe('getCalendarMonthRange', () => {
+  it('returns start of current month and start of next month with offset 0', () => {
+    const now = new Date(2026, 3, 15); // April 15, 2026
+    const { start, end } = getCalendarMonthRange(now, 0);
+    expect(start).toEqual(new Date(2026, 3, 1));
+    expect(end).toEqual(new Date(2026, 4, 1));
+  });
+
+  it('returns previous month with offset -1', () => {
+    const now = new Date(2026, 3, 15);
+    const { start, end } = getCalendarMonthRange(now, -1);
+    expect(start).toEqual(new Date(2026, 2, 1));
+    expect(end).toEqual(new Date(2026, 3, 1));
+  });
+
+  it('handles year boundary (January)', () => {
+    const now = new Date(2026, 0, 15);
+    const { start, end } = getCalendarMonthRange(now, -1);
+    expect(start).toEqual(new Date(2025, 11, 1));
+    expect(end).toEqual(new Date(2026, 0, 1));
+  });
+});
+
+describe('computeMoMGrowth', () => {
+  it('returns positive % when current > previous', () => {
+    expect(computeMoMGrowth(120, 100)).toBe(20);
+  });
+  it('returns negative % when current < previous', () => {
+    expect(computeMoMGrowth(75, 100)).toBe(-25);
+  });
+  it('returns 0 when both are 0', () => {
+    expect(computeMoMGrowth(0, 0)).toBe(0);
+  });
+  it('returns 100 when previous is 0 and current is non-zero', () => {
+    expect(computeMoMGrowth(50, 0)).toBe(100);
+  });
+  it('rounds to integer', () => {
+    expect(computeMoMGrowth(10.7, 10)).toBe(7);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/stats.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — "Cannot find module '@/lib/admin-dashboard/stats'".
+
+- [ ] **Step 3: Create types file**
+
+Create `lib/admin-dashboard/types.ts`:
+
+```ts
+export type RevenuePoint = { month: string; revenue: number };
+export type GrowthPoint = { date: string; count: number };
+export type ActivityEvent =
+  | { type: 'join'; at: Date; userId: string; displayName: string; avatarUrl: string | null }
+  | { type: 'cancel'; at: Date; userId: string; displayName: string; avatarUrl: string | null }
+  | { type: 'post'; at: Date; userId: string; displayName: string; avatarUrl: string | null; threadId: string; categoryName: string | null }
+  | { type: 'failed_payment'; at: Date; userId: string | null; displayName: string; amount: number };
+```
+
+- [ ] **Step 4: Implement helpers**
+
+Create `lib/admin-dashboard/stats.ts`:
+
+```ts
+/**
+ * Calendar month range. start is inclusive (1st of month at 00:00 local),
+ * end is exclusive (1st of the *next* month). offsetMonths shifts both by N.
+ */
+export function getCalendarMonthRange(
+  now: Date = new Date(),
+  offsetMonths: number = 0
+): { start: Date; end: Date } {
+  const start = new Date(now.getFullYear(), now.getMonth() + offsetMonths, 1);
+  const end = new Date(now.getFullYear(), now.getMonth() + offsetMonths + 1, 1);
+  return { start, end };
+}
+
+/**
+ * Rounded percentage change. previous=0 with current>0 returns 100
+ * (no baseline; treated as full growth). Both 0 returns 0.
+ */
+export function computeMoMGrowth(current: number, previous: number): number {
+  if (previous > 0) {
+    return Math.round(((current - previous) / previous) * 100);
+  }
+  if (current > 0) return 100;
+  return 0;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/stats.test.ts 2>&1 | tail -15
+```
+
+Expected: 8 passing tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add lib/admin-dashboard/types.ts lib/admin-dashboard/stats.ts __tests__/lib/admin-dashboard/stats.test.ts && git commit -m "feat(admin): stats helpers — month range + MoM growth
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Stats helpers — revenue (current month + MoM) (TDD)
+
+**Files:**
+- Modify: `lib/admin-dashboard/stats.ts` (append)
+- Modify: `__tests__/lib/admin-dashboard/stats.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `__tests__/lib/admin-dashboard/stats.test.ts`:
+
+```ts
+import { getMonthlyRevenue } from '@/lib/admin-dashboard/stats';
+
+const mockChargesList = jest.fn();
+const mockAccountsRetrieve = jest.fn();
+jest.mock('@/lib/stripe', () => ({
+  stripe: {
+    accounts: { retrieve: (...a: unknown[]) => mockAccountsRetrieve(...a) },
+    charges: { list: (...a: unknown[]) => mockChargesList(...a) },
+  },
+}));
+
+describe('getMonthlyRevenue', () => {
+  beforeEach(() => {
+    mockChargesList.mockReset();
+    mockAccountsRetrieve.mockReset();
+  });
+
+  it('returns 0/0 when stripeAccountId is null', async () => {
+    const result = await getMonthlyRevenue(null, new Date(2026, 3, 15));
+    expect(result).toEqual({ monthlyRevenue: 0, revenueGrowth: 0 });
+    expect(mockAccountsRetrieve).not.toHaveBeenCalled();
+  });
+
+  it('returns 0/0 when account is not charges_enabled', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: false });
+    const result = await getMonthlyRevenue('acct_x', new Date(2026, 3, 15));
+    expect(result).toEqual({ monthlyRevenue: 0, revenueGrowth: 0 });
+  });
+
+  it('sums succeeded charges and computes MoM', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: true });
+    mockChargesList
+      .mockResolvedValueOnce({ data: [
+        { status: 'succeeded', amount: 5000 },
+        { status: 'succeeded', amount: 3000 },
+        { status: 'failed',    amount: 1000 },
+      ] })
+      .mockResolvedValueOnce({ data: [
+        { status: 'succeeded', amount: 4000 },
+      ] });
+    const result = await getMonthlyRevenue('acct_x', new Date(2026, 3, 15));
+    expect(result.monthlyRevenue).toBe(80); // (5000+3000)/100
+    expect(result.revenueGrowth).toBe(100); // (80-40)/40 = 100%
+  });
+
+  it('falls back to 0/0 when accounts.retrieve throws', async () => {
+    mockAccountsRetrieve.mockRejectedValueOnce(new Error('stripe down'));
+    const result = await getMonthlyRevenue('acct_x', new Date(2026, 3, 15));
+    expect(result).toEqual({ monthlyRevenue: 0, revenueGrowth: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/stats.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — "Cannot find module '@/lib/admin-dashboard/stats'" or "getMonthlyRevenue is not a function".
+
+- [ ] **Step 3: Implement helper**
+
+Append to `lib/admin-dashboard/stats.ts`:
+
+```ts
+import { stripe } from '@/lib/stripe';
+import type Stripe from 'stripe';
+
+async function sumSucceeded(
+  stripeAccountId: string,
+  start: Date,
+  end: Date
+): Promise<number> {
+  const charges = await stripe.charges.list(
+    {
+      created: {
+        gte: Math.floor(start.getTime() / 1000),
+        lt: Math.floor(end.getTime() / 1000),
+      },
+      limit: 100,
+    },
+    { stripeAccount: stripeAccountId }
+  );
+  return charges.data.reduce(
+    (total: number, c: Stripe.Charge) =>
+      c.status === 'succeeded' ? total + c.amount / 100 : total,
+    0
+  );
+}
+
+export async function getMonthlyRevenue(
+  stripeAccountId: string | null,
+  now: Date = new Date()
+): Promise<{ monthlyRevenue: number; revenueGrowth: number }> {
+  if (!stripeAccountId) return { monthlyRevenue: 0, revenueGrowth: 0 };
+
+  try {
+    const account = await stripe.accounts.retrieve(stripeAccountId);
+    if (!account.charges_enabled) return { monthlyRevenue: 0, revenueGrowth: 0 };
+  } catch {
+    return { monthlyRevenue: 0, revenueGrowth: 0 };
+  }
+
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+  const [thisMonthRevenue, lastMonthRevenue] = await Promise.all([
+    sumSucceeded(stripeAccountId, thisMonth.start, thisMonth.end),
+    sumSucceeded(stripeAccountId, lastMonth.start, lastMonth.end),
+  ]);
+
+  return {
+    monthlyRevenue: thisMonthRevenue,
+    revenueGrowth: computeMoMGrowth(thisMonthRevenue, lastMonthRevenue),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/stats.test.ts 2>&1 | tail -15
+```
+
+Expected: 12 passing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add lib/admin-dashboard/stats.ts __tests__/lib/admin-dashboard/stats.test.ts && git commit -m "feat(admin): getMonthlyRevenue helper with MoM growth
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Stats helpers — 6-month revenue chart (TDD)
+
+**Files:**
+- Modify: `lib/admin-dashboard/stats.ts` (append)
+- Modify: `__tests__/lib/admin-dashboard/stats.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+import { getRevenueChart6Months } from '@/lib/admin-dashboard/stats';
+
+describe('getRevenueChart6Months', () => {
+  beforeEach(() => {
+    mockChargesList.mockReset();
+    mockAccountsRetrieve.mockReset();
+  });
+
+  it('returns 6 zero points when stripeAccountId is null', async () => {
+    const result = await getRevenueChart6Months(null, new Date(2026, 3, 15));
+    expect(result).toHaveLength(6);
+    expect(result.every((p) => p.revenue === 0)).toBe(true);
+    expect(result[result.length - 1].month).toBe('2026-04');
+    expect(result[0].month).toBe('2025-11');
+  });
+
+  it('queries Stripe per month and sums succeeded charges', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: true });
+    // 6 months = 6 list calls. Earliest first.
+    for (let i = 0; i < 6; i++) {
+      mockChargesList.mockResolvedValueOnce({
+        data: [{ status: 'succeeded', amount: (i + 1) * 1000 }],
+      });
+    }
+    const result = await getRevenueChart6Months('acct_x', new Date(2026, 3, 15));
+    expect(result.map((p) => p.revenue)).toEqual([10, 20, 30, 40, 50, 60]);
+    expect(result.map((p) => p.month)).toEqual([
+      '2025-11', '2025-12', '2026-01', '2026-02', '2026-03', '2026-04',
+    ]);
+  });
+
+  it('returns zero points when account is not charges_enabled', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: false });
+    const result = await getRevenueChart6Months('acct_x', new Date(2026, 3, 15));
+    expect(result.every((p) => p.revenue === 0)).toBe(true);
+    expect(mockChargesList).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/stats.test.ts -t "getRevenueChart6Months" 2>&1 | tail -10
+```
+
+Expected: FAIL — "getRevenueChart6Months is not a function".
+
+- [ ] **Step 3: Implement helper**
+
+Append to `lib/admin-dashboard/stats.ts`:
+
+```ts
+import type { RevenuePoint } from './types';
+
+function formatYearMonth(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export async function getRevenueChart6Months(
+  stripeAccountId: string | null,
+  now: Date = new Date()
+): Promise<RevenuePoint[]> {
+  // Build the 6 month markers (earliest first), -5..0
+  const months = Array.from({ length: 6 }, (_, i) => getCalendarMonthRange(now, i - 5));
+  const zeros: RevenuePoint[] = months.map((m) => ({ month: formatYearMonth(m.start), revenue: 0 }));
+
+  if (!stripeAccountId) return zeros;
+  try {
+    const account = await stripe.accounts.retrieve(stripeAccountId);
+    if (!account.charges_enabled) return zeros;
+  } catch {
+    return zeros;
+  }
+
+  const revenues = await Promise.all(
+    months.map(({ start, end }) => sumSucceeded(stripeAccountId, start, end))
+  );
+  return months.map(({ start }, i) => ({
+    month: formatYearMonth(start),
+    revenue: revenues[i],
+  }));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/stats.test.ts 2>&1 | tail -15
+```
+
+Expected: all stats.test.ts tests pass (15 total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add lib/admin-dashboard/stats.ts __tests__/lib/admin-dashboard/stats.test.ts && git commit -m "feat(admin): getRevenueChart6Months for revenue tab
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+> **Note on pagination:** `sumSucceeded` uses `limit: 100`. If a single community ever has >100 charges in one month, that month's number will undercount. Acceptable for now; tracked as a follow-up to switch to `autoPagingEach` if any community exceeds it.
+
+---
+
+## Task 6: Stats helpers — member growth 90d series (TDD)
+
+**Files:**
+- Modify: `lib/admin-dashboard/stats.ts` (append)
+- Modify: `__tests__/lib/admin-dashboard/stats.test.ts` (append)
+
+The chart shows current active member count over the last 90 days. Computation: starting from the count of currently-active members, walk *backwards* through joins (subtract) and cancellations (add), giving the active count as it was on each prior day. Forward-render as a 90-element array.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+import { buildMemberGrowthSeries } from '@/lib/admin-dashboard/stats';
+
+describe('buildMemberGrowthSeries', () => {
+  it('produces a 90-day series ending at currentActive', () => {
+    const now = new Date(2026, 3, 15); // Apr 15
+    const series = buildMemberGrowthSeries({
+      now,
+      currentActiveCount: 10,
+      joins: [],         // no joins in window
+      cancellations: [], // no cancels in window
+    });
+    expect(series).toHaveLength(90);
+    expect(series[series.length - 1].count).toBe(10);
+    expect(series[0].count).toBe(10); // flat
+  });
+
+  it('walks back: a join 30 days ago means the count was 1 lower before that day', () => {
+    const now = new Date(2026, 3, 15);
+    const joinedAt = new Date(2026, 2, 16); // 30 days before
+    const series = buildMemberGrowthSeries({
+      now,
+      currentActiveCount: 5,
+      joins: [{ at: joinedAt }],
+      cancellations: [],
+    });
+    expect(series[series.length - 1].count).toBe(5);          // today: 5
+    expect(series[series.length - 30].count).toBe(5);         // join day: still 5 (event happened)
+    expect(series[series.length - 31].count).toBe(4);         // day before: 4
+    expect(series[0].count).toBe(4);                          // 90 days ago: 4
+  });
+
+  it('walks back: a cancellation 10 days ago means the count was 1 higher before that day', () => {
+    const now = new Date(2026, 3, 15);
+    const cancelledAt = new Date(2026, 3, 5); // 10 days before
+    const series = buildMemberGrowthSeries({
+      now,
+      currentActiveCount: 7,
+      joins: [],
+      cancellations: [{ at: cancelledAt }],
+    });
+    expect(series[series.length - 1].count).toBe(7);   // today
+    expect(series[series.length - 10].count).toBe(7);  // cancel day: 7 (event applied)
+    expect(series[series.length - 11].count).toBe(8);  // day before: 8
+  });
+
+  it('clamps at 0 (never returns negative counts)', () => {
+    const now = new Date(2026, 3, 15);
+    const cancelledAt = new Date(2026, 3, 5);
+    const series = buildMemberGrowthSeries({
+      now,
+      currentActiveCount: 0,
+      joins: [],
+      cancellations: [{ at: cancelledAt }],
+    });
+    // walking back, day-before-cancel would be 1 (recovered) which is fine
+    // but day-before-90d-with-extra-cancels stays >= 0
+    expect(series.every((p) => p.count >= 0)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/stats.test.ts -t "buildMemberGrowthSeries" 2>&1 | tail -10
+```
+
+Expected: FAIL — "buildMemberGrowthSeries is not a function".
+
+- [ ] **Step 3: Implement helper**
+
+Append to `lib/admin-dashboard/stats.ts`:
+
+```ts
+import type { GrowthPoint } from './types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+/**
+ * Builds a 90-day cumulative active-member-count series ending today.
+ * Algorithm: start from the current active count and walk *backward*
+ * through events. A join in the window means the count was 1 lower
+ * BEFORE the join day; a cancellation means it was 1 higher before
+ * the cancel day. Then write counts forward into the result array.
+ */
+export function buildMemberGrowthSeries({
+  now,
+  currentActiveCount,
+  joins,
+  cancellations,
+}: {
+  now: Date;
+  currentActiveCount: number;
+  joins: { at: Date }[];
+  cancellations: { at: Date }[];
+}): GrowthPoint[] {
+  const today = startOfDay(now);
+  const startDay = new Date(today.getTime() - 89 * DAY_MS);
+
+  // Initialize each day with the *current* count; we'll subtract later.
+  const days: GrowthPoint[] = [];
+  for (let i = 0; i < 90; i++) {
+    const d = new Date(startDay.getTime() + i * DAY_MS);
+    days.push({
+      date: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`,
+      count: currentActiveCount,
+    });
+  }
+
+  // For each event in the window, retroactively adjust earlier days.
+  // A join on day J means days BEFORE J had one fewer member.
+  for (const j of joins) {
+    const jDay = startOfDay(j.at);
+    if (jDay.getTime() < startDay.getTime() || jDay.getTime() > today.getTime()) continue;
+    const idx = Math.round((jDay.getTime() - startDay.getTime()) / DAY_MS);
+    for (let i = 0; i < idx; i++) days[i].count -= 1;
+  }
+  // A cancel on day C means days BEFORE C had one more member.
+  for (const c of cancellations) {
+    const cDay = startOfDay(c.at);
+    if (cDay.getTime() < startDay.getTime() || cDay.getTime() > today.getTime()) continue;
+    const idx = Math.round((cDay.getTime() - startDay.getTime()) / DAY_MS);
+    for (let i = 0; i < idx; i++) days[i].count += 1;
+  }
+
+  // Clamp at 0 (defensive; cancellations of members that joined before the window
+  // could push values negative if data is messy).
+  for (const d of days) if (d.count < 0) d.count = 0;
+  return days;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/stats.test.ts 2>&1 | tail -15
+```
+
+Expected: all stats.test.ts tests pass (19 total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add lib/admin-dashboard/stats.ts __tests__/lib/admin-dashboard/stats.test.ts && git commit -m "feat(admin): buildMemberGrowthSeries for the Members chart
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Activity-feed helpers — merge events (TDD)
+
+**Files:**
+- Create: `lib/admin-dashboard/activity-feed.ts`
+- Create: `__tests__/lib/admin-dashboard/activity-feed.test.ts`
+
+This task adds the pure merge-and-truncate function. The DB/Stripe queries that produce the inputs live directly in the page (one DB query per type), and we test the merge logic in isolation.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/lib/admin-dashboard/activity-feed.test.ts`:
+
+```ts
+import { mergeActivityEvents } from '@/lib/admin-dashboard/activity-feed';
+import type { ActivityEvent } from '@/lib/admin-dashboard/types';
+
+const make = (overrides: Partial<ActivityEvent>): ActivityEvent =>
+  ({
+    type: 'join',
+    at: new Date(2026, 3, 1),
+    userId: 'u1',
+    displayName: 'X',
+    avatarUrl: null,
+    ...overrides,
+  } as ActivityEvent);
+
+describe('mergeActivityEvents', () => {
+  it('merges multiple lists, sorts DESC by at, caps at limit', () => {
+    const a: ActivityEvent[] = [
+      make({ at: new Date('2026-04-10T09:00:00Z'), userId: 'a1' }),
+      make({ at: new Date('2026-04-05T09:00:00Z'), userId: 'a2' }),
+    ];
+    const b: ActivityEvent[] = [
+      make({ at: new Date('2026-04-12T09:00:00Z'), userId: 'b1', type: 'cancel' }),
+      make({ at: new Date('2026-04-08T09:00:00Z'), userId: 'b2', type: 'cancel' }),
+    ];
+    const result = mergeActivityEvents([a, b], 3);
+    expect(result.map((e) => e.userId)).toEqual(['b1', 'a1', 'b2']);
+  });
+
+  it('returns empty array when all inputs empty', () => {
+    expect(mergeActivityEvents([[], [], []], 10)).toEqual([]);
+  });
+
+  it('preserves stable order between same-timestamp events', () => {
+    const t = new Date('2026-04-12T09:00:00Z');
+    const a: ActivityEvent[] = [make({ at: t, userId: 'a1' })];
+    const b: ActivityEvent[] = [make({ at: t, userId: 'b1' })];
+    const result = mergeActivityEvents([a, b], 10);
+    expect(result.map((e) => e.userId)).toEqual(['a1', 'b1']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/activity-feed.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — "Cannot find module '@/lib/admin-dashboard/activity-feed'".
+
+- [ ] **Step 3: Implement merge helper**
+
+Create `lib/admin-dashboard/activity-feed.ts`:
+
+```ts
+import type { ActivityEvent } from './types';
+
+/**
+ * Concatenate event lists, sort newest-first by `at`, slice to `limit`.
+ * Stable: equal timestamps keep their relative input order.
+ */
+export function mergeActivityEvents(
+  lists: ActivityEvent[][],
+  limit: number
+): ActivityEvent[] {
+  const flat: { event: ActivityEvent; idx: number }[] = [];
+  let counter = 0;
+  for (const list of lists) {
+    for (const event of list) {
+      flat.push({ event, idx: counter++ });
+    }
+  }
+  flat.sort((a, b) => {
+    const diff = b.event.at.getTime() - a.event.at.getTime();
+    return diff !== 0 ? diff : a.idx - b.idx;
+  });
+  return flat.slice(0, limit).map((x) => x.event);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/activity-feed.test.ts 2>&1 | tail -15
+```
+
+Expected: 3 passing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add lib/admin-dashboard/activity-feed.ts __tests__/lib/admin-dashboard/activity-feed.test.ts && git commit -m "feat(admin): mergeActivityEvents helper
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Activity-feed helper — getRecentFailedPayments (TDD)
+
+**Files:**
+- Modify: `lib/admin-dashboard/activity-feed.ts` (append)
+- Modify: `__tests__/lib/admin-dashboard/activity-feed.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+import { getRecentFailedPayments } from '@/lib/admin-dashboard/activity-feed';
+
+const mockChargesList = jest.fn();
+const mockAccountsRetrieve = jest.fn();
+jest.mock('@/lib/stripe', () => ({
+  stripe: {
+    accounts: { retrieve: (...a: unknown[]) => mockAccountsRetrieve(...a) },
+    charges: { list: (...a: unknown[]) => mockChargesList(...a) },
+  },
+}));
+
+describe('getRecentFailedPayments', () => {
+  beforeEach(() => {
+    mockChargesList.mockReset();
+    mockAccountsRetrieve.mockReset();
+  });
+
+  it('returns [] when stripeAccountId is null', async () => {
+    const result = await getRecentFailedPayments(null);
+    expect(result).toEqual([]);
+    expect(mockChargesList).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when account is not charges_enabled', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: false });
+    const result = await getRecentFailedPayments('acct_x');
+    expect(result).toEqual([]);
+  });
+
+  it('maps failed charges to ActivityEvent rows', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: true });
+    const t = new Date('2026-04-12T09:00:00Z');
+    mockChargesList.mockResolvedValueOnce({
+      data: [
+        {
+          status: 'failed',
+          amount: 1500,
+          created: Math.floor(t.getTime() / 1000),
+          billing_details: { name: 'Anna Test' },
+          metadata: { user_id: 'u1' },
+        },
+      ],
+    });
+    const result = await getRecentFailedPayments('acct_x');
+    expect(result).toEqual([
+      {
+        type: 'failed_payment',
+        at: t,
+        userId: 'u1',
+        displayName: 'Anna Test',
+        amount: 15,
+      },
+    ]);
+  });
+
+  it('falls back to "Unknown" displayName when billing_details.name is missing', async () => {
+    mockAccountsRetrieve.mockResolvedValueOnce({ charges_enabled: true });
+    mockChargesList.mockResolvedValueOnce({
+      data: [{ status: 'failed', amount: 1000, created: 1700000000, billing_details: {}, metadata: {} }],
+    });
+    const result = await getRecentFailedPayments('acct_x');
+    expect(result[0].displayName).toBe('Unknown');
+    expect(result[0].userId).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/activity-feed.test.ts -t "getRecentFailedPayments" 2>&1 | tail -10
+```
+
+Expected: FAIL — "getRecentFailedPayments is not a function".
+
+- [ ] **Step 3: Implement helper**
+
+Append to `lib/admin-dashboard/activity-feed.ts`:
+
+```ts
+import { stripe } from '@/lib/stripe';
+import type Stripe from 'stripe';
+
+const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
+
+export async function getRecentFailedPayments(
+  stripeAccountId: string | null,
+  now: Date = new Date()
+): Promise<ActivityEvent[]> {
+  if (!stripeAccountId) return [];
+  try {
+    const account = await stripe.accounts.retrieve(stripeAccountId);
+    if (!account.charges_enabled) return [];
+  } catch {
+    return [];
+  }
+
+  const sinceSec = Math.floor(now.getTime() / 1000) - THIRTY_DAYS_SECONDS;
+  const charges = await stripe.charges.list(
+    { created: { gte: sinceSec }, limit: 10 },
+    { stripeAccount: stripeAccountId }
+  );
+
+  return charges.data
+    .filter((c: Stripe.Charge) => c.status === 'failed')
+    .map((c: Stripe.Charge) => ({
+      type: 'failed_payment' as const,
+      at: new Date(c.created * 1000),
+      userId: (c.metadata?.user_id as string | undefined) ?? null,
+      displayName: c.billing_details?.name ?? 'Unknown',
+      amount: c.amount / 100,
+    }));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard/activity-feed.test.ts 2>&1 | tail -15
+```
+
+Expected: 7 passing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add lib/admin-dashboard/activity-feed.ts __tests__/lib/admin-dashboard/activity-feed.test.ts && git commit -m "feat(admin): getRecentFailedPayments for activity feed
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Rewrite DashboardKpis — adaptive 5-tile grid
+
+**Files:**
+- Rewrite: `components/admin/DashboardKpis.tsx`
+
+- [ ] **Step 1: Replace the file**
+
+Replace `components/admin/DashboardKpis.tsx` with:
+
+```tsx
+import { Users, TrendingUp, TrendingDown, DollarSign, MessageSquare, UserMinus } from 'lucide-react';
+
+export interface DashboardStats {
+  isPaid: boolean;
+  monthlyRevenue: number;        // EUR; 0 on free
+  revenueGrowth: number;         // %; 0 on free
+  membersTotal: number;          // currently active members, excl. creator
+  membersPaying: number;         // subset; 0 on free
+  newMembersThisMonth: number;
+  newMembersGrowth: number;
+  cancellationsThisMonth: number;     // 0 on free
+  cancellationsLastMonth: number;     // 0 on free
+  postsThreadsThisMonth: number;
+  postsCommentsThisMonth: number;
+}
+
+export function DashboardKpis({ stats }: { stats: DashboardStats }) {
+  const tiles: React.ReactNode[] = [];
+
+  if (stats.isPaid) {
+    tiles.push(
+      <Tile
+        key="revenue"
+        label="Revenue this month"
+        value={`€${stats.monthlyRevenue.toFixed(2)}`}
+        sublineNumber={stats.revenueGrowth}
+        sublineSuffix="vs last month"
+        icon={<DollarSign className="h-5 w-5 text-secondary" />}
+        iconBg="bg-secondary/20"
+      />
+    );
+  }
+
+  tiles.push(
+    <Tile
+      key="members"
+      label="Members"
+      value={stats.membersTotal.toString()}
+      sublineText={stats.isPaid ? `${stats.membersPaying} paying` : undefined}
+      icon={<Users className="h-5 w-5 text-primary" />}
+      iconBg="bg-primary/10"
+    />
+  );
+
+  tiles.push(
+    <Tile
+      key="new"
+      label="New members this month"
+      value={stats.newMembersThisMonth.toString()}
+      sublineNumber={stats.newMembersGrowth}
+      sublineSuffix="vs last month"
+      icon={<TrendingUp className="h-5 w-5 text-primary" />}
+      iconBg="bg-primary/10"
+    />
+  );
+
+  if (stats.isPaid) {
+    tiles.push(
+      <Tile
+        key="cancellations"
+        label="Cancellations this month"
+        value={stats.cancellationsThisMonth.toString()}
+        sublineText={`${stats.cancellationsLastMonth} last month`}
+        icon={<UserMinus className="h-5 w-5 text-secondary" />}
+        iconBg="bg-secondary/20"
+      />
+    );
+  }
+
+  tiles.push(
+    <Tile
+      key="posts"
+      label="Posts this month"
+      value={`${stats.postsThreadsThisMonth} threads`}
+      sublineText={`${stats.postsCommentsThisMonth} replies`}
+      icon={<MessageSquare className="h-5 w-5 text-accent" />}
+      iconBg="bg-accent/20"
+    />
+  );
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {tiles}
+    </div>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  sublineNumber,
+  sublineSuffix,
+  sublineText,
+  icon,
+  iconBg,
+}: {
+  label: string;
+  value: string;
+  sublineNumber?: number;
+  sublineSuffix?: string;
+  sublineText?: string;
+  icon: React.ReactNode;
+  iconBg: string;
+}) {
+  const showNumber = typeof sublineNumber === 'number';
+  const isPositive = showNumber && (sublineNumber as number) >= 0;
+
+  return (
+    <div className="bg-card rounded-2xl p-6 border-2 border-transparent hover:border-primary/20 hover:shadow-lg transition-all duration-300 ease-out space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-muted-foreground">{label}</h3>
+        <div className={`h-10 w-10 rounded-xl ${iconBg} flex items-center justify-center`}>
+          {icon}
+        </div>
+      </div>
+      <p className="font-display text-3xl font-bold text-foreground">{value}</p>
+      {showNumber ? (
+        <p className={`text-sm font-medium ${isPositive ? 'text-primary' : 'text-destructive'}`}>
+          {isPositive ? (
+            <TrendingUp className="h-4 w-4 inline mr-1" />
+          ) : (
+            <TrendingDown className="h-4 w-4 inline mr-1" />
+          )}
+          {isPositive ? '+' : ''}
+          {sublineNumber}% {sublineSuffix}
+        </p>
+      ) : sublineText ? (
+        <p className="text-sm text-muted-foreground">{sublineText}</p>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "DashboardKpis"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add components/admin/DashboardKpis.tsx && git commit -m "feat(admin): rewrite DashboardKpis as adaptive 5-tile grid
+
+Drives tile visibility from stats.isPaid; plain-language labels; uses
+TrendingDown for negative MoM growth.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: DashboardChart client island
+
+**Files:**
+- Create: `components/admin/DashboardChart.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+'use client';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+import type { RevenuePoint, GrowthPoint } from '@/lib/admin-dashboard/types';
+
+export function DashboardChart({
+  isPaid,
+  revenue,
+  growth,
+}: {
+  isPaid: boolean;
+  revenue: RevenuePoint[];
+  growth: GrowthPoint[];
+}) {
+  const hasGrowthData = growth.some((p) => p.count > 0);
+  const hasRevenueData = revenue.some((p) => p.revenue > 0);
+
+  if (!isPaid) {
+    return (
+      <div className="bg-card rounded-2xl border border-border/50 p-6">
+        <h2 className="font-display text-lg font-semibold mb-4">Member growth (last 90 days)</h2>
+        {hasGrowthData ? <GrowthChart data={growth} /> : <EmptyState />}
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-2xl border border-border/50 p-6">
+      <Tabs defaultValue="revenue">
+        <TabsList className="mb-4">
+          <TabsTrigger value="revenue">Revenue</TabsTrigger>
+          <TabsTrigger value="members">Members</TabsTrigger>
+        </TabsList>
+        <TabsContent value="revenue">
+          {hasRevenueData ? <RevenueChart data={revenue} /> : <EmptyState />}
+        </TabsContent>
+        <TabsContent value="members">
+          {hasGrowthData ? <GrowthChart data={growth} /> : <EmptyState />}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function RevenueChart({ data }: { data: RevenuePoint[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-border/40" />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} className="text-xs" />
+        <YAxis tickLine={false} axisLine={false} className="text-xs" tickFormatter={(v) => `€${v}`} />
+        <Tooltip formatter={(v: number) => [`€${v.toFixed(2)}`, 'Revenue']} />
+        <Bar dataKey="revenue" radius={[6, 6, 0, 0]} className="fill-primary" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function GrowthChart({ data }: { data: GrowthPoint[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <LineChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-border/40" />
+        <XAxis dataKey="date" tickLine={false} axisLine={false} className="text-xs" interval={14} />
+        <YAxis tickLine={false} axisLine={false} className="text-xs" allowDecimals={false} />
+        <Tooltip />
+        <Line type="monotone" dataKey="count" strokeWidth={2} dot={false} className="stroke-primary" />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="h-[240px] flex items-center justify-center text-sm text-muted-foreground">
+      Not enough data yet
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "DashboardChart"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add components/admin/DashboardChart.tsx && git commit -m "feat(admin): DashboardChart client island (Recharts + Tabs)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: DashboardActivityFeed server component
+
+**Files:**
+- Create: `components/admin/DashboardActivityFeed.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { formatDistanceToNow } from 'date-fns';
+import Link from 'next/link';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { UserPlus, UserMinus, MessageSquare, AlertTriangle } from 'lucide-react';
+import type { ActivityEvent } from '@/lib/admin-dashboard/types';
+
+export function DashboardActivityFeed({
+  events,
+  communitySlug,
+}: {
+  events: ActivityEvent[];
+  communitySlug: string;
+}) {
+  if (events.length === 0) {
+    return (
+      <div className="bg-card rounded-2xl border border-border/50 p-6">
+        <h2 className="font-display text-lg font-semibold mb-4">Recent activity</h2>
+        <p className="text-sm text-muted-foreground text-center py-8">No recent activity yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-2xl border border-border/50 p-6">
+      <h2 className="font-display text-lg font-semibold mb-4">Recent activity</h2>
+      <ul className="space-y-3">
+        {events.map((e, i) => (
+          <ActivityRow key={`${e.type}-${e.at.getTime()}-${i}`} event={e} communitySlug={communitySlug} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ActivityRow({ event, communitySlug }: { event: ActivityEvent; communitySlug: string }) {
+  if (event.type === 'failed_payment') {
+    return (
+      <li className="flex items-start gap-3 p-3 rounded-xl bg-amber-50/40 border border-amber-200/40">
+        <div className="h-9 w-9 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+          <AlertTriangle className="h-4 w-4 text-amber-700" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm">
+            <span className="font-medium">{event.displayName}</span>'s payment of €{event.amount.toFixed(2)} failed
+          </p>
+          <p className="text-xs text-muted-foreground">{formatDistanceToNow(event.at, { addSuffix: true })}</p>
+        </div>
+        <Link
+          href={`/${communitySlug}/admin/members`}
+          className="text-xs font-medium text-primary hover:underline self-center"
+        >
+          Resolve
+        </Link>
+      </li>
+    );
+  }
+
+  const icon =
+    event.type === 'join' ? <UserPlus className="h-4 w-4 text-primary" /> :
+    event.type === 'cancel' ? <UserMinus className="h-4 w-4 text-muted-foreground" /> :
+    <MessageSquare className="h-4 w-4 text-primary" />;
+
+  const verb =
+    event.type === 'join' ? 'joined' :
+    event.type === 'cancel' ? 'cancelled' :
+    `posted${event.type === 'post' && event.categoryName ? ` in ${event.categoryName}` : ''}`;
+
+  return (
+    <li className="flex items-start gap-3">
+      <Avatar className="h-9 w-9 flex-shrink-0">
+        {event.avatarUrl ? <AvatarImage src={event.avatarUrl} alt={event.displayName} /> : null}
+        <AvatarFallback className="bg-primary/10 text-primary text-xs">
+          {event.displayName[0]?.toUpperCase() ?? '?'}
+        </AvatarFallback>
+      </Avatar>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm">
+          <span className="font-medium">{event.displayName}</span> {verb}
+        </p>
+        <p className="text-xs text-muted-foreground">{formatDistanceToNow(event.at, { addSuffix: true })}</p>
+      </div>
+      <div className="hidden sm:flex h-9 w-9 rounded-full bg-muted/50 items-center justify-center flex-shrink-0">
+        {icon}
+      </div>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "DashboardActivityFeed"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add components/admin/DashboardActivityFeed.tsx && git commit -m "feat(admin): DashboardActivityFeed server component
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Wire up the dashboard page
+
+**Files:**
+- Rewrite: `app/[communitySlug]/admin/page.tsx`
+
+- [ ] **Step 1: Replace the page**
+
+```tsx
+import { queryOne, query } from '@/lib/db';
+import {
+  getCalendarMonthRange,
+  getMonthlyRevenue,
+  getRevenueChart6Months,
+  buildMemberGrowthSeries,
+  computeMoMGrowth,
+} from '@/lib/admin-dashboard/stats';
+import {
+  mergeActivityEvents,
+  getRecentFailedPayments,
+} from '@/lib/admin-dashboard/activity-feed';
+import type { ActivityEvent } from '@/lib/admin-dashboard/types';
+import { DashboardKpis } from '@/components/admin/DashboardKpis';
+import { DashboardChart } from '@/components/admin/DashboardChart';
+import { DashboardActivityFeed } from '@/components/admin/DashboardActivityFeed';
+
+export const dynamic = 'force-dynamic';
+export const fetchCache = 'force-no-store';
+
+type CommunityRow = {
+  id: string;
+  created_by: string;
+  membership_enabled: boolean;
+  stripe_account_id: string | null;
+};
+
+type MembersCounts = { total: number; paying: number };
+type CountRow = { count: number };
+type JoinEvent = { user_id: string; display_name: string | null; avatar_url: string | null; joined_at: Date };
+type CancelEvent = { user_id: string; display_name: string | null; avatar_url: string | null; updated_at: Date };
+type PostEvent = { id: string; user_id: string; author_name: string | null; author_image: string | null; category_name: string | null; created_at: Date };
+
+export default async function AdminDashboardPage({
+  params,
+}: {
+  params: { communitySlug: string };
+}) {
+  const community = await queryOne<CommunityRow>`
+    SELECT id, created_by, membership_enabled, stripe_account_id
+    FROM communities
+    WHERE slug = ${params.communitySlug}
+  `;
+  if (!community) return null;
+
+  const now = new Date();
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+  const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+
+  const [
+    membersCountsRow,
+    newMembersThisMonthRow,
+    newMembersLastMonthRow,
+    cancellationsThisMonthRow,
+    cancellationsLastMonthRow,
+    threadsRow,
+    commentsRow,
+    revenue,
+    revenueChart,
+    joinsLast90,
+    cancelsLast90,
+    recentJoinEvents,
+    recentCancelEvents,
+    recentPostEvents,
+    failedPayments,
+  ] = await Promise.all([
+    queryOne<MembersCounts>`
+      SELECT
+        COUNT(*) FILTER (WHERE status='active')::int AS total,
+        COUNT(*) FILTER (WHERE status='active' AND stripe_subscription_id IS NOT NULL)::int AS paying
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND joined_at >= ${thisMonth.start.toISOString()}
+        AND joined_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND joined_at >= ${lastMonth.start.toISOString()}
+        AND joined_at < ${lastMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+        AND updated_at >= ${thisMonth.start.toISOString()}
+        AND updated_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+        AND updated_at >= ${lastMonth.start.toISOString()}
+        AND updated_at < ${lastMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM threads
+      WHERE community_id = ${community.id}
+        AND created_at >= ${thisMonth.start.toISOString()}
+        AND created_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM comments c
+      JOIN threads t ON c.thread_id = t.id
+      WHERE t.community_id = ${community.id}
+        AND c.created_at >= ${thisMonth.start.toISOString()}
+        AND c.created_at < ${thisMonth.end.toISOString()}
+    `,
+    getMonthlyRevenue(community.stripe_account_id, now),
+    getRevenueChart6Months(community.stripe_account_id, now),
+    query<{ joined_at: Date }>`
+      SELECT joined_at
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND joined_at >= ${ninetyDaysAgo.toISOString()}
+    `,
+    query<{ updated_at: Date }>`
+      SELECT updated_at
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+        AND updated_at >= ${ninetyDaysAgo.toISOString()}
+    `,
+    query<JoinEvent>`
+      SELECT user_id, formatted_display_name AS display_name, avatar_url, joined_at
+      FROM community_members_with_profiles
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+      ORDER BY joined_at DESC
+      LIMIT 10
+    `,
+    query<CancelEvent>`
+      SELECT user_id, formatted_display_name AS display_name, avatar_url, updated_at
+      FROM community_members_with_profiles
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+      ORDER BY updated_at DESC
+      LIMIT 10
+    `,
+    query<PostEvent>`
+      SELECT id, user_id, author_name, author_image, category_name, created_at
+      FROM threads
+      WHERE community_id = ${community.id}
+      ORDER BY created_at DESC
+      LIMIT 10
+    `,
+    getRecentFailedPayments(community.stripe_account_id, now),
+  ]);
+
+  const membersTotal = membersCountsRow?.total ?? 0;
+  const membersPaying = membersCountsRow?.paying ?? 0;
+  const newMembersThisMonth = newMembersThisMonthRow?.count ?? 0;
+  const newMembersLastMonth = newMembersLastMonthRow?.count ?? 0;
+  const cancellationsThisMonth = cancellationsThisMonthRow?.count ?? 0;
+  const cancellationsLastMonth = cancellationsLastMonthRow?.count ?? 0;
+  const threadsThisMonth = threadsRow?.count ?? 0;
+  const commentsThisMonth = commentsRow?.count ?? 0;
+
+  const stats = {
+    isPaid: community.membership_enabled,
+    monthlyRevenue: revenue.monthlyRevenue,
+    revenueGrowth: revenue.revenueGrowth,
+    membersTotal,
+    membersPaying,
+    newMembersThisMonth,
+    newMembersGrowth: computeMoMGrowth(newMembersThisMonth, newMembersLastMonth),
+    cancellationsThisMonth,
+    cancellationsLastMonth,
+    postsThreadsThisMonth: threadsThisMonth,
+    postsCommentsThisMonth: commentsThisMonth,
+  };
+
+  const growth = buildMemberGrowthSeries({
+    now,
+    currentActiveCount: membersTotal,
+    joins: joinsLast90.map((r) => ({ at: new Date(r.joined_at) })),
+    cancellations: cancelsLast90.map((r) => ({ at: new Date(r.updated_at) })),
+  });
+
+  const joins: ActivityEvent[] = recentJoinEvents.map((r) => ({
+    type: 'join',
+    at: new Date(r.joined_at),
+    userId: r.user_id,
+    displayName: r.display_name ?? 'Anonymous',
+    avatarUrl: r.avatar_url,
+  }));
+  const cancels: ActivityEvent[] = recentCancelEvents.map((r) => ({
+    type: 'cancel',
+    at: new Date(r.updated_at),
+    userId: r.user_id,
+    displayName: r.display_name ?? 'Anonymous',
+    avatarUrl: r.avatar_url,
+  }));
+  const posts: ActivityEvent[] = recentPostEvents.map((r) => ({
+    type: 'post',
+    at: new Date(r.created_at),
+    userId: r.user_id,
+    displayName: r.author_name ?? 'Anonymous',
+    avatarUrl: r.author_image,
+    threadId: r.id,
+    categoryName: r.category_name,
+  }));
+
+  const events = mergeActivityEvents([joins, cancels, posts, failedPayments], 10);
+
+  return (
+    <div className="animate-in fade-in slide-in-from-bottom-1 duration-500 space-y-8">
+      <header>
+        <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground">
+          Dashboard
+        </h1>
+      </header>
+
+      <DashboardKpis stats={stats} />
+
+      <DashboardChart isPaid={stats.isPaid} revenue={revenueChart} growth={growth} />
+
+      <DashboardActivityFeed events={events} communitySlug={params.communitySlug} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "admin/page"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run all admin-dashboard tests**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bunx jest __tests__/lib/admin-dashboard 2>&1 | tail -10
+```
+
+Expected: 22 passing tests across two files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git add app/\[communitySlug\]/admin/page.tsx && git commit -m "feat(admin): wire up dashboard page with new components
+
+Single Promise.all orchestrates DB + Stripe queries; tile/chart/feed
+components consume the assembled stats.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Build, deploy preprod, manual QA
+
+**Files:** none
+
+- [ ] **Step 1: Build in the worktree**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && bun run build 2>&1 | tail -20
+```
+
+Expected: build completes without errors. Look for `▲ Next.js` and `✓ Compiled successfully`.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git push -u origin feat/admin-dashboard-redesign 2>&1 | tail -3
+```
+
+Expected: branch pushed (or already up-to-date).
+
+- [ ] **Step 3: Deploy to preprod**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && ./deploy-preprod.sh restart feat/admin-dashboard-redesign 2>&1 | tail -10
+```
+
+Expected: `Done! Preprod restarted.` and pm2 process `dance-hub-preprod` online.
+
+- [ ] **Step 4: Verify it serves**
+
+```bash
+sleep 3 && curl -sS -o /dev/null -w "preprod: HTTP %{http_code} | %{time_total}s\n" http://localhost:3009
+```
+
+Expected: `HTTP 200`.
+
+- [ ] **Step 5: Manual QA — ask the user to verify**
+
+Visit `https://preprod.dance-hub.io/<community-slug>/admin` for:
+
+| Scenario | What to check |
+|---|---|
+| Paid community with active members + recent joins/cancellations | All 5 tiles populated; chart tabs both render; feed shows recent events |
+| Free community (`membership_enabled=false`) | Revenue + Cancellations tiles hidden; chart card has no tabs (Members only) |
+| Community with no `stripe_account_id` | Revenue tile shows €0.00 / +0%; failed-payments don't appear in feed |
+| Brand-new community | Empty state for chart ("Not enough data yet"); empty state for feed ("No recent activity yet") |
+| Nav | Dashboard link active when on `/admin`; subpages do NOT highlight Dashboard |
+
+If anything renders wrong, fix in another task and redeploy preprod.
+
+---
+
+## Task 14: Ship to production
+
+**Files:** none
+
+- [ ] **Step 1: Open PR**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && gh pr create --base main --head feat/admin-dashboard-redesign --title "feat(admin): redesign community admin dashboard" --body "$(cat <<'EOF'
+## Summary
+
+Replaces the broken 4-tile KPI grid at `/[communitySlug]/admin` with:
+
+- An adaptive 5-tile overview (3 tiles for free communities) — Revenue, Members, New members, Cancellations, Posts — all in plain language.
+- A tabbed Recharts card: revenue last 6 months (paid only) + member growth last 90 days.
+- A 10-event recent-activity feed: joins, cancellations, failed payments (highlighted), and new posts.
+- A Dashboard link in the admin nav, with exact-match active state for the index path.
+
+Spec: `docs/superpowers/specs/2026-04-27-admin-dashboard-redesign-design.md`
+Plan: `docs/superpowers/plans/2026-04-27-admin-dashboard-redesign.md`
+
+Validated on preprod (https://preprod.dance-hub.io).
+
+## Test plan
+- [ ] Paid community: all 5 tiles populated; both chart tabs render; feed shows recent events
+- [ ] Free community: Revenue + Cancellations hidden; chart shows Members only (no tabs)
+- [ ] Community without Stripe Connect: revenue gracefully shows €0.00 / +0%
+- [ ] Brand-new community: empty states for chart + feed
+- [ ] Dashboard nav link: active only on `/admin`, not on subpages
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 2: Squash-merge after user approval**
+
+```bash
+gh pr merge <PR-number> --squash 2>&1 | tail -5
+```
+
+Expected: merged.
+
+- [ ] **Step 3: Deploy prod**
+
+```bash
+cd /home/debian/apps/dance-hub && ./deploy.sh code 2>&1 | tail -10
+```
+
+Expected: `Done! Redeployed.` and pm2 process `dance-hub` restarted.
+
+- [ ] **Step 4: Verify prod**
+
+```bash
+sleep 3 && curl -sS -o /dev/null -w "prod: HTTP %{http_code} | %{time_total}s\n" https://dance-hub.io
+```
+
+Expected: `HTTP 200`.
+
+- [ ] **Step 5: Clean up preprod worktree**
+
+```bash
+cd /home/debian/apps/dance-hub-preprod && git fetch origin && git checkout --detach origin/main && git fetch --prune origin && git branch -D feat/admin-dashboard-redesign 2>&1 | tail -3
+```
+
+Expected: HEAD detached on the new origin/main; merged branch deleted locally.
+
+- [ ] **Step 6: Delete the abandoned `fix/dashboard-revenue` branch**
+
+```bash
+git push origin --delete fix/dashboard-revenue 2>&1 | tail -3
+```
+
+Expected: remote branch deleted (the work is folded into this redesign).
+
+---
+
+## Notes for follow-ups
+
+These were called out in the spec or surfaced during planning:
+
+1. **Stripe pagination**: `sumSucceeded` uses `limit: 100`. Fine for current community sizes; switch to `autoPagingEach` if any community exceeds 100 charges/month.
+2. **Dead routes**: `app/api/community/[communitySlug]/stripe-revenue/route.ts` and `app/api/community/[communitySlug]/stats/route.ts` are unused after this redesign. Delete in a follow-up cleanup PR.
+3. **shadcn-charts**: if the team adopts shadcn's chart primitives later, wrap the Recharts components in `<ChartContainer>` for a more cohesive theme.
+4. **Activity-feed Resolve link**: currently navigates to `/admin/members` without anchoring to the specific row. If the members page adds row anchoring, update the link to `/admin/members#<userId>`.

--- a/docs/superpowers/specs/2026-04-27-admin-dashboard-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-27-admin-dashboard-redesign-design.md
@@ -1,0 +1,225 @@
+# Admin Dashboard Redesign — Design
+
+**Date:** 2026-04-27
+**Branch:** `feat/admin-dashboard-redesign`
+**Scope:** Replace the four-tile KPI grid at `/[communitySlug]/admin/page.tsx` with a teacher-friendly overview that surfaces money, growth, and recent activity. Add a "Dashboard" entry to `AdminNav`. Adapts to free vs paid communities via `community.membership_enabled`.
+
+## Motivation
+
+The current dashboard has four KPI tiles (Total Members, Monthly Revenue, Total Threads, Active Members), and three of them are broken:
+
+- `monthlyRevenue` and `revenueGrowth` are hardcoded to `0`.
+- `Total Members` and `Active Members` use overlapping definitions and inconsistent creator-exclusion (Total excludes the creator, Active does not — so on a small community Active can read higher than Total).
+- The `+N this month` subline on Total Members filters by `status='active'` while the parent number counts every status, so the parent and subline mean different things.
+
+Beyond the data bugs, the dashboard reads as a generic "stats grid" with no perspective on what a community owner — typically a dance teacher, not a SaaS operator — actually needs to know at a glance: *am I making money, is the community growing, is anything broken?*
+
+This redesign narrows the dashboard around two priorities (money first, growth second), uses plain-language labels for the audience (no "MRR", no "churn"), and adds a chart and a recent-activity feed so the page communicates trend and texture, not just point-in-time counts.
+
+## Non-goals
+
+- Multi-admin support. Admin access is still gated to `community.created_by === session.user.id` (see `app/[communitySlug]/admin/layout.tsx:22`).
+- Replacing the deep-dive admin pages (Members, Subscriptions, Broadcasts, Thread Categories). The dashboard is an overview; drilling in still happens in those routes.
+- Net-new analytics infrastructure (events table, time-series store). All data comes from existing sources: `community_members`, `threads`, `comments`, and Stripe Connect.
+- Real-time updates. The page is server-rendered with `force-no-store`; refresh by reloading.
+- Generalising the chart/activity-feed components beyond this page. If reused later, extract then.
+
+## Audience
+
+Community owner — almost always a dance teacher running a small (10–50 paying members) community. Comfortable with money concepts ("how much did I make?") and growth concepts ("how many new students?"), but not with subscription-business jargon ("MRR", "churn rate", "ARPU"). Labels reflect this throughout.
+
+## Architecture
+
+### Page structure
+
+```
+app/[communitySlug]/admin/page.tsx     ← server component, orchestrates data
+components/admin/
+  DashboardHeader.tsx                  ← page title + community context
+  DashboardKpis.tsx                    ← REPLACES existing; tile grid (server)
+  DashboardChart.tsx                   ← client island, tabbed (Recharts)
+  DashboardActivityFeed.tsx            ← server component (no client interactivity needed)
+  AdminNav.tsx                         ← updated to add "Dashboard" link
+```
+
+The page itself stays an RSC. The chart is the only client island (it needs Recharts + tabs state). KPIs and activity feed are server-rendered for speed and to keep the client bundle small — same pattern already used elsewhere in `app/[communitySlug]/admin/`.
+
+### Layout
+
+Desktop (≥md):
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Dashboard                                            │
+├──────────────────────────────────────────────────────┤
+│ ┌──────────┐ ┌──────────┐ ┌──────────┐               │
+│ │ Tile 1   │ │ Tile 2   │ │ Tile 3   │               │
+│ └──────────┘ └──────────┘ └──────────┘               │
+│ ┌──────────┐ ┌──────────┐ ┌──────────┐               │
+│ │ Tile 4   │ │ Tile 5   │ │  (gap)   │               │
+│ └──────────┘ └──────────┘ └──────────┘               │
+├──────────────────────────────────────────────────────┤
+│ ┌──────────────────────────────────────────────────┐ │
+│ │ [Revenue · Members]                              │ │
+│ │ ▁▂▃▅▆▇  (chart)                                  │ │
+│ └──────────────────────────────────────────────────┘ │
+├──────────────────────────────────────────────────────┤
+│ ┌──────────────────────────────────────────────────┐ │
+│ │ Recent activity                                  │ │
+│ │ • Marie joined · 2h ago                          │ │
+│ │ • Anna's payment failed · 1d ago     [Resolve]   │ │
+│ │ • Logan posted in Salsa Tips · 1d ago            │ │
+│ │ …                                                │ │
+│ └──────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────┘
+```
+
+Mobile (<md): tiles stack 1-col; chart and feed fill the row.
+
+3-column tile grid (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`). On a paid community there are 5 tiles, leaving one empty cell on row 2 col 3 (intentional white space — matches the airy `font-display` page header). On a free community there are 3 tiles, filling row 1.
+
+### Data sources
+
+| Source | Used for |
+|---|---|
+| `community_members` (Postgres) | Members, New members, Cancellations tiles; Member-growth chart; Activity feed (joins, cancellations) |
+| `threads`, `comments` (Postgres) | Posts tile; Activity feed (new posts) |
+| Stripe `charges.list` (per Connect account) | Revenue tile, Revenue chart, Activity feed (failed payments) |
+| `communities.membership_enabled` | Drives conditional tile/chart visibility |
+| `communities.stripe_account_id` | Required for any Stripe call; absent → revenue/failed-payments shown as zero/empty |
+
+All Postgres queries use the existing `queryOne` / `query` helpers from `lib/db.ts`. Stripe calls use the existing `Stripe` SDK already imported elsewhere.
+
+## KPI tiles — adaptive
+
+Tile visibility depends on `community.membership_enabled`:
+
+| # | Paid (`membership_enabled=true`) | Free (`membership_enabled=false`) | Query |
+|---|---|---|---|
+| 1 | **Revenue this month** — `€X` · `+Y%` MoM | *hidden* | Stripe `charges.list` for `[startOfMonth, now]`, sum `amount/100` where `status='succeeded'`. Compare against `[startOfLastMonth, startOfMonth]` for MoM. |
+| 2 | **Members** — `N total` · `M paying` | **Members** — `N total` | `SELECT COUNT(*) FILTER (WHERE status='active') AS total, COUNT(*) FILTER (WHERE status='active' AND stripe_subscription_id IS NOT NULL) AS paying FROM community_members WHERE community_id=X AND user_id != created_by` |
+| 3 | **New members this month** — `N` · `+Y%` MoM | same | `WHERE joined_at >= startOfMonth AND user_id != created_by`. Compare with `[startOfLastMonth, startOfMonth]`. |
+| 4 | **Cancellations this month** — `N` · `M last month` | *hidden* | `WHERE status IN ('inactive','cancelled') AND updated_at >= startOfMonth`. (Schema does not have a dedicated `cancelled_at` column; `updated_at` is the closest proxy.) |
+| 5 | **Posts this month** — `N threads` · `M replies` | same | `SELECT COUNT(*) FROM threads WHERE community_id=X AND created_at >= startOfMonth` + `SELECT COUNT(*) FROM comments WHERE thread_id IN (...) AND created_at >= startOfMonth` |
+
+### Edge cases
+
+- Community has no `stripe_account_id` or `account.charges_enabled === false` → tile 1 shows `€0.00 · +0%` (graceful, no error).
+- Last-month value is `0` and this-month value is non-zero → `+Y%` shows `+100%` (mathematical fallback for division-by-zero).
+- Last-month and this-month both `0` → `+0%`.
+- All counts default to `0` when the underlying query returns no rows.
+
+### "Members" tile semantics — important
+
+`Total` here means **currently active members** (`status='active'`), not lifetime joined. Reasoning: for a teacher running a community, "I have 23 members" means people currently in the community, not "23 people have ever joined". This also resolves the original bug where Total counted any-status rows, making the number drift upward over time as people cancelled.
+
+`Paying` is the subset with an active Stripe subscription. On a free community, hide the `paying` line entirely.
+
+## Chart card
+
+Single card with two tabs:
+
+| Tab | Period | Type | Y-axis | Visible on |
+|---|---|---|---|---|
+| **Revenue** | Last 6 calendar months | Bar | € | Paid communities only |
+| **Members** | Last 90 days | Cumulative line | total active members | All communities |
+
+On a free community, the **Revenue** tab is removed — the card shows only the Members chart with no tab strip.
+
+### Library
+
+Use **Recharts**. Reasons:
+- De facto React standard, healthy maintenance, plays well with Next.js + Tailwind.
+- Used under the hood by shadcn's chart primitives if we adopt those later.
+- No charting lib currently in `package.json` (verified) — we add this dependency.
+
+### Data computation
+
+- **Revenue chart**: for each of the last 6 calendar months, query Stripe `charges.list` with `created` window for that month, sum succeeded amounts. **Pagination required** — Stripe's `charges.list` returns max 100 per page, and a 6-month window across all months can plausibly exceed that for active communities. Use the SDK's `autoPagingEach` (or `autoPagingToArray({ limit: 1000 })`) to iterate. The single-month KPI tile uses the same pagination, applied per-month to keep code symmetric.
+- **Members chart**: pull rows ordered by `joined_at`, accumulate net membership (`+1` per join, `-1` when an `inactive`/`cancelled` row's `updated_at` falls in the window), bin per day. Server-side computation; chart receives a `[{ date, count }]` array.
+
+### Empty states
+
+- Community younger than the chart period: render the chart axis but show a centered "Not enough data yet" message.
+- Stripe call fails: render the Members chart only (or, on free, an empty card with the message).
+
+## Recent activity feed
+
+Last 10 events, mixed types, ordered by recency. Each row is plain-language: actor, verb, target/context, relative time.
+
+| Type | Source | Example row | Notes |
+|---|---|---|---|
+| **Member joined** | `community_members.joined_at` (any status) | "Marie joined · 2h ago" | Free joins included |
+| **Cancellation** | `community_members.updated_at` where `status IN ('inactive','cancelled')` | "Lucas cancelled · 1d ago" | Same proxy as tile 4 |
+| **Failed payment** | Stripe `charges.list({status:'failed'})` last 30d | "Anna's payment failed · 2d ago [Resolve]" | Highlighted; "Resolve" links to `/admin/members#<userId>` |
+| **New post** | `threads.created_at` | "Logan posted in Salsa Tips · 6h ago" | Category name, not full title, to keep rows skimmable |
+
+Feed query strategy: each event type is its own SELECT (or Stripe call), each capped at 10 rows ordered DESC, then merged client-side and re-sorted by timestamp, sliced to the top 10. This avoids a single union query that's harder to optimise.
+
+### Visual treatment
+
+- One row per event, avatar/icon on the left, text in the middle, relative time on the right.
+- **Failed-payment** rows get a subtle amber tint (`bg-amber-50/40 border-amber-200/40`) and an inline "Resolve" link.
+- Empty state: "No recent activity yet" centered, same visual weight as the comments-section empty state in `ThreadView.tsx`.
+
+### Why merge in app code, not SQL UNION
+
+A SQL `UNION ALL` across `community_members`, `threads`, and a virtual table for Stripe failed-payments would be neater in theory but:
+- Stripe data isn't queryable from Postgres.
+- Each event type needs different metadata (post category, member display name, etc.) that's awkward in a flat UNION.
+- 10-row caps per type → at most 30+ rows merged in JS, trivial cost.
+
+## Nav update
+
+Add a "Dashboard" link to `components/admin/AdminNav.tsx` as the first item. Currently the nav lists General, Members, Subscriptions, Thread Categories, Broadcasts — and the dashboard is the route's index but has no nav entry, which is confusing. New order:
+
+1. **Dashboard** → `/${slug}/admin`
+2. General
+3. Members
+4. Subscriptions
+5. Thread Categories
+6. Broadcasts
+
+Active-state styling matches the existing nav pattern (active when `pathname === href` for Dashboard, since the index path is exact-match).
+
+## Caching & performance
+
+- Keep `dynamic = 'force-dynamic'` and `fetchCache = 'force-no-store'`. Owners want fresh numbers; this page is rarely loaded so caching pays little.
+- All Postgres queries + Stripe calls run in a single `Promise.all` at the top of the page.
+- Stripe calls (revenue current month, revenue last 5 months for chart, failed payments last 30d, account status check) — that's up to 8 Stripe calls. They run in parallel and Stripe handles concurrent requests on a Connect account fine.
+- For the failed-payments activity feed call, reuse the account-status retrieval done for the revenue tile (one `accounts.retrieve`, share the result).
+
+## Error handling
+
+- **Stripe outage / account misconfigured**: revenue tile + chart-revenue tab + failed-payments feed entries all degrade to empty/zero. The rest of the page renders normally. No page-level error.
+- **DB query fails**: page errors out via Next's default error boundary. Acceptable since the dashboard is unusable without member counts.
+- **Per-section errors**: each section component renders its own empty/error state, so one failure doesn't break the whole page.
+
+## Testing
+
+- Unit tests for the helpers in `lib/admin-dashboard-stats.ts` (extract revenue + chart computations from the page so they're testable):
+  - Stripe-revenue helper: monthly sum, MoM growth math (incl. zero-baseline edge cases).
+  - Member-growth aggregator: cumulative line over a 90d window with mixed joins/cancellations.
+  - Activity-feed merge: top-10 across types with correct DESC ordering.
+- Existing Jest setup (`bunx jest`, see `__tests__/`) — same harness already used by `ThreadView.test.tsx`.
+- Manual QA on preprod against a community with: paid + active members, paid + recent cancellations, free community (no Stripe), brand-new community (empty states).
+
+## Migration / rollout
+
+No database migration required (uses existing columns).
+
+Single PR, single deploy:
+1. Develop on `feat/admin-dashboard-redesign` (this branch).
+2. Validate on preprod via `./deploy-preprod.sh restart feat/admin-dashboard-redesign` against representative communities.
+3. PR to main → squash-merge → `./deploy.sh code` for prod.
+
+The previously-pushed branch `fix/dashboard-revenue` (a partial revenue-only fix) is **superseded by this redesign** — its work is folded into tile 1 + the revenue chart. We will close that branch's PR (if opened) without merging and delete it.
+
+## Open questions for implementation
+
+These don't block design approval; the implementation plan should resolve them:
+
+1. **Chart styling**: Recharts default theme, or wrap in shadcn's chart primitives (added to the project)? Defaulting to plain Recharts unless the codebase already uses shadcn-charts.
+2. **Activity-feed avatar source**: members have a `users.avatar_url`. Verify the join in the existing members-list query works the same way here. Failure mode: fall back to initials avatar.
+3. **"Cancelled" vs "Inactive" terminology** in the feed: schema uses both. The feed will show both as "cancelled" in plain language; data layer treats them as one bucket (mirroring tile 4).
+4. **Recharts bundle size**: Recharts isn't tiny (~90KB minzipped). Acceptable for an admin-only page that's not on the critical path. If concerns arise, lazy-load the chart island.

--- a/docs/superpowers/specs/2026-04-27-admin-dashboard-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-27-admin-dashboard-redesign-design.md
@@ -99,7 +99,7 @@ Tile visibility depends on `community.membership_enabled`:
 | 1 | **Revenue this month** — `€X` · `+Y%` MoM | *hidden* | Stripe `charges.list` for `[startOfMonth, now]`, sum `amount/100` where `status='succeeded'`. Compare against `[startOfLastMonth, startOfMonth]` for MoM. |
 | 2 | **Members** — `N total` · `M paying` | **Members** — `N total` | `SELECT COUNT(*) FILTER (WHERE status='active') AS total, COUNT(*) FILTER (WHERE status='active' AND stripe_subscription_id IS NOT NULL) AS paying FROM community_members WHERE community_id=X AND user_id != created_by` |
 | 3 | **New members this month** — `N` · `+Y%` MoM | same | `WHERE joined_at >= startOfMonth AND user_id != created_by`. Compare with `[startOfLastMonth, startOfMonth]`. |
-| 4 | **Cancellations this month** — `N` · `M last month` | *hidden* | `WHERE status IN ('inactive','cancelled') AND updated_at >= startOfMonth`. (Schema does not have a dedicated `cancelled_at` column; `updated_at` is the closest proxy.) |
+| 4 | **Cancellations this month** — `N` · `M last month` | *hidden* | `WHERE status IN ('inactive','cancelled') AND updated_at >= startOfMonth`. Both statuses mean "no longer a member" (see Members tile semantics). Schema does not have a dedicated `cancelled_at` column; `updated_at` is the proxy. |
 | 5 | **Posts this month** — `N threads` · `M replies` | same | `SELECT COUNT(*) FROM threads WHERE community_id=X AND created_at >= startOfMonth` + `SELECT COUNT(*) FROM comments WHERE thread_id IN (...) AND created_at >= startOfMonth` |
 
 ### Edge cases
@@ -109,11 +109,11 @@ Tile visibility depends on `community.membership_enabled`:
 - Last-month and this-month both `0` → `+0%`.
 - All counts default to `0` when the underlying query returns no rows.
 
-### "Members" tile semantics — important
+### "Members" tile semantics
 
-`Total` here means **currently active members** (`status='active'`), not lifetime joined. Reasoning: for a teacher running a community, "I have 23 members" means people currently in the community, not "23 people have ever joined". This also resolves the original bug where Total counted any-status rows, making the number drift upward over time as people cancelled.
+`Total` means **currently active members** (`status='active'`). In this product there is no "inactive but still a member" state — when a subscription is cancelled or fails to be paid, the member is removed from the community. The DB stores two distinct cancellation statuses (`inactive` set by the Stripe webhook on `customer.subscription.deleted`, `cancelled` set by the manual `/leave` route), but both mean the same thing in product terms: the person is no longer a member. Active is the only "current member" state.
 
-`Paying` is the subset with an active Stripe subscription. On a free community, hide the `paying` line entirely.
+`Paying` is the subset of active members that also have a Stripe subscription. On a free community, hide the `paying` line entirely.
 
 ## Chart card
 
@@ -221,5 +221,4 @@ These don't block design approval; the implementation plan should resolve them:
 
 1. **Chart styling**: Recharts default theme, or wrap in shadcn's chart primitives (added to the project)? Defaulting to plain Recharts unless the codebase already uses shadcn-charts.
 2. **Activity-feed avatar source**: members have a `users.avatar_url`. Verify the join in the existing members-list query works the same way here. Failure mode: fall back to initials avatar.
-3. **"Cancelled" vs "Inactive" terminology** in the feed: schema uses both. The feed will show both as "cancelled" in plain language; data layer treats them as one bucket (mirroring tile 4).
-4. **Recharts bundle size**: Recharts isn't tiny (~90KB minzipped). Acceptable for an admin-only page that's not on the critical path. If concerns arise, lazy-load the chart island.
+3. **Recharts bundle size**: Recharts isn't tiny (~90KB minzipped). Acceptable for an admin-only page that's not on the critical path. If concerns arise, lazy-load the chart island.

--- a/lib/admin-dashboard/activity-feed.ts
+++ b/lib/admin-dashboard/activity-feed.ts
@@ -39,8 +39,10 @@ export async function getRecentFailedPayments(
   }
 
   const sinceSec = Math.floor(now.getTime() / 1000) - THIRTY_DAYS_SECONDS;
+  // Stripe has no server-side status filter; over-fetch and filter client-side
+  // so a recent burst of succeeded charges doesn't hide older failures.
   const charges = await stripe.charges.list(
-    { created: { gte: sinceSec }, limit: 10 },
+    { created: { gte: sinceSec }, limit: 100 },
     { stripeAccount: stripeAccountId }
   );
 

--- a/lib/admin-dashboard/activity-feed.ts
+++ b/lib/admin-dashboard/activity-feed.ts
@@ -1,4 +1,6 @@
 import type { ActivityEvent } from './types';
+import { stripe } from '@/lib/stripe';
+import type Stripe from 'stripe';
 
 /**
  * Concatenate event lists, sort newest-first by `at`, slice to `limit`.
@@ -20,4 +22,35 @@ export function mergeActivityEvents(
     return diff !== 0 ? diff : a.idx - b.idx;
   });
   return flat.slice(0, limit).map((x) => x.event);
+}
+
+const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
+
+export async function getRecentFailedPayments(
+  stripeAccountId: string | null,
+  now: Date = new Date()
+): Promise<ActivityEvent[]> {
+  if (!stripeAccountId) return [];
+  try {
+    const account = await stripe.accounts.retrieve(stripeAccountId);
+    if (!account.charges_enabled) return [];
+  } catch {
+    return [];
+  }
+
+  const sinceSec = Math.floor(now.getTime() / 1000) - THIRTY_DAYS_SECONDS;
+  const charges = await stripe.charges.list(
+    { created: { gte: sinceSec }, limit: 10 },
+    { stripeAccount: stripeAccountId }
+  );
+
+  return charges.data
+    .filter((c: Stripe.Charge) => c.status === 'failed')
+    .map((c: Stripe.Charge) => ({
+      type: 'failed_payment' as const,
+      at: new Date(c.created * 1000),
+      userId: (c.metadata?.user_id as string | undefined) ?? null,
+      displayName: c.billing_details?.name ?? 'Unknown',
+      amount: c.amount / 100,
+    }));
 }

--- a/lib/admin-dashboard/activity-feed.ts
+++ b/lib/admin-dashboard/activity-feed.ts
@@ -1,0 +1,23 @@
+import type { ActivityEvent } from './types';
+
+/**
+ * Concatenate event lists, sort newest-first by `at`, slice to `limit`.
+ * Stable: equal timestamps keep their relative input order.
+ */
+export function mergeActivityEvents(
+  lists: ActivityEvent[][],
+  limit: number
+): ActivityEvent[] {
+  const flat: { event: ActivityEvent; idx: number }[] = [];
+  let counter = 0;
+  for (const list of lists) {
+    for (const event of list) {
+      flat.push({ event, idx: counter++ });
+    }
+  }
+  flat.sort((a, b) => {
+    const diff = b.event.at.getTime() - a.event.at.getTime();
+    return diff !== 0 ? diff : a.idx - b.idx;
+  });
+  return flat.slice(0, limit).map((x) => x.event);
+}

--- a/lib/admin-dashboard/stats.ts
+++ b/lib/admin-dashboard/stats.ts
@@ -1,0 +1,24 @@
+/**
+ * Calendar month range. start is inclusive (1st of month at 00:00 local),
+ * end is exclusive (1st of the *next* month). offsetMonths shifts both by N.
+ */
+export function getCalendarMonthRange(
+  now: Date = new Date(),
+  offsetMonths: number = 0
+): { start: Date; end: Date } {
+  const start = new Date(now.getFullYear(), now.getMonth() + offsetMonths, 1);
+  const end = new Date(now.getFullYear(), now.getMonth() + offsetMonths + 1, 1);
+  return { start, end };
+}
+
+/**
+ * Rounded percentage change. previous=0 with current>0 returns 100
+ * (no baseline; treated as full growth). Both 0 returns 0.
+ */
+export function computeMoMGrowth(current: number, previous: number): number {
+  if (previous > 0) {
+    return Math.round(((current - previous) / previous) * 100);
+  }
+  if (current > 0) return 100;
+  return 0;
+}

--- a/lib/admin-dashboard/stats.ts
+++ b/lib/admin-dashboard/stats.ts
@@ -1,6 +1,6 @@
 import { stripe } from '@/lib/stripe';
 import type Stripe from 'stripe';
-import type { RevenuePoint } from './types';
+import type { RevenuePoint, GrowthPoint } from './types';
 
 /**
  * Calendar month range. start is inclusive (1st of month at 00:00 local),
@@ -101,4 +101,50 @@ export async function getRevenueChart6Months(
     month: formatYearMonth(start),
     revenue: revenues[i],
   }));
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+export function buildMemberGrowthSeries({
+  now,
+  currentActiveCount,
+  joins,
+  cancellations,
+}: {
+  now: Date;
+  currentActiveCount: number;
+  joins: { at: Date }[];
+  cancellations: { at: Date }[];
+}): GrowthPoint[] {
+  const today = startOfDay(now);
+  const startDay = new Date(today.getTime() - 89 * DAY_MS);
+
+  const days: GrowthPoint[] = [];
+  for (let i = 0; i < 90; i++) {
+    const d = new Date(startDay.getTime() + i * DAY_MS);
+    days.push({
+      date: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`,
+      count: currentActiveCount,
+    });
+  }
+
+  for (const j of joins) {
+    const jDay = startOfDay(j.at);
+    if (jDay.getTime() < startDay.getTime() || jDay.getTime() > today.getTime()) continue;
+    const idx = Math.round((jDay.getTime() - startDay.getTime()) / DAY_MS);
+    for (let i = 0; i <= idx; i++) days[i].count -= 1;
+  }
+  for (const c of cancellations) {
+    const cDay = startOfDay(c.at);
+    if (cDay.getTime() < startDay.getTime() || cDay.getTime() > today.getTime()) continue;
+    const idx = Math.round((cDay.getTime() - startDay.getTime()) / DAY_MS);
+    for (let i = 0; i <= idx; i++) days[i].count += 1;
+  }
+
+  for (const d of days) if (d.count < 0) d.count = 0;
+  return days;
 }

--- a/lib/admin-dashboard/stats.ts
+++ b/lib/admin-dashboard/stats.ts
@@ -1,3 +1,6 @@
+import { stripe } from '@/lib/stripe';
+import type Stripe from 'stripe';
+
 /**
  * Calendar month range. start is inclusive (1st of month at 00:00 local),
  * end is exclusive (1st of the *next* month). offsetMonths shifts both by N.
@@ -21,4 +24,52 @@ export function computeMoMGrowth(current: number, previous: number): number {
   }
   if (current > 0) return 100;
   return 0;
+}
+
+async function sumSucceeded(
+  stripeAccountId: string,
+  start: Date,
+  end: Date
+): Promise<number> {
+  const charges = await stripe.charges.list(
+    {
+      created: {
+        gte: Math.floor(start.getTime() / 1000),
+        lt: Math.floor(end.getTime() / 1000),
+      },
+      limit: 100,
+    },
+    { stripeAccount: stripeAccountId }
+  );
+  return charges.data.reduce(
+    (total: number, c: Stripe.Charge) =>
+      c.status === 'succeeded' ? total + c.amount / 100 : total,
+    0
+  );
+}
+
+export async function getMonthlyRevenue(
+  stripeAccountId: string | null,
+  now: Date = new Date()
+): Promise<{ monthlyRevenue: number; revenueGrowth: number }> {
+  if (!stripeAccountId) return { monthlyRevenue: 0, revenueGrowth: 0 };
+
+  try {
+    const account = await stripe.accounts.retrieve(stripeAccountId);
+    if (!account.charges_enabled) return { monthlyRevenue: 0, revenueGrowth: 0 };
+  } catch {
+    return { monthlyRevenue: 0, revenueGrowth: 0 };
+  }
+
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+  const [thisMonthRevenue, lastMonthRevenue] = await Promise.all([
+    sumSucceeded(stripeAccountId, thisMonth.start, thisMonth.end),
+    sumSucceeded(stripeAccountId, lastMonth.start, lastMonth.end),
+  ]);
+
+  return {
+    monthlyRevenue: thisMonthRevenue,
+    revenueGrowth: computeMoMGrowth(thisMonthRevenue, lastMonthRevenue),
+  };
 }

--- a/lib/admin-dashboard/stats.ts
+++ b/lib/admin-dashboard/stats.ts
@@ -1,5 +1,6 @@
 import { stripe } from '@/lib/stripe';
 import type Stripe from 'stripe';
+import type { RevenuePoint } from './types';
 
 /**
  * Calendar month range. start is inclusive (1st of month at 00:00 local),
@@ -72,4 +73,32 @@ export async function getMonthlyRevenue(
     monthlyRevenue: thisMonthRevenue,
     revenueGrowth: computeMoMGrowth(thisMonthRevenue, lastMonthRevenue),
   };
+}
+
+function formatYearMonth(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export async function getRevenueChart6Months(
+  stripeAccountId: string | null,
+  now: Date = new Date()
+): Promise<RevenuePoint[]> {
+  const months = Array.from({ length: 6 }, (_, i) => getCalendarMonthRange(now, i - 5));
+  const zeros: RevenuePoint[] = months.map((m) => ({ month: formatYearMonth(m.start), revenue: 0 }));
+
+  if (!stripeAccountId) return zeros;
+  try {
+    const account = await stripe.accounts.retrieve(stripeAccountId);
+    if (!account.charges_enabled) return zeros;
+  } catch {
+    return zeros;
+  }
+
+  const revenues = await Promise.all(
+    months.map(({ start, end }) => sumSucceeded(stripeAccountId, start, end))
+  );
+  return months.map(({ start }, i) => ({
+    month: formatYearMonth(start),
+    revenue: revenues[i],
+  }));
 }

--- a/lib/admin-dashboard/types.ts
+++ b/lib/admin-dashboard/types.ts
@@ -1,0 +1,7 @@
+export type RevenuePoint = { month: string; revenue: number };
+export type GrowthPoint = { date: string; count: number };
+export type ActivityEvent =
+  | { type: 'join'; at: Date; userId: string; displayName: string; avatarUrl: string | null }
+  | { type: 'cancel'; at: Date; userId: string; displayName: string; avatarUrl: string | null }
+  | { type: 'post'; at: Date; userId: string; displayName: string; avatarUrl: string | null; threadId: string; categoryName: string | null }
+  | { type: 'failed_payment'; at: Date; userId: string | null; displayName: string; amount: number };

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-hook-form": "^7.53.1",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.3.0",
+    "recharts": "^3.8.1",
     "resend": "^6.0.1",
     "sharp": "^0.34.5",
     "stripe": "17.5.0",

--- a/supabase/migrations/20260427_add_cancelled_at_to_community_members.sql
+++ b/supabase/migrations/20260427_add_cancelled_at_to_community_members.sql
@@ -1,0 +1,8 @@
+-- Track when a community membership was cancelled.
+-- The schema previously had no timestamp for "when did this person leave",
+-- which the admin dashboard needs to count cancellations per month.
+-- Stamped by app/api/webhooks/stripe/route.ts (subscription deleted)
+-- and app/api/cron/process-community-openings/route.ts (no subscription found).
+
+ALTER TABLE community_members
+ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
## Summary

Replaces the broken 4-tile KPI grid at `/[communitySlug]/admin` with:

- An adaptive 4-tile overview (3 tiles for free communities) — Revenue, Members, New members, Cancellations, Posts — all in plain language.
- A tabbed Recharts card: revenue last 6 months (paid only) + member growth last 90 days.
- A 10-event recent-activity feed: joins, cancellations, failed payments (highlighted), and new posts.
- A Dashboard link in the admin nav, with exact-match active state for the index path.
- New `cancelled_at` column on `community_members` (stamped by the Stripe webhook + the `process-community-openings` cron when status flips to `inactive`) — the schema previously had no way to answer "when did this person leave".

Spec: `docs/superpowers/specs/2026-04-27-admin-dashboard-redesign-design.md`
Plan: `docs/superpowers/plans/2026-04-27-admin-dashboard-redesign.md`

Validated on preprod (https://preprod.dance-hub.io).

## Migration

Migration file: `supabase/migrations/20260427_add_cancelled_at_to_community_members.sql`

**Already applied to both Neon branches** (preprod `br-small-union-ahrks3mo` + prod `br-curly-voice-ah5z69fc`) before this PR is merged, so the new code's `cancelled_at` queries land on a column that exists.

## Test plan
- [ ] Paid community: 4 tiles populated; both chart tabs render; feed shows recent events
- [ ] Free community: Revenue + Cancellations hidden; chart shows Members only (no tabs)
- [ ] Community without Stripe Connect: revenue gracefully shows €0.00 / +0%
- [ ] Brand-new community: empty states for chart + feed
- [ ] Dashboard nav link: active only on `/admin`, not on subpages
- [ ] Existing cancelled members (NULL `cancelled_at`): excluded from "this month" counts — honest behavior since timestamp wasn't recorded retroactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)