### PR TITLE
fix(community): upcoming-classes widget window, dynamic, and clickable cards

### DIFF
--- a/app/api/community/[communitySlug]/upcoming-classes/route.ts
+++ b/app/api/community/[communitySlug]/upcoming-classes/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { query, queryOne } from "@/lib/db";
 
+// Force dynamic - no caching
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 interface Community {
   id: string;
 }

--- a/app/api/community/[communitySlug]/upcoming-classes/route.ts
+++ b/app/api/community/[communitySlug]/upcoming-classes/route.ts
@@ -40,11 +40,11 @@ export async function GET(
       WHERE community_id = ${community.id}
         AND (status = 'scheduled' OR status = 'live')
         AND scheduled_start_time >= NOW() - INTERVAL '2 hours'
-        AND scheduled_start_time <= NOW() + INTERVAL '24 hours'
+        AND scheduled_start_time <= NOW() + INTERVAL '14 days'
       ORDER BY
         CASE WHEN status = 'live' THEN 0 ELSE 1 END,
         scheduled_start_time ASC
-      LIMIT 3
+      LIMIT 5
     `;
 
     return NextResponse.json(classes);

--- a/components/community/CommunitySidebar.tsx
+++ b/components/community/CommunitySidebar.tsx
@@ -183,61 +183,73 @@ export default function CommunitySidebar({
           <div className="space-y-3">
             {upcomingClasses.map((cls) => {
               const isLive = cls.status === "live" || cls.is_currently_active;
-              const isStartingSoon = cls.is_starting_soon;
+              const isStartingSoon = cls.is_starting_soon && !isLive;
+              const href =
+                isLive || isStartingSoon
+                  ? `/live-class/${cls.id}`
+                  : `/${communitySlug}/calendar`;
 
               return (
-                <div
+                <Link
                   key={cls.id}
+                  href={href}
                   className={cn(
-                    "rounded-xl p-3 border transition-colors",
+                    "block rounded-xl p-3 border transition-colors",
                     isLive
-                      ? "border-red-500/30 bg-red-500/5"
-                      : "border-border/50 bg-muted/30"
+                      ? "border-red-600 bg-red-500 text-white hover:bg-red-600"
+                      : isStartingSoon
+                      ? "border-amber-600 bg-amber-500 text-white hover:bg-amber-600"
+                      : "border-border/50 bg-muted/30 hover:bg-muted/50"
                   )}
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
-                      <p className="text-sm font-medium text-foreground truncate">
+                      <p
+                        className={cn(
+                          "text-sm font-medium truncate",
+                          isLive || isStartingSoon
+                            ? "text-white"
+                            : "text-foreground"
+                        )}
+                      >
                         {cls.title}
                       </p>
                     </div>
                     {isLive && (
-                      <span className="flex items-center gap-1 text-xs font-medium text-red-500 flex-shrink-0">
+                      <span className="flex items-center gap-1 text-xs font-semibold text-white flex-shrink-0">
                         <span className="relative flex h-2 w-2">
-                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
-                          <span className="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-75" />
+                          <span className="relative inline-flex rounded-full h-2 w-2 bg-white" />
                         </span>
                         LIVE
                       </span>
                     )}
+                    {isStartingSoon && (
+                      <span className="text-xs font-semibold text-white flex-shrink-0">
+                        SOON
+                      </span>
+                    )}
                   </div>
 
-                  <p className="text-xs text-muted-foreground mt-1.5">
+                  <p
+                    className={cn(
+                      "text-xs mt-1.5",
+                      isLive || isStartingSoon
+                        ? "text-white/90"
+                        : "text-muted-foreground"
+                    )}
+                  >
                     {isLive
                       ? "Happening now"
                       : formatClassTime(cls.scheduled_start_time)}
                   </p>
 
-                  {isLive || isStartingSoon ? (
-                    <Link href={`/${communitySlug}/calendar`}>
-                      <Button
-                        size="sm"
-                        className={cn(
-                          "w-full mt-2 h-7 text-xs",
-                          isLive
-                            ? "bg-purple-600 hover:bg-purple-700 text-white"
-                            : "bg-primary hover:bg-primary/90"
-                        )}
-                      >
-                        {isLive ? "Join Now" : "Join"}
-                      </Button>
-                    </Link>
-                  ) : (
+                  {!isLive && !isStartingSoon && (
                     <p className="text-xs text-muted-foreground/70 mt-2">
                       {getTimeUntil(cls.scheduled_start_time)}
                     </p>
                   )}
-                </div>
+                </Link>
               );
             })}
           </div>


### PR DESCRIPTION
## Summary
- Widen the sidebar widget's lookahead from 24 h / 3 results to 14 days / 5 results so a class scheduled later this/next week actually shows up.
- Force the API route dynamic — without `dynamic = 'force-dynamic'`, Next.js was caching the Neon `fetch` call at build time and serving stale (often empty) results forever. Matches the pattern other routes under `app/api/community/[communitySlug]` already use.
- Make each card a clickable link and align its colors with the calendar's `LiveClassCard`: red for live, amber for "starting soon", neutral muted for plain scheduled. Live/soon cards deep-link to `/live-class/{id}`; scheduled cards go to the community calendar.

## Test plan
- [x] Verified on preprod: a class 3 days out now appears.
- [x] API returns the row for `bachataflowlive` after the dynamic flag was added.
- [ ] Eyeball the live/amber/neutral states on prod once a class is live or within 15 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)