### PR TITLE
feat(admin): redesign platform dashboard (cycle 1 of admin overhaul)

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,143 +1,91 @@
-import { sql } from '@/lib/db';
-import { Users, MessageSquare, CreditCard, DollarSign, Percent } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { headers } from 'next/headers';
+import {
+  getUserStats,
+  getCommunityStats,
+  getGrowthSeries90Days,
+} from '@/lib/admin-platform/stats';
+import {
+  getMonthlyRevenueStats,
+  getRevenueChart6Months,
+  getActiveSubscriptionsStats,
+} from '@/lib/admin-platform/revenue';
+import {
+  getRecentSignups,
+  getRecentCommunities,
+  getRecentAdminActions,
+  getRecentFailedPaymentsAcrossPlatform,
+  mergePlatformEvents,
+} from '@/lib/admin-platform/activity-feed';
+import { PlatformDashboardKpis } from '@/components/admin/platform/PlatformDashboardKpis';
+import { PlatformDashboardChart } from '@/components/admin/platform/PlatformDashboardChart';
+import { PlatformDashboardActivityFeed } from '@/components/admin/platform/PlatformDashboardActivityFeed';
+import type { PlatformStats } from '@/lib/admin-platform/types';
 
-interface AdminAccessLog {
-  id: string;
-  action: string;
-  resource_type: string;
-  created_at: string;
-}
-
-async function getAdminStats() {
-  const headersList = headers();
-  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https';
-  const host = headersList.get('host') || '';
-  const baseUrl = `${protocol}://${host}`;
-
-  const [
-    usersCountResult,
-    communitiesCountResult,
-    threadsCountResult,
-    recentActivity,
-    subscriptionStats
-  ] = await Promise.all([
-    sql`SELECT COUNT(*) as count FROM profiles`,
-    sql`SELECT COUNT(*) as count FROM communities`,
-    sql`SELECT COUNT(*) as count FROM threads`,
-    sql`SELECT * FROM admin_access_log ORDER BY created_at DESC LIMIT 5`,
-    fetch(`${baseUrl}/api/admin/subscriptions`).then(res => {
-      if (!res.ok) {
-        console.error('Failed to fetch subscription stats:', res.status);
-        return { total_active_subscriptions: 0, total_recurring_revenue: 0, platform_revenue: 0 };
-      }
-      return res.json();
-    }).catch(err => {
-      console.error('Error fetching subscription stats:', err);
-      return { total_active_subscriptions: 0, total_recurring_revenue: 0, platform_revenue: 0 };
-    })
-  ]);
-
-  return {
-    usersCount: Number(usersCountResult[0]?.count) || 0,
-    communitiesCount: Number(communitiesCountResult[0]?.count) || 0,
-    threadsCount: Number(threadsCountResult[0]?.count) || 0,
-    recentActivity: recentActivity as AdminAccessLog[],
-    subscriptionStats
-  };
-}
+export const dynamic = 'force-dynamic';
+export const fetchCache = 'force-no-store';
 
 export default async function AdminDashboard() {
-  const stats = await getAdminStats();
+  const now = new Date();
 
-  const StatCard = ({ title, value, icon: Icon, subtitle }: {
-    title: string;
-    value: number | string;
-    icon: React.ComponentType<{ className?: string }>;
-    subtitle?: string;
-  }) => (
-    <Card className="overflow-hidden">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 px-4 pt-4">
-        <CardTitle className="text-xs font-medium">
-          {title}
-        </CardTitle>
-        <Icon className="h-4 w-4 text-muted-foreground" />
-      </CardHeader>
-      <CardContent className="px-4 pb-4">
-        <div className="text-xl font-bold">{value}</div>
-        {subtitle && (
-          <p className="text-[10px] text-muted-foreground mt-0.5 line-clamp-1">
-            {subtitle}
-          </p>
-        )}
-      </CardContent>
-    </Card>
-  );
+  const [
+    userStats,
+    communityStats,
+    revenueStats,
+    subscriptionStats,
+    revenueChart,
+    growthSeries,
+    signups,
+    communities,
+    adminActions,
+    failedPayments,
+  ] = await Promise.all([
+    getUserStats(now),
+    getCommunityStats(now),
+    getMonthlyRevenueStats(now),
+    getActiveSubscriptionsStats(now),
+    getRevenueChart6Months(now),
+    getGrowthSeries90Days(now),
+    getRecentSignups(),
+    getRecentCommunities(),
+    getRecentAdminActions(),
+    getRecentFailedPaymentsAcrossPlatform(now),
+  ]);
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD'
-    }).format(amount);
+  const stats: PlatformStats = {
+    usersTotal: userStats.total,
+    newUsersThisMonth: userStats.newThisMonth,
+    newUsersGrowth: userStats.growth,
+    communitiesTotal: communityStats.total,
+    newCommunitiesThisMonth: communityStats.newThisMonth,
+    newCommunitiesGrowth: communityStats.growth,
+    activeSubscriptions: subscriptionStats.count,
+    activeSubscriptionsGrowth: subscriptionStats.growth,
+    platformRevenueThisMonth: revenueStats.platformRevenueThisMonth,
+    platformRevenueGrowth: revenueStats.platformRevenueGrowth,
+    communitiesRevenueThisMonth: revenueStats.communitiesRevenueThisMonth,
+    communitiesRevenueGrowth: revenueStats.communitiesRevenueGrowth,
   };
 
+  const events = mergePlatformEvents(
+    [signups, communities, adminActions, failedPayments],
+    10
+  );
+
   return (
-    <div className="space-y-6">
-      <h2 className="text-3xl font-bold tracking-tight">Admin Dashboard</h2>
+    <div className="animate-in fade-in slide-in-from-bottom-1 duration-500 space-y-8">
+      <header>
+        <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] text-foreground">
+          Dashboard
+        </h1>
+        <p className="text-muted-foreground mt-2">
+          Platform-wide overview across all communities, users, and revenue.
+        </p>
+      </header>
 
-      <div className="grid gap-3 grid-cols-5">
-        <StatCard
-          title="Total Users"
-          value={stats.usersCount || 0}
-          icon={Users}
-        />
-        <StatCard
-          title="Communities"
-          value={stats.communitiesCount || 0}
-          icon={MessageSquare}
-        />
-        <StatCard
-          title="Active Subscriptions"
-          value={stats.subscriptionStats?.total_active_subscriptions || 0}
-          icon={CreditCard}
-        />
-        <StatCard
-          title="Communities Revenue"
-          value={formatCurrency(stats.subscriptionStats?.total_recurring_revenue || 0)}
-          icon={DollarSign}
-          subtitle="Total monthly revenue across all communities"
-        />
-        <StatCard
-          title="Platform Revenue"
-          value={formatCurrency(stats.subscriptionStats?.platform_revenue || 0)}
-          icon={Percent}
-          subtitle="Monthly revenue from platform fees"
-        />
-      </div>
+      <PlatformDashboardKpis stats={stats} />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Recent Activity</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {stats.recentActivity?.map((activity) => (
-              <div
-                key={activity.id}
-                className="flex flex-col space-y-1 border-b pb-4 last:border-0"
-              >
-                <p className="text-sm text-muted-foreground">
-                  {new Date(activity.created_at).toLocaleString()}
-                </p>
-                <p className="text-sm">
-                  {activity.action} - {activity.resource_type}
-                </p>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      <PlatformDashboardChart revenue={revenueChart} growth={growthSeries} />
+
+      <PlatformDashboardActivityFeed events={events} />
     </div>
   );
 }

--- a/components/admin/platform/PlatformDashboardActivityFeed.tsx
+++ b/components/admin/platform/PlatformDashboardActivityFeed.tsx
@@ -1,0 +1,133 @@
+import { formatDistanceToNow } from 'date-fns';
+import Link from 'next/link';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  UserPlus,
+  Sparkles,
+  ShieldCheck,
+  AlertTriangle,
+} from 'lucide-react';
+import type { PlatformActivityEvent } from '@/lib/admin-platform/types';
+
+export function PlatformDashboardActivityFeed({
+  events,
+}: {
+  events: PlatformActivityEvent[];
+}) {
+  if (events.length === 0) {
+    return (
+      <div className="bg-card rounded-2xl border border-border/50 p-6">
+        <h2 className="font-display text-lg font-semibold mb-4">Recent activity</h2>
+        <p className="text-sm text-muted-foreground text-center py-8">
+          No recent activity yet
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-2xl border border-border/50 p-6">
+      <h2 className="font-display text-lg font-semibold mb-4">Recent activity</h2>
+      <ul className="space-y-3">
+        {events.map((e, i) => (
+          <ActivityRow key={`${e.type}-${e.at.getTime()}-${i}`} event={e} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ActivityRow({ event }: { event: PlatformActivityEvent }) {
+  const ago = formatDistanceToNow(event.at, { addSuffix: true });
+
+  if (event.type === 'failed_payment') {
+    return (
+      <li className="flex items-start gap-3 p-3 rounded-xl bg-amber-50/40 border border-amber-200/40">
+        <div className="h-9 w-9 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+          <AlertTriangle className="h-4 w-4 text-amber-700" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm">
+            <span className="font-medium">{event.displayName}</span>'s payment of €
+            {event.amount.toFixed(2)} failed
+            {event.communitySlug ? (
+              <>
+                {' '}in{' '}
+                <Link
+                  href={`/${event.communitySlug}`}
+                  className="text-primary hover:underline font-medium"
+                >
+                  {event.communitySlug}
+                </Link>
+              </>
+            ) : null}
+          </p>
+          <p className="text-xs text-muted-foreground">{ago}</p>
+        </div>
+      </li>
+    );
+  }
+
+  if (event.type === 'admin_action') {
+    return (
+      <li className="flex items-start gap-3">
+        <div className="h-9 w-9 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+          <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm">
+            <span className="font-medium">{event.adminName ?? 'Admin'}</span>{' '}
+            <span className="text-muted-foreground">
+              {event.action}
+              {event.resourceType ? ` ${event.resourceType}` : ''}
+            </span>
+          </p>
+          <p className="text-xs text-muted-foreground">{ago}</p>
+        </div>
+      </li>
+    );
+  }
+
+  // signup or community_created
+  const icon =
+    event.type === 'signup' ? (
+      <UserPlus className="h-4 w-4 text-primary" />
+    ) : (
+      <Sparkles className="h-4 w-4 text-secondary" />
+    );
+
+  return (
+    <li className="flex items-start gap-3">
+      <Avatar className="h-9 w-9 flex-shrink-0">
+        {event.avatarUrl ? (
+          <AvatarImage src={event.avatarUrl} alt={event.displayName} />
+        ) : null}
+        <AvatarFallback className="bg-primary/10 text-primary text-xs">
+          {event.displayName[0]?.toUpperCase() ?? '?'}
+        </AvatarFallback>
+      </Avatar>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm">
+          <span className="font-medium">{event.displayName}</span>{' '}
+          {event.type === 'signup' ? (
+            <span className="text-muted-foreground">signed up</span>
+          ) : (
+            <>
+              <span className="text-muted-foreground">created </span>
+              <Link
+                href={`/${event.communitySlug}`}
+                className="text-primary hover:underline font-medium"
+              >
+                {event.communityName}
+              </Link>
+            </>
+          )}
+        </p>
+        <p className="text-xs text-muted-foreground">{ago}</p>
+      </div>
+      <div className="hidden sm:flex h-9 w-9 rounded-full bg-muted/50 items-center justify-center flex-shrink-0">
+        {icon}
+      </div>
+    </li>
+  );
+}

--- a/components/admin/platform/PlatformDashboardChart.tsx
+++ b/components/admin/platform/PlatformDashboardChart.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Legend,
+} from 'recharts';
+import type {
+  PlatformRevenuePoint,
+  PlatformGrowthPoint,
+} from '@/lib/admin-platform/types';
+
+export function PlatformDashboardChart({
+  revenue,
+  growth,
+}: {
+  revenue: PlatformRevenuePoint[];
+  growth: PlatformGrowthPoint[];
+}) {
+  const hasRevenue = revenue.some((p) => p.total > 0 || p.platformFees > 0);
+  const hasGrowth = growth.some((p) => p.users > 0 || p.communities > 0);
+
+  return (
+    <div className="bg-card rounded-2xl border border-border/50 p-6">
+      <Tabs defaultValue="revenue">
+        <TabsList className="mb-4">
+          <TabsTrigger value="revenue">Revenue</TabsTrigger>
+          <TabsTrigger value="growth">Growth</TabsTrigger>
+        </TabsList>
+        <TabsContent value="revenue">
+          {hasRevenue ? <RevenueChart data={revenue} /> : <EmptyState />}
+        </TabsContent>
+        <TabsContent value="growth">
+          {hasGrowth ? <GrowthChart data={growth} /> : <EmptyState />}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function RevenueChart({ data }: { data: PlatformRevenuePoint[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-border/40" />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} className="text-xs" />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          className="text-xs"
+          tickFormatter={(v) => `€${Math.round(Number(v))}`}
+        />
+        <Tooltip
+          formatter={(value, name) =>
+            [
+              `€${Number(value).toFixed(2)}`,
+              name === 'total' ? 'Communities revenue' : 'Platform fees',
+            ] as [string, string]
+          }
+        />
+        <Legend
+          formatter={(value) =>
+            value === 'total' ? 'Communities revenue' : 'Platform fees'
+          }
+        />
+        <Bar dataKey="total" fill="hsl(var(--primary))" radius={[6, 6, 0, 0]} />
+        <Bar dataKey="platformFees" fill="hsl(var(--secondary))" radius={[6, 6, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function GrowthChart({ data }: { data: PlatformGrowthPoint[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <LineChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-border/40" />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          className="text-xs"
+          interval={14}
+        />
+        <YAxis tickLine={false} axisLine={false} className="text-xs" allowDecimals={false} />
+        <Tooltip />
+        <Legend />
+        <Line
+          type="monotone"
+          dataKey="users"
+          name="Users"
+          stroke="hsl(var(--primary))"
+          strokeWidth={2}
+          dot={false}
+        />
+        <Line
+          type="monotone"
+          dataKey="communities"
+          name="Communities"
+          stroke="hsl(var(--secondary))"
+          strokeWidth={2}
+          dot={false}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="h-[280px] flex items-center justify-center text-sm text-muted-foreground">
+      Not enough data yet
+    </div>
+  );
+}

--- a/components/admin/platform/PlatformDashboardKpis.tsx
+++ b/components/admin/platform/PlatformDashboardKpis.tsx
@@ -1,0 +1,119 @@
+import {
+  Users,
+  MessageSquare,
+  CreditCard,
+  DollarSign,
+  Percent,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+} from 'lucide-react';
+import type { PlatformStats } from '@/lib/admin-platform/types';
+
+export function PlatformDashboardKpis({ stats }: { stats: PlatformStats }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4">
+      <Tile
+        label="Users"
+        value={stats.usersTotal.toLocaleString()}
+        sublineNumber={stats.newUsersGrowth}
+        sublineSuffix={`${stats.newUsersThisMonth} new this month`}
+        icon={<Users className="h-5 w-5 text-primary" />}
+        iconBg="bg-primary/10"
+      />
+      <Tile
+        label="Communities"
+        value={stats.communitiesTotal.toLocaleString()}
+        sublineNumber={stats.newCommunitiesGrowth}
+        sublineSuffix={`${stats.newCommunitiesThisMonth} new this month`}
+        icon={<MessageSquare className="h-5 w-5 text-primary" />}
+        iconBg="bg-primary/10"
+      />
+      <Tile
+        label="Active subscriptions"
+        value={stats.activeSubscriptions.toLocaleString()}
+        sublineNumber={stats.activeSubscriptionsGrowth}
+        sublineSuffix="vs last month"
+        icon={<CreditCard className="h-5 w-5 text-secondary" />}
+        iconBg="bg-secondary/20"
+      />
+      <Tile
+        label="Communities revenue"
+        value={formatCurrency(stats.communitiesRevenueThisMonth)}
+        sublineNumber={stats.communitiesRevenueGrowth}
+        sublineSuffix="vs last month"
+        icon={<DollarSign className="h-5 w-5 text-secondary" />}
+        iconBg="bg-secondary/20"
+      />
+      <Tile
+        label="Platform revenue"
+        value={formatCurrency(stats.platformRevenueThisMonth)}
+        sublineNumber={stats.platformRevenueGrowth}
+        sublineSuffix="vs last month"
+        icon={<Percent className="h-5 w-5 text-accent" />}
+        iconBg="bg-accent/20"
+      />
+    </div>
+  );
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: amount >= 1000 ? 0 : 2,
+  }).format(amount);
+}
+
+function Tile({
+  label,
+  value,
+  sublineNumber,
+  sublineSuffix,
+  icon,
+  iconBg,
+}: {
+  label: string;
+  value: string;
+  sublineNumber?: number;
+  sublineSuffix?: string;
+  icon: React.ReactNode;
+  iconBg: string;
+}) {
+  const n = typeof sublineNumber === 'number' ? sublineNumber : null;
+  const trend: 'up' | 'down' | 'flat' | null =
+    n === null ? null : n > 0 ? 'up' : n < 0 ? 'down' : 'flat';
+
+  return (
+    <div className="bg-card rounded-2xl p-6 border-2 border-transparent hover:border-primary/20 hover:shadow-lg transition-all duration-300 ease-out space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-muted-foreground">{label}</h3>
+        <div className={`h-10 w-10 rounded-xl ${iconBg} flex items-center justify-center`}>
+          {icon}
+        </div>
+      </div>
+      <p className="font-display text-3xl font-bold text-foreground">{value}</p>
+      {trend ? (
+        <p
+          className={`text-sm font-medium ${
+            trend === 'up'
+              ? 'text-primary'
+              : trend === 'down'
+              ? 'text-destructive'
+              : 'text-muted-foreground'
+          }`}
+        >
+          {trend === 'up' ? (
+            <TrendingUp className="h-4 w-4 inline mr-1" />
+          ) : trend === 'down' ? (
+            <TrendingDown className="h-4 w-4 inline mr-1" />
+          ) : (
+            <Minus className="h-4 w-4 inline mr-1" />
+          )}
+          {trend === 'up' ? '+' : ''}
+          {sublineNumber}% {sublineSuffix}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/lib/admin-platform/activity-feed.ts
+++ b/lib/admin-platform/activity-feed.ts
@@ -1,0 +1,176 @@
+import { query } from '@/lib/db';
+import { stripe } from '@/lib/stripe';
+import type Stripe from 'stripe';
+import type { PlatformActivityEvent } from './types';
+import { getAllConnectedAccountIds } from './revenue';
+
+type SignupRow = {
+  auth_user_id: string;
+  display_name: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+  created_at: Date;
+};
+
+type CommunityRow = {
+  created_by: string;
+  display_name: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+  community_name: string;
+  community_slug: string;
+  created_at: Date;
+};
+
+type AdminLogRow = {
+  action: string;
+  resource_type: string | null;
+  display_name: string | null;
+  full_name: string | null;
+  created_at: Date;
+};
+
+type StripeAccountRow = {
+  stripe_account_id: string;
+  slug: string;
+};
+
+const FEED_LOOKBACK_DAYS = 30;
+const PER_SOURCE_LIMIT = 20;
+
+/**
+ * Concatenate event lists, sort newest-first by `at`, slice to `limit`.
+ * Identical contract to mergeActivityEvents in lib/admin-dashboard, but
+ * typed for PlatformActivityEvent so the two feeds stay independent.
+ */
+export function mergePlatformEvents(
+  lists: PlatformActivityEvent[][],
+  limit: number
+): PlatformActivityEvent[] {
+  const flat: { event: PlatformActivityEvent; idx: number }[] = [];
+  let counter = 0;
+  for (const list of lists) {
+    for (const event of list) flat.push({ event, idx: counter++ });
+  }
+  flat.sort((a, b) => {
+    const diff = b.event.at.getTime() - a.event.at.getTime();
+    return diff !== 0 ? diff : a.idx - b.idx;
+  });
+  return flat.slice(0, limit).map((x) => x.event);
+}
+
+export async function getRecentSignups(): Promise<PlatformActivityEvent[]> {
+  const rows = await query<SignupRow>`
+    SELECT auth_user_id, display_name, full_name, avatar_url, created_at
+    FROM profiles
+    ORDER BY created_at DESC
+    LIMIT ${PER_SOURCE_LIMIT}
+  `;
+  return rows.map((r) => ({
+    type: 'signup' as const,
+    at: new Date(r.created_at),
+    userId: r.auth_user_id,
+    displayName: r.display_name ?? r.full_name ?? 'Anonymous',
+    avatarUrl: r.avatar_url,
+  }));
+}
+
+export async function getRecentCommunities(): Promise<PlatformActivityEvent[]> {
+  const rows = await query<CommunityRow>`
+    SELECT
+      c.created_by,
+      p.display_name,
+      p.full_name,
+      p.avatar_url,
+      c.name AS community_name,
+      c.slug AS community_slug,
+      c.created_at
+    FROM communities c
+    LEFT JOIN profiles p ON p.auth_user_id = c.created_by
+    ORDER BY c.created_at DESC
+    LIMIT ${PER_SOURCE_LIMIT}
+  `;
+  return rows.map((r) => ({
+    type: 'community_created' as const,
+    at: new Date(r.created_at),
+    userId: r.created_by,
+    displayName: r.display_name ?? r.full_name ?? 'Anonymous',
+    avatarUrl: r.avatar_url,
+    communityName: r.community_name,
+    communitySlug: r.community_slug,
+  }));
+}
+
+export async function getRecentAdminActions(): Promise<PlatformActivityEvent[]> {
+  const rows = await query<AdminLogRow>`
+    SELECT
+      l.action,
+      l.resource_type,
+      p.display_name,
+      p.full_name,
+      l.created_at
+    FROM admin_access_log l
+    LEFT JOIN profiles p ON p.id = l.admin_id
+    ORDER BY l.created_at DESC
+    LIMIT ${PER_SOURCE_LIMIT}
+  `;
+  return rows.map((r) => ({
+    type: 'admin_action' as const,
+    at: new Date(r.created_at),
+    action: r.action,
+    resourceType: r.resource_type ?? '',
+    adminName: r.display_name ?? r.full_name,
+  }));
+}
+
+/**
+ * Failed charges across every connected account in the last 30 days.
+ * autoPagingToArray walks pages so a busy account isn't truncated.
+ */
+export async function getRecentFailedPaymentsAcrossPlatform(
+  now: Date = new Date()
+): Promise<PlatformActivityEvent[]> {
+  const sinceSec =
+    Math.floor(now.getTime() / 1000) - FEED_LOOKBACK_DAYS * 24 * 60 * 60;
+
+  const accountRows = await query<StripeAccountRow>`
+    SELECT stripe_account_id, slug
+    FROM communities
+    WHERE stripe_account_id IS NOT NULL
+  `;
+
+  const perAccount = await Promise.all(
+    accountRows.map(async (a) => {
+      try {
+        const account = await stripe.accounts.retrieve(a.stripe_account_id);
+        if (!account.charges_enabled) return [] as PlatformActivityEvent[];
+      } catch {
+        return [] as PlatformActivityEvent[];
+      }
+
+      const charges = await stripe.charges
+        .list(
+          { created: { gte: sinceSec }, limit: 100 },
+          { stripeAccount: a.stripe_account_id }
+        )
+        .autoPagingToArray({ limit: 1000 });
+
+      return charges
+        .filter((c: Stripe.Charge) => c.status === 'failed')
+        .slice(0, PER_SOURCE_LIMIT)
+        .map<PlatformActivityEvent>((c) => ({
+          type: 'failed_payment' as const,
+          at: new Date(c.created * 1000),
+          displayName: c.billing_details?.name ?? 'Unknown',
+          amount: c.amount / 100,
+          communitySlug: a.slug,
+        }));
+    })
+  );
+
+  // Mark intentional unused — getAllConnectedAccountIds isn't reused here
+  // because we need slugs alongside ids; kept as exported helper for revenue.ts.
+  void getAllConnectedAccountIds;
+
+  return perAccount.flat();
+}

--- a/lib/admin-platform/revenue.ts
+++ b/lib/admin-platform/revenue.ts
@@ -1,0 +1,222 @@
+import { stripe } from '@/lib/stripe';
+import { query } from '@/lib/db';
+import type Stripe from 'stripe';
+import {
+  getCalendarMonthRange,
+  computeMoMGrowth,
+} from '@/lib/admin-dashboard/stats';
+import type { PlatformRevenuePoint } from './types';
+
+type CommunityRow = { stripe_account_id: string | null };
+
+export async function getAllConnectedAccountIds(): Promise<string[]> {
+  const rows = await query<CommunityRow>`
+    SELECT stripe_account_id
+    FROM communities
+    WHERE stripe_account_id IS NOT NULL
+  `;
+  return rows.map((r) => r.stripe_account_id!).filter(Boolean);
+}
+
+/**
+ * Sum of application_fee.amount (platform's slice) on the platform account
+ * within the given window. autoPagingToArray walks all pages so very busy
+ * months don't get truncated.
+ */
+async function sumPlatformFees(start: Date, end: Date): Promise<number> {
+  const fees = await stripe.applicationFees
+    .list({
+      created: {
+        gte: Math.floor(start.getTime() / 1000),
+        lt: Math.floor(end.getTime() / 1000),
+      },
+      limit: 100,
+    })
+    .autoPagingToArray({ limit: 1000 });
+  return fees.reduce((sum, f) => sum + f.amount / 100, 0);
+}
+
+/**
+ * Sum of succeeded charge amounts on a single connected account within
+ * the given window.
+ */
+async function sumSucceededOnAccount(
+  stripeAccountId: string,
+  start: Date,
+  end: Date
+): Promise<number> {
+  try {
+    const account = await stripe.accounts.retrieve(stripeAccountId);
+    if (!account.charges_enabled) return 0;
+  } catch {
+    return 0;
+  }
+
+  const charges = await stripe.charges
+    .list(
+      {
+        created: {
+          gte: Math.floor(start.getTime() / 1000),
+          lt: Math.floor(end.getTime() / 1000),
+        },
+        limit: 100,
+      },
+      { stripeAccount: stripeAccountId }
+    )
+    .autoPagingToArray({ limit: 1000 });
+  return charges.reduce(
+    (total, c: Stripe.Charge) =>
+      c.status === 'succeeded' ? total + c.amount / 100 : total,
+    0
+  );
+}
+
+async function sumCommunitiesRevenue(
+  accountIds: string[],
+  start: Date,
+  end: Date
+): Promise<number> {
+  if (accountIds.length === 0) return 0;
+  const perAccount = await Promise.all(
+    accountIds.map((id) => sumSucceededOnAccount(id, start, end))
+  );
+  return perAccount.reduce((sum, v) => sum + v, 0);
+}
+
+/**
+ * This-month and last-month totals for both revenue streams + MoM growth.
+ * One Promise.all to parallelize the four sums.
+ */
+export async function getMonthlyRevenueStats(now: Date = new Date()) {
+  const accountIds = await getAllConnectedAccountIds();
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+
+  const [platformThis, platformLast, commThis, commLast] = await Promise.all([
+    sumPlatformFees(thisMonth.start, thisMonth.end),
+    sumPlatformFees(lastMonth.start, lastMonth.end),
+    sumCommunitiesRevenue(accountIds, thisMonth.start, thisMonth.end),
+    sumCommunitiesRevenue(accountIds, lastMonth.start, lastMonth.end),
+  ]);
+
+  return {
+    platformRevenueThisMonth: platformThis,
+    platformRevenueGrowth: computeMoMGrowth(platformThis, platformLast),
+    communitiesRevenueThisMonth: commThis,
+    communitiesRevenueGrowth: computeMoMGrowth(commThis, commLast),
+  };
+}
+
+/**
+ * Last 6 months — one PlatformRevenuePoint per month with both series.
+ */
+export async function getRevenueChart6Months(
+  now: Date = new Date()
+): Promise<PlatformRevenuePoint[]> {
+  const accountIds = await getAllConnectedAccountIds();
+  const months = Array.from({ length: 6 }, (_, i) => getCalendarMonthRange(now, i - 5));
+
+  const results = await Promise.all(
+    months.map(async ({ start, end }) => {
+      const [platform, community] = await Promise.all([
+        sumPlatformFees(start, end),
+        sumCommunitiesRevenue(accountIds, start, end),
+      ]);
+      return { platform, community };
+    })
+  );
+
+  return months.map(({ start }, i) => ({
+    month: `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`,
+    total: results[i].community,
+    platformFees: results[i].platform,
+  }));
+}
+
+/**
+ * Active subscriptions across the platform account + every connected account.
+ * MoM growth compares this-month-end count to last-month-end count via
+ * subscriptions created/cancelled in those windows — Stripe doesn't expose
+ * a "count at point in time" so we approximate with current count vs.
+ * (current - net new this month).
+ */
+export async function getActiveSubscriptionsStats(
+  now: Date = new Date()
+): Promise<{ count: number; growth: number }> {
+  const accountIds = await getAllConnectedAccountIds();
+
+  const platformSubs = await stripe.subscriptions
+    .list({ status: 'active', limit: 100 })
+    .autoPagingToArray({ limit: 1000 });
+
+  const connectedCounts = await Promise.all(
+    accountIds.map(async (id) => {
+      try {
+        const account = await stripe.accounts.retrieve(id);
+        if (!account.charges_enabled) return 0;
+      } catch {
+        return 0;
+      }
+      const subs = await stripe.subscriptions
+        .list({ status: 'active', limit: 100 }, { stripeAccount: id })
+        .autoPagingToArray({ limit: 1000 });
+      return subs.length;
+    })
+  );
+
+  const total = platformSubs.length + connectedCounts.reduce((a, b) => a + b, 0);
+
+  // Approximate MoM: count subs created this month minus those cancelled
+  // this month (across all accounts), against last month's same delta.
+  // Cheap heuristic — good enough for a dashboard signal.
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+  const [thisDelta, lastDelta] = await Promise.all([
+    deltaInWindow(accountIds, thisMonth.start, thisMonth.end),
+    deltaInWindow(accountIds, lastMonth.start, lastMonth.end),
+  ]);
+
+  return {
+    count: total,
+    growth: computeMoMGrowth(thisDelta, lastDelta),
+  };
+}
+
+async function deltaInWindow(
+  accountIds: string[],
+  start: Date,
+  end: Date
+): Promise<number> {
+  const sinceSec = Math.floor(start.getTime() / 1000);
+  const untilSec = Math.floor(end.getTime() / 1000);
+
+  // Platform-account net new (created in window, minus cancelled in window).
+  const created = await stripe.subscriptions
+    .list({ created: { gte: sinceSec, lt: untilSec }, limit: 100 })
+    .autoPagingToArray({ limit: 1000 });
+  const cancelled = created.filter(
+    (s) => s.canceled_at && s.canceled_at >= sinceSec && s.canceled_at < untilSec
+  ).length;
+
+  let total = created.length - cancelled;
+
+  for (const id of accountIds) {
+    try {
+      const account = await stripe.accounts.retrieve(id);
+      if (!account.charges_enabled) continue;
+    } catch {
+      continue;
+    }
+    const sub = await stripe.subscriptions
+      .list(
+        { created: { gte: sinceSec, lt: untilSec }, limit: 100 },
+        { stripeAccount: id }
+      )
+      .autoPagingToArray({ limit: 1000 });
+    const subCancelled = sub.filter(
+      (s) => s.canceled_at && s.canceled_at >= sinceSec && s.canceled_at < untilSec
+    ).length;
+    total += sub.length - subCancelled;
+  }
+  return total;
+}

--- a/lib/admin-platform/stats.ts
+++ b/lib/admin-platform/stats.ts
@@ -1,0 +1,145 @@
+import { queryOne, query } from '@/lib/db';
+import {
+  getCalendarMonthRange,
+  computeMoMGrowth,
+} from '@/lib/admin-dashboard/stats';
+import type { PlatformGrowthPoint } from './types';
+
+type CountRow = { count: number };
+
+/**
+ * Total profiles count + new this month + MoM growth.
+ */
+export async function getUserStats(now: Date = new Date()) {
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+
+  const [total, thisCount, lastCount] = await Promise.all([
+    queryOne<CountRow>`SELECT COUNT(*)::int AS count FROM profiles`,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM profiles
+      WHERE created_at >= ${thisMonth.start.toISOString()}
+        AND created_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM profiles
+      WHERE created_at >= ${lastMonth.start.toISOString()}
+        AND created_at < ${lastMonth.end.toISOString()}
+    `,
+  ]);
+
+  const newThisMonth = thisCount?.count ?? 0;
+  const newLastMonth = lastCount?.count ?? 0;
+  return {
+    total: total?.count ?? 0,
+    newThisMonth,
+    growth: computeMoMGrowth(newThisMonth, newLastMonth),
+  };
+}
+
+/**
+ * Total communities count + new this month + MoM growth.
+ */
+export async function getCommunityStats(now: Date = new Date()) {
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+
+  const [total, thisCount, lastCount] = await Promise.all([
+    queryOne<CountRow>`SELECT COUNT(*)::int AS count FROM communities`,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM communities
+      WHERE created_at >= ${thisMonth.start.toISOString()}
+        AND created_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM communities
+      WHERE created_at >= ${lastMonth.start.toISOString()}
+        AND created_at < ${lastMonth.end.toISOString()}
+    `,
+  ]);
+
+  const newThisMonth = thisCount?.count ?? 0;
+  const newLastMonth = lastCount?.count ?? 0;
+  return {
+    total: total?.count ?? 0,
+    newThisMonth,
+    growth: computeMoMGrowth(newThisMonth, newLastMonth),
+  };
+}
+
+/**
+ * Cumulative users + communities, day-by-day, for the last 90 days.
+ * Both series live on the same chart — see PlatformDashboardChart.
+ */
+export async function getGrowthSeries90Days(
+  now: Date = new Date()
+): Promise<PlatformGrowthPoint[]> {
+  const today = startOfDay(now);
+  const startDay = new Date(today.getTime() - 89 * DAY_MS);
+
+  const [users, communities, totalUsers, totalCommunities] = await Promise.all([
+    query<{ created_at: Date }>`
+      SELECT created_at
+      FROM profiles
+      WHERE created_at >= ${startDay.toISOString()}
+    `,
+    query<{ created_at: Date }>`
+      SELECT created_at
+      FROM communities
+      WHERE created_at >= ${startDay.toISOString()}
+    `,
+    queryOne<CountRow>`SELECT COUNT(*)::int AS count FROM profiles`,
+    queryOne<CountRow>`SELECT COUNT(*)::int AS count FROM communities`,
+  ]);
+
+  const days: PlatformGrowthPoint[] = [];
+  for (let i = 0; i < 90; i++) {
+    const d = new Date(startDay.getTime() + i * DAY_MS);
+    days.push({
+      date: formatDate(d),
+      users: totalUsers?.count ?? 0,
+      communities: totalCommunities?.count ?? 0,
+    });
+  }
+
+  // Walk backward: each event in the window means the count was 1 lower
+  // on every day at-or-before the event day.
+  for (const u of users) {
+    const idx = dayIndex(u.created_at, startDay, today);
+    if (idx === null) continue;
+    for (let i = 0; i <= idx; i++) days[i].users -= 1;
+  }
+  for (const c of communities) {
+    const idx = dayIndex(c.created_at, startDay, today);
+    if (idx === null) continue;
+    for (let i = 0; i <= idx; i++) days[i].communities -= 1;
+  }
+
+  for (const d of days) {
+    if (d.users < 0) d.users = 0;
+    if (d.communities < 0) d.communities = 0;
+  }
+  return days;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function formatDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function dayIndex(at: Date, startDay: Date, today: Date): number | null {
+  const day = startOfDay(new Date(at));
+  if (day.getTime() < startDay.getTime() || day.getTime() > today.getTime()) {
+    return null;
+  }
+  return Math.round((day.getTime() - startDay.getTime()) / DAY_MS);
+}

--- a/lib/admin-platform/types.ts
+++ b/lib/admin-platform/types.ts
@@ -1,0 +1,65 @@
+// Types shared across the platform-wide admin dashboard (`/admin`).
+// Sibling of lib/admin-dashboard/types.ts which lives in the
+// community-owner admin (`/[communitySlug]/admin`).
+
+export interface PlatformStats {
+  usersTotal: number;
+  newUsersThisMonth: number;
+  newUsersGrowth: number;
+  communitiesTotal: number;
+  newCommunitiesThisMonth: number;
+  newCommunitiesGrowth: number;
+  activeSubscriptions: number;
+  activeSubscriptionsGrowth: number;
+  platformRevenueThisMonth: number;
+  platformRevenueGrowth: number;
+  communitiesRevenueThisMonth: number;
+  communitiesRevenueGrowth: number;
+}
+
+// One bar group per month: total community revenue (gross) and the
+// platform's slice (application fees) plotted side-by-side.
+export type PlatformRevenuePoint = {
+  month: string;
+  total: number;
+  platformFees: number;
+};
+
+// One point per day. Two series share the x-axis on the same chart.
+export type PlatformGrowthPoint = {
+  date: string;
+  users: number;
+  communities: number;
+};
+
+export type PlatformActivityEvent =
+  | {
+      type: 'signup';
+      at: Date;
+      userId: string;
+      displayName: string;
+      avatarUrl: string | null;
+    }
+  | {
+      type: 'community_created';
+      at: Date;
+      userId: string;
+      displayName: string;
+      avatarUrl: string | null;
+      communityName: string;
+      communitySlug: string;
+    }
+  | {
+      type: 'admin_action';
+      at: Date;
+      action: string;
+      resourceType: string;
+      adminName: string | null;
+    }
+  | {
+      type: 'failed_payment';
+      at: Date;
+      displayName: string;
+      amount: number;
+      communitySlug: string | null;
+    };


### PR DESCRIPTION
## Summary
First page of the page-by-page admin overhaul. Replaces the old `/admin` dashboard with a layout that mirrors the community-admin redesign (KPIs → chart → activity feed) and adopts the same RSC-with-helpers pattern.

## What's new
- **5 KPI cards**: users, communities, active subscriptions, communities revenue, platform revenue — each with MoM growth.
- **Chart panel** with two tabs:
  - **Revenue**: 6-month grouped bar showing total community revenue next to platform fees (DanceHub's slice).
  - **Growth**: 90-day dual-line chart of cumulative users + cumulative communities.
- **Activity feed** mixing signups, communities created, admin actions (`admin_access_log`), and failed payments across every connected Stripe account.

## Other fixes folded in
- Drops the `fetch('/api/admin/subscriptions')` self-fetch from a Server Component — same anti-pattern that just bit us with the middleware self-fetch (PR #33). Stripe calls now happen directly inline via the new helpers.
- Active-subscriptions count now correctly aggregates the platform account *plus* every connected account.

## Files
- `lib/admin-platform/{types,stats,revenue,activity-feed}.ts` — sibling to `lib/admin-dashboard/`.
- `components/admin/platform/PlatformDashboard{Kpis,Chart,ActivityFeed}.tsx` — sibling to `components/admin/Dashboard*`.
- `app/admin/page.tsx` — rewritten.

Cycles 2–5 (table pages: `/admin/users`, `/admin/communities`, `/admin/threads`, `/admin/courses`) tracked separately.

## Test plan
- [x] Verified end-to-end on preprod with the production-shaped data set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)