### PR TITLE
feat(admin): inline detail panel on /admin/communities (cycle 3.5)

### DIFF
--- a/app/api/admin/communities/[communityId]/snapshot/route.ts
+++ b/app/api/admin/communities/[communityId]/snapshot/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth-session';
+import { getCommunitySnapshot } from '@/lib/admin-platform/community-snapshot';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { communityId: string } }
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!session.user.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const snapshot = await getCommunitySnapshot(params.communityId);
+  if (!snapshot) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(snapshot);
+}

--- a/components/admin/platform/AdminDataTable.tsx
+++ b/components/admin/platform/AdminDataTable.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { Fragment, type ReactNode, useState } from 'react';
 import {
   type ColumnDef,
+  type ExpandedState,
+  type Row,
   type SortingState,
   flexRender,
   getCoreRowModel,
+  getExpandedRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
@@ -21,7 +24,7 @@ import {
 } from '@/components/ui/table';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { ArrowUpDown, ArrowUp, ArrowDown, ChevronLeft, ChevronRight, Search } from 'lucide-react';
+import { ArrowUpDown, ArrowUp, ArrowDown, ChevronLeft, ChevronRight, Search, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface AdminDataTableProps<T> {
@@ -34,6 +37,10 @@ interface AdminDataTableProps<T> {
   pageSize?: number;
   // Empty-state message when no rows match the current filter.
   emptyMessage?: string;
+  // When provided, rows become expandable: clicking a row toggles an inline
+  // panel below it that renders this function's output. Adds a chevron
+  // affordance on the leading cell. Pass undefined to keep rows static.
+  renderSubComponent?: (row: Row<T>) => ReactNode;
 }
 
 export function AdminDataTable<T>({
@@ -42,21 +49,31 @@ export function AdminDataTable<T>({
   searchPlaceholder,
   pageSize,
   emptyMessage = 'No results.',
+  renderSubComponent,
 }: AdminDataTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [globalFilter, setGlobalFilter] = useState('');
+  const [expanded, setExpanded] = useState<ExpandedState>({});
 
   const usePagination = typeof pageSize === 'number' && pageSize > 0;
+  const expandable = Boolean(renderSubComponent);
 
   const table = useReactTable({
     data,
     columns,
-    state: { sorting, globalFilter },
+    state: { sorting, globalFilter, expanded },
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
+    onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    ...(expandable
+      ? {
+          getExpandedRowModel: getExpandedRowModel(),
+          getRowCanExpand: () => true,
+        }
+      : {}),
     ...(usePagination
       ? {
           getPaginationRowModel: getPaginationRowModel(),
@@ -84,6 +101,7 @@ export function AdminDataTable<T>({
           <TableHeader>
             {table.getHeaderGroups().map((hg) => (
               <TableRow key={hg.id} className="border-border/50 hover:bg-transparent">
+                {expandable ? <TableHead className="w-8" /> : null}
                 {hg.headers.map((header) => {
                   const canSort = header.column.getCanSort();
                   const sortState = header.column.getIsSorted();
@@ -118,21 +136,67 @@ export function AdminDataTable<T>({
           </TableHeader>
           <TableBody>
             {table.getRowModel().rows.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  className="border-border/50 hover:bg-muted/40 transition-colors"
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
+              table.getRowModel().rows.map((row) => {
+                const isExpanded = row.getIsExpanded();
+                return (
+                  <Fragment key={row.id}>
+                    <TableRow
+                      className={cn(
+                        'border-border/50 transition-colors',
+                        expandable && 'cursor-pointer hover:bg-muted/40',
+                        !expandable && 'hover:bg-muted/40',
+                        isExpanded && 'bg-muted/30'
+                      )}
+                      onClick={
+                        expandable
+                          ? (e) => {
+                              // Don't toggle when clicking inside an interactive
+                              // element (link, button, dropdown, etc.) inside
+                              // the row.
+                              const target = e.target as HTMLElement;
+                              if (target.closest('a, button, [role="menuitem"], [role="dialog"]')) {
+                                return;
+                              }
+                              row.toggleExpanded();
+                            }
+                          : undefined
+                      }
+                    >
+                      {expandable ? (
+                        <TableCell className="w-8 p-0 pl-3">
+                          <ChevronDown
+                            className={cn(
+                              'h-4 w-4 text-muted-foreground transition-transform',
+                              isExpanded && 'rotate-180'
+                            )}
+                          />
+                        </TableCell>
+                      ) : null}
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                    {expandable && isExpanded ? (
+                      <TableRow className="border-border/50 bg-muted/10 hover:bg-muted/10">
+                        <TableCell
+                          colSpan={row.getVisibleCells().length + 1}
+                          className="p-0"
+                        >
+                          {renderSubComponent!(row)}
+                        </TableCell>
+                      </TableRow>
+                    ) : null}
+                  </Fragment>
+                );
+              })
             ) : (
               <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                <TableCell
+                  colSpan={columns.length + (expandable ? 1 : 0)}
+                  className="h-24 text-center text-muted-foreground"
+                >
                   {emptyMessage}
                 </TableCell>
               </TableRow>

--- a/components/admin/platform/CommunitiesTable.tsx
+++ b/components/admin/platform/CommunitiesTable.tsx
@@ -8,6 +8,7 @@ import { Users, AlertTriangle } from 'lucide-react';
 import { EditCommunityButton } from '@/components/admin/edit-community-button';
 import { DeleteCommunityButton } from '@/components/admin/delete-community-button';
 import { AdminDataTable } from './AdminDataTable';
+import { CommunityDetailPanel } from './CommunityDetailPanel';
 import type { AdminCommunityRow } from '@/lib/admin-platform/communities';
 
 const formatEur = (amount: number) =>
@@ -172,6 +173,12 @@ export function CommunitiesTable({ communities }: { communities: AdminCommunityR
       searchPlaceholder="Search communities by name…"
       pageSize={25}
       emptyMessage="No communities yet."
+      renderSubComponent={(row) => (
+        <CommunityDetailPanel
+          communityId={row.original.id}
+          slug={row.original.slug}
+        />
+      )}
     />
   );
 }

--- a/components/admin/platform/CommunityDetailPanel.tsx
+++ b/components/admin/platform/CommunityDetailPanel.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import useSWR from 'swr';
+import Link from 'next/link';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Users,
+  UserPlus,
+  UserMinus,
+  DollarSign,
+  ExternalLink,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { CommunitySnapshot } from '@/lib/admin-platform/community-snapshot';
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error ?? 'Failed to load community snapshot');
+    }
+    return res.json();
+  });
+
+const formatEur = (amount: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: amount >= 1000 ? 0 : 2,
+  }).format(amount);
+
+export function CommunityDetailPanel({
+  communityId,
+  slug,
+}: {
+  communityId: string;
+  slug: string;
+}) {
+  const { data, error, isLoading } = useSWR<CommunitySnapshot>(
+    `/api/admin/communities/${communityId}/snapshot`,
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+
+  if (isLoading) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">Loading details…</div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-6 text-sm text-destructive">
+        {error instanceof Error ? error.message : 'Failed to load details.'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h3 className="font-display text-xl font-semibold">{data.name}</h3>
+          <p className="text-xs text-muted-foreground">/{data.slug}</p>
+        </div>
+        <Link href={`/${slug}`} target="_blank" rel="noopener noreferrer">
+          <Button variant="outline" size="sm">
+            <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+            Visit community
+          </Button>
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {data.isPaid ? (
+          <KpiTile
+            label="Revenue this month"
+            value={formatEur(data.monthlyRevenue)}
+            growth={data.revenueGrowth}
+            growthSuffix="vs last month"
+            icon={<DollarSign className="h-4 w-4 text-secondary" />}
+            iconBg="bg-secondary/20"
+          />
+        ) : null}
+        <KpiTile
+          label="Active members"
+          value={data.membersTotal.toLocaleString()}
+          icon={<Users className="h-4 w-4 text-primary" />}
+          iconBg="bg-primary/10"
+        />
+        <KpiTile
+          label="New this month"
+          value={data.newMembersThisMonth.toLocaleString()}
+          growth={data.newMembersGrowth}
+          growthSuffix="vs last month"
+          icon={<UserPlus className="h-4 w-4 text-primary" />}
+          iconBg="bg-primary/10"
+        />
+        {data.isPaid ? (
+          <KpiTile
+            label="Cancellations"
+            value={data.cancellationsThisMonth.toLocaleString()}
+            sublineText={`${data.cancellationsLastMonth} last month`}
+            icon={<UserMinus className="h-4 w-4 text-secondary" />}
+            iconBg="bg-secondary/20"
+          />
+        ) : null}
+      </div>
+
+      {data.isPaid ? (
+        <div className="bg-card rounded-xl border border-border/50 p-4">
+          <h4 className="text-sm font-medium mb-3">Revenue (last 6 months)</h4>
+          <ResponsiveContainer width="100%" height={200}>
+            <BarChart
+              data={data.revenueChart6Months}
+              margin={{ top: 4, right: 4, left: 4, bottom: 4 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                vertical={false}
+                className="stroke-border/40"
+              />
+              <XAxis
+                dataKey="month"
+                tickLine={false}
+                axisLine={false}
+                className="text-xs"
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                className="text-xs"
+                tickFormatter={(v) => `€${Math.round(Number(v))}`}
+              />
+              <Tooltip
+                formatter={(value) =>
+                  [`€${Number(value).toFixed(2)}`, 'Revenue'] as [string, string]
+                }
+              />
+              <Bar
+                dataKey="revenue"
+                fill="hsl(var(--primary))"
+                radius={[6, 6, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function KpiTile({
+  label,
+  value,
+  growth,
+  growthSuffix,
+  sublineText,
+  icon,
+  iconBg,
+}: {
+  label: string;
+  value: string;
+  growth?: number;
+  growthSuffix?: string;
+  sublineText?: string;
+  icon: React.ReactNode;
+  iconBg: string;
+}) {
+  const trend: 'up' | 'down' | 'flat' | null =
+    typeof growth === 'number'
+      ? growth > 0
+        ? 'up'
+        : growth < 0
+        ? 'down'
+        : 'flat'
+      : null;
+
+  return (
+    <div className="bg-card rounded-xl border border-border/50 p-3 space-y-1.5">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+          {label}
+        </span>
+        <div className={`h-7 w-7 rounded-lg ${iconBg} flex items-center justify-center`}>
+          {icon}
+        </div>
+      </div>
+      <p className="font-display text-xl font-bold">{value}</p>
+      {trend ? (
+        <p
+          className={`text-xs font-medium flex items-center gap-1 ${
+            trend === 'up'
+              ? 'text-primary'
+              : trend === 'down'
+              ? 'text-destructive'
+              : 'text-muted-foreground'
+          }`}
+        >
+          {trend === 'up' ? (
+            <TrendingUp className="h-3 w-3" />
+          ) : trend === 'down' ? (
+            <TrendingDown className="h-3 w-3" />
+          ) : (
+            <Minus className="h-3 w-3" />
+          )}
+          {trend === 'up' ? '+' : ''}
+          {growth}% {growthSuffix}
+        </p>
+      ) : sublineText ? (
+        <p className="text-xs text-muted-foreground">{sublineText}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/lib/admin-platform/community-snapshot.ts
+++ b/lib/admin-platform/community-snapshot.ts
@@ -1,0 +1,132 @@
+import { queryOne } from '@/lib/db';
+import {
+  getCalendarMonthRange,
+  getMonthlyRevenue,
+  getRevenueChart6Months,
+  computeMoMGrowth,
+} from '@/lib/admin-dashboard/stats';
+import type { RevenuePoint } from '@/lib/admin-dashboard/types';
+
+export interface CommunitySnapshot {
+  id: string;
+  name: string;
+  slug: string;
+  imageUrl: string | null;
+  isPaid: boolean;
+  // KPIs
+  monthlyRevenue: number;
+  revenueGrowth: number;
+  membersTotal: number;
+  newMembersThisMonth: number;
+  newMembersGrowth: number;
+  cancellationsThisMonth: number;
+  cancellationsLastMonth: number;
+  // Chart series
+  revenueChart6Months: RevenuePoint[];
+}
+
+interface CommunityRow {
+  id: string;
+  name: string;
+  slug: string;
+  image_url: string | null;
+  membership_enabled: boolean;
+  stripe_account_id: string | null;
+  created_by: string;
+}
+
+interface CountRow {
+  count: number;
+}
+
+/**
+ * Slim snapshot for the inline detail panel on /admin/communities. Reuses
+ * the per-community helpers from lib/admin-dashboard/* so the numbers shown
+ * here match exactly what the community owner sees on their own admin page.
+ */
+export async function getCommunitySnapshot(
+  communityId: string,
+  now: Date = new Date()
+): Promise<CommunitySnapshot | null> {
+  const community = await queryOne<CommunityRow>`
+    SELECT id, name, slug, image_url, membership_enabled, stripe_account_id, created_by
+    FROM communities
+    WHERE id = ${communityId}
+  `;
+  if (!community) return null;
+
+  const thisMonth = getCalendarMonthRange(now, 0);
+  const lastMonth = getCalendarMonthRange(now, -1);
+
+  const [
+    membersTotalRow,
+    newMembersThisMonthRow,
+    newMembersLastMonthRow,
+    cancellationsThisMonthRow,
+    cancellationsLastMonthRow,
+    revenue,
+    revenueChart,
+  ] = await Promise.all([
+    queryOne<CountRow>`
+      SELECT COUNT(*) FILTER (WHERE status='active')::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND joined_at >= ${thisMonth.start.toISOString()}
+        AND joined_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND joined_at >= ${lastMonth.start.toISOString()}
+        AND joined_at < ${lastMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+        AND cancelled_at >= ${thisMonth.start.toISOString()}
+        AND cancelled_at < ${thisMonth.end.toISOString()}
+    `,
+    queryOne<CountRow>`
+      SELECT COUNT(*)::int AS count
+      FROM community_members
+      WHERE community_id = ${community.id}
+        AND user_id != ${community.created_by}
+        AND status IN ('inactive','cancelled')
+        AND cancelled_at >= ${lastMonth.start.toISOString()}
+        AND cancelled_at < ${lastMonth.end.toISOString()}
+    `,
+    getMonthlyRevenue(community.stripe_account_id, now),
+    getRevenueChart6Months(community.stripe_account_id, now),
+  ]);
+
+  const newMembersThisMonth = newMembersThisMonthRow?.count ?? 0;
+  const newMembersLastMonth = newMembersLastMonthRow?.count ?? 0;
+
+  return {
+    id: community.id,
+    name: community.name,
+    slug: community.slug,
+    imageUrl: community.image_url,
+    isPaid: community.membership_enabled,
+    monthlyRevenue: revenue.monthlyRevenue,
+    revenueGrowth: revenue.revenueGrowth,
+    membersTotal: membersTotalRow?.count ?? 0,
+    newMembersThisMonth,
+    newMembersGrowth: computeMoMGrowth(newMembersThisMonth, newMembersLastMonth),
+    cancellationsThisMonth: cancellationsThisMonthRow?.count ?? 0,
+    cancellationsLastMonth: cancellationsLastMonthRow?.count ?? 0,
+    revenueChart6Months: revenueChart,
+  };
+}


### PR DESCRIPTION
## Summary
Click any community row on \`/admin/communities\` to expand an inline panel with that community's KPIs and a revenue chart. The panel mirrors the slim community-owner dashboard, so platform admins see the same numbers a community owner sees on their own \`/[slug]/admin\` page.

## What expands
- **4 KPI tiles**: revenue this month (paid only), active members, new members this month, cancellations this month — each with month-over-month growth where it makes sense.
- **6-month revenue bar chart** (paid communities only).
- **Visit community** button linking to \`/{slug}\`.

## Architecture
- New helper \`lib/admin-platform/community-snapshot.ts\` reuses the existing \`lib/admin-dashboard/*\` helpers so per-community numbers match exactly what owners see on their own dashboards.
- New API route \`GET /api/admin/communities/[communityId]/snapshot\` gates on \`session.user.isAdmin\` and returns the snapshot. **Lazy loaded** via SWR when a row expands so the page-level render doesn't fan out N Stripe calls upfront.
- \`AdminDataTable\` picks up an optional \`renderSubComponent\` prop (TanStack \`getExpandedRowModel\`) — other admin tables can adopt the same expand pattern in cycles 4–5 if useful.
- Row click is filtered to ignore clicks inside interactive children (links, buttons, dropdowns) so editing/deleting still works without toggling expansion.

## Test plan
- [x] Verified end-to-end on preprod: clicking expands and lazy-loads, "Visit community" opens \`/{slug}\` in a new tab, edit/delete still work.
- [x] Free communities render fewer tiles (no revenue, no chart).
- [x] Paid communities show full panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)