### PR TITLE
fix(admin): give site admins full access to every community

### DIFF
--- a/app/[communitySlug]/FeedClient.tsx
+++ b/app/[communitySlug]/FeedClient.tsx
@@ -873,8 +873,10 @@ export default function FeedClient({
     );
   }
 
-  // Only show main content for active members
-  if (!isMember) {
+  // Only show main content for active members. Creators and site admins
+  // also have access (server-side gate already let them through; mirror that
+  // here so they don't see a blank page).
+  if (!isMember && !isCreator && !initialIsAdmin) {
     return null;
   }
 

--- a/app/[communitySlug]/admin/layout.tsx
+++ b/app/[communitySlug]/admin/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth-session';
 import { queryOne } from '@/lib/db';
+import { getUserIsAdmin } from '@/lib/community-data';
 import { AdminNav } from '@/components/admin/AdminNav';
 
 export default async function AdminLayout({
@@ -17,7 +18,12 @@ export default async function AdminLayout({
     SELECT id, created_by, name FROM communities WHERE slug = ${params.communitySlug}
   `;
   if (!community) redirect(`/${params.communitySlug}`);
-  if (community.created_by !== session.user.id) redirect(`/${params.communitySlug}`);
+
+  // The community owner OR a site-wide admin (profiles.is_admin) can manage.
+  // Anything else bounces to the community feed.
+  const isOwner = community.created_by === session.user.id;
+  const canManage = isOwner || (await getUserIsAdmin(session.user.id));
+  if (!canManage) redirect(`/${params.communitySlug}`);
 
   return (
     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-10 lg:py-14 font-sans pb-[calc(6rem+env(safe-area-inset-bottom))] md:pb-14">

--- a/app/[communitySlug]/calendar/page.tsx
+++ b/app/[communitySlug]/calendar/page.tsx
@@ -4,6 +4,7 @@ import { getSession } from '@/lib/auth-session';
 import {
   getCommunityBySlug,
   getLiveClassesForWeek,
+  getUserIsAdmin,
 } from '@/lib/community-data';
 import WeekCalendar from '@/components/WeekCalendar';
 
@@ -20,6 +21,7 @@ export default async function CommunityCalendarPage({
 
   const session = await getSession();
   const isCreator = !!session && community.created_by === session.user.id;
+  const isAdmin = !!session && (await getUserIsAdmin(session.user.id));
 
   const now = new Date();
   const weekStart = startOfWeek(now, { weekStartsOn: 0 });
@@ -44,7 +46,7 @@ export default async function CommunityCalendarPage({
       <WeekCalendar
         communityId={community.id}
         communitySlug={params.communitySlug}
-        isTeacher={isCreator}
+        isTeacher={isCreator || isAdmin}
         initialClasses={initialClasses}
       />
     </div>

--- a/app/[communitySlug]/layout.tsx
+++ b/app/[communitySlug]/layout.tsx
@@ -4,6 +4,7 @@ import {
   getCommunityBySlug,
   getCommunityMembership,
   getProfileForUser,
+  getUserIsAdmin,
 } from '@/lib/community-data';
 import Navbar from '@/app/components/Navbar';
 import CommunityNavbar from '@/components/CommunityNavbar';
@@ -24,9 +25,10 @@ export default async function CommunityLayout({
 
   const session = await getSession();
   const isOwner = !!session && community.created_by === session.user.id;
-  const [isMember, navProfile] = await Promise.all([
+  const [isMember, navProfile, isAdmin] = await Promise.all([
     session ? getCommunityMembership(community.id, session.user.id) : Promise.resolve(false),
     session ? getProfileForUser(session.user.id) : Promise.resolve(null),
+    session ? getUserIsAdmin(session.user.id) : Promise.resolve(false),
   ]);
 
   return (
@@ -41,6 +43,7 @@ export default async function CommunityLayout({
           communitySlug={params.communitySlug}
           isMember={isMember}
           isOwner={isOwner}
+          isAdmin={isAdmin}
         />
       </div>
 
@@ -51,6 +54,7 @@ export default async function CommunityLayout({
         communityImageUrl={community.image_url}
         isMember={isMember}
         isOwner={isOwner}
+        isAdmin={isAdmin}
         user={session?.user ?? null}
         profile={navProfile}
       />

--- a/components/CommunityNavbar.tsx
+++ b/components/CommunityNavbar.tsx
@@ -8,12 +8,18 @@ interface CommunityNavbarProps {
   communitySlug: string;
   isMember: boolean;
   isOwner?: boolean;
+  isAdmin?: boolean;
   // Legacy: pages that still render their own chrome pass this. Active tab is
   // now derived from usePathname; remove once all pages are migrated.
   activePage?: string;
 }
 
-export default function CommunityNavbar({ communitySlug, isMember, isOwner = false }: CommunityNavbarProps) {
+export default function CommunityNavbar({
+  communitySlug,
+  isMember,
+  isOwner = false,
+  isAdmin = false,
+}: CommunityNavbarProps) {
   const pathname = usePathname();
 
   const navItems: Array<{ label: string; href: string; memberOnly?: boolean; ownerOnly?: boolean }> = [
@@ -27,9 +33,11 @@ export default function CommunityNavbar({ communitySlug, isMember, isOwner = fal
 
   const broadcastsEnabled = process.env.NEXT_PUBLIC_BROADCASTS_ENABLED === "true";
 
+  // Site admins (profiles.is_admin) get the same nav surface as owners and
+  // members for any community they visit, so they can actually moderate.
   const visibleItems = navItems.filter(item => {
-    if (item.memberOnly && !isMember) return false;
-    if (item.ownerOnly && !isOwner) return false;
+    if (item.memberOnly && !isMember && !isOwner && !isAdmin) return false;
+    if (item.ownerOnly && !isOwner && !isAdmin) return false;
     if (item.label === "Admin" && !broadcastsEnabled) return false;
     return true;
   });

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -25,6 +25,7 @@ type MobileNavProps = {
   communityImageUrl: string | null;
   isMember: boolean;
   isOwner: boolean;
+  isAdmin?: boolean;
   user: { id: string; email?: string | null } | null;
   profile: { full_name?: string | null; avatar_url?: string | null } | null;
 };
@@ -43,6 +44,7 @@ export default function MobileNav({
   communityImageUrl,
   isMember,
   isOwner,
+  isAdmin = false,
   user,
   profile,
 }: MobileNavProps) {
@@ -52,7 +54,10 @@ export default function MobileNav({
   const [moreOpen, setMoreOpen] = useState(false);
 
   const broadcastsEnabled = process.env.NEXT_PUBLIC_BROADCASTS_ENABLED === 'true';
-  const showAdmin = isOwner && broadcastsEnabled;
+  // Site admins (profiles.is_admin) get full chrome on every community —
+  // same tabs as a member/owner — so they can actually moderate.
+  const hasFullAccess = isMember || isOwner || isAdmin;
+  const showAdmin = (isOwner || isAdmin) && broadcastsEnabled;
 
   const rootHref = `/${communitySlug}`;
   const allTabs: Tab[] = [
@@ -61,7 +66,7 @@ export default function MobileNav({
     { key: 'lessons', label: 'Lessons', href: `/${communitySlug}/private-lessons`, icon: GraduationCap },
     { key: 'calendar', label: 'Calendar', href: `/${communitySlug}/calendar`, icon: Calendar, memberOnly: true },
   ];
-  const tabs = allTabs.filter((t) => !t.memberOnly || isMember);
+  const tabs = allTabs.filter((t) => !t.memberOnly || hasFullAccess);
 
   const isActive = (href: string) =>
     href === rootHref ? pathname === rootHref : pathname?.startsWith(href) ?? false;


### PR DESCRIPTION
## Summary
Site admins (\`profiles.is_admin=true\`) had inconsistent access across communities they didn't create or join. The feed and classroom server-side gates already checked \`isAdmin\`, but the surrounding chrome (navbars) and a handful of other pages didn't — producing the "sometimes I can see it, sometimes I can't, sometimes I'm bounced to /about" mess.

## Six connected fixes

1. **\`app/[communitySlug]/layout.tsx\`** — compute \`isAdmin\` alongside \`isMember\` / \`isOwner\` and pass it down to \`CommunityNavbar\` and \`MobileNav\`.

2. **\`components/CommunityNavbar.tsx\`** — accept an \`isAdmin\` prop. memberOnly tabs (Classroom, Calendar) and the ownerOnly Admin tab now show for site admins too.

3. **\`components/MobileNav.tsx\`** — same treatment.

4. **\`app/[communitySlug]/FeedClient.tsx\`** — the blank-page gate (\`if (!isMember) return null\`) was firing for site admins even though the server-side gate let them through. That produced the "I'm on the right URL but the page is empty so I clicked About" symptom. Now also lets creators and site admins through.

5. **\`app/[communitySlug]/admin/layout.tsx\`** — was strictly \`community.created_by === session.user.id\`, so site admins got bounced out of every community admin they didn't own. Now allows owner OR site admin.

6. **\`app/[communitySlug]/calendar/page.tsx\`** — \`isTeacher\` is now \`isCreator || isAdmin\` so site admins can manage live classes anywhere.

## Test plan
- [x] Verified end-to-end on preprod against a community I'm not a member of:
  - Full nav (all tabs visible).
  - Feed renders, no blank page.
  - Classroom/Calendar open.
  - Community admin pages load.
  - Calendar shows teacher controls.
- [x] Owners and members behave identically (same conditions are still satisfied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)