### PR TITLE
chore(admin): cleanup follow-ups from /simplify review

### DIFF
--- a/app/[communitySlug]/FeedClient.tsx
+++ b/app/[communitySlug]/FeedClient.tsx
@@ -184,8 +184,8 @@ export default function FeedClient({
   communitySlug,
   initialCommunity,
   initialThreads,
-  isCreator: initialIsCreator,
-  isAdmin: initialIsAdmin,
+  isCreator,
+  isAdmin,
   isMember: initialIsMember,
   isPreRegistered: initialIsPreRegistered,
   memberStatus: initialMemberStatus,
@@ -235,7 +235,6 @@ export default function FeedClient({
   const [threads, setThreads] = useState<Thread[]>(initialThreads);
   const [isMember, setIsMember] = useState(initialIsMember);
   const [isPreRegistered, setIsPreRegistered] = useState(initialIsPreRegistered);
-  const [isCreator, setIsCreator] = useState(initialIsCreator);
   const [error, setError] = useState<Error | null>(null);
   const [paymentClientSecret, setPaymentClientSecret] = useState<string | null>(
     null
@@ -876,7 +875,7 @@ export default function FeedClient({
   // Only show main content for active members. Creators and site admins
   // also have access (server-side gate already let them through; mirror that
   // here so they don't see a blank page).
-  if (!isMember && !isCreator && !initialIsAdmin) {
+  if (!isMember && !isCreator && !isAdmin) {
     return null;
   }
 

--- a/components/admin/platform/AdminDataTable.tsx
+++ b/components/admin/platform/AdminDataTable.tsx
@@ -4,7 +4,6 @@ import { Fragment, type ReactNode, useState } from 'react';
 import {
   type ColumnDef,
   type ExpandedState,
-  type Row,
   type SortingState,
   flexRender,
   getCoreRowModel,
@@ -40,7 +39,7 @@ interface AdminDataTableProps<T> {
   // When provided, rows become expandable: clicking a row toggles an inline
   // panel below it that renders this function's output. Adds a chevron
   // affordance on the leading cell. Pass undefined to keep rows static.
-  renderSubComponent?: (row: Row<T>) => ReactNode;
+  renderSubComponent?: (rowData: T) => ReactNode;
 }
 
 export function AdminDataTable<T>({
@@ -184,7 +183,7 @@ export function AdminDataTable<T>({
                           colSpan={row.getVisibleCells().length + 1}
                           className="p-0"
                         >
-                          {renderSubComponent!(row)}
+                          {renderSubComponent!(row.original)}
                         </TableCell>
                       </TableRow>
                     ) : null}

--- a/components/admin/platform/CommunitiesTable.tsx
+++ b/components/admin/platform/CommunitiesTable.tsx
@@ -9,14 +9,8 @@ import { EditCommunityButton } from '@/components/admin/edit-community-button';
 import { DeleteCommunityButton } from '@/components/admin/delete-community-button';
 import { AdminDataTable } from './AdminDataTable';
 import { CommunityDetailPanel } from './CommunityDetailPanel';
+import { formatEur } from '@/lib/admin-platform/format';
 import type { AdminCommunityRow } from '@/lib/admin-platform/communities';
-
-const formatEur = (amount: number) =>
-  new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: amount >= 1000 ? 0 : 2,
-  }).format(amount);
 
 export function CommunitiesTable({ communities }: { communities: AdminCommunityRow[] }) {
   const columns = useMemo<ColumnDef<AdminCommunityRow>[]>(
@@ -173,10 +167,10 @@ export function CommunitiesTable({ communities }: { communities: AdminCommunityR
       searchPlaceholder="Search communities by name…"
       pageSize={25}
       emptyMessage="No communities yet."
-      renderSubComponent={(row) => (
+      renderSubComponent={(community) => (
         <CommunityDetailPanel
-          communityId={row.original.id}
-          slug={row.original.slug}
+          communityId={community.id}
+          slug={community.slug}
         />
       )}
     />

--- a/components/admin/platform/CommunityDetailPanel.tsx
+++ b/components/admin/platform/CommunityDetailPanel.tsx
@@ -22,6 +22,7 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { formatEur } from '@/lib/admin-platform/format';
 import type { CommunitySnapshot } from '@/lib/admin-platform/community-snapshot';
 
 const fetcher = (url: string) =>
@@ -32,13 +33,6 @@ const fetcher = (url: string) =>
     }
     return res.json();
   });
-
-const formatEur = (amount: number) =>
-  new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: amount >= 1000 ? 0 : 2,
-  }).format(amount);
 
 export function CommunityDetailPanel({
   communityId,

--- a/components/admin/platform/PlatformDashboardActivityFeed.tsx
+++ b/components/admin/platform/PlatformDashboardActivityFeed.tsx
@@ -14,25 +14,20 @@ export function PlatformDashboardActivityFeed({
 }: {
   events: PlatformActivityEvent[];
 }) {
-  if (events.length === 0) {
-    return (
-      <div className="bg-card rounded-2xl border border-border/50 p-6">
-        <h2 className="font-display text-lg font-semibold mb-4">Recent activity</h2>
-        <p className="text-sm text-muted-foreground text-center py-8">
-          No recent activity yet
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div className="bg-card rounded-2xl border border-border/50 p-6">
       <h2 className="font-display text-lg font-semibold mb-4">Recent activity</h2>
-      <ul className="space-y-3">
-        {events.map((e, i) => (
-          <ActivityRow key={`${e.type}-${e.at.getTime()}-${i}`} event={e} />
-        ))}
-      </ul>
+      {events.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-8">
+          No recent activity yet
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {events.map((e, i) => (
+            <ActivityRow key={`${e.type}-${e.at.getTime()}-${i}`} event={e} />
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/components/admin/platform/PlatformDashboardKpis.tsx
+++ b/components/admin/platform/PlatformDashboardKpis.tsx
@@ -8,6 +8,7 @@ import {
   TrendingDown,
   Minus,
 } from 'lucide-react';
+import { formatEur } from '@/lib/admin-platform/format';
 import type { PlatformStats } from '@/lib/admin-platform/types';
 
 export function PlatformDashboardKpis({ stats }: { stats: PlatformStats }) {
@@ -39,7 +40,7 @@ export function PlatformDashboardKpis({ stats }: { stats: PlatformStats }) {
       />
       <Tile
         label="Communities revenue"
-        value={formatCurrency(stats.communitiesRevenueThisMonth)}
+        value={formatEur(stats.communitiesRevenueThisMonth)}
         sublineNumber={stats.communitiesRevenueGrowth}
         sublineSuffix="vs last month"
         icon={<DollarSign className="h-5 w-5 text-secondary" />}
@@ -47,7 +48,7 @@ export function PlatformDashboardKpis({ stats }: { stats: PlatformStats }) {
       />
       <Tile
         label="Platform revenue"
-        value={formatCurrency(stats.platformRevenueThisMonth)}
+        value={formatEur(stats.platformRevenueThisMonth)}
         sublineNumber={stats.platformRevenueGrowth}
         sublineSuffix="vs last month"
         icon={<Percent className="h-5 w-5 text-accent" />}
@@ -55,14 +56,6 @@ export function PlatformDashboardKpis({ stats }: { stats: PlatformStats }) {
       />
     </div>
   );
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: amount >= 1000 ? 0 : 2,
-  }).format(amount);
 }
 
 function Tile({

--- a/lib/admin-platform/activity-feed.ts
+++ b/lib/admin-platform/activity-feed.ts
@@ -2,7 +2,7 @@ import { query } from '@/lib/db';
 import { stripe } from '@/lib/stripe';
 import type Stripe from 'stripe';
 import type { PlatformActivityEvent } from './types';
-import { getAllConnectedAccountIds } from './revenue';
+import { isAccountChargesEnabled } from './revenue';
 
 type SignupRow = {
   auth_user_id: string;
@@ -38,11 +38,7 @@ type StripeAccountRow = {
 const FEED_LOOKBACK_DAYS = 30;
 const PER_SOURCE_LIMIT = 20;
 
-/**
- * Concatenate event lists, sort newest-first by `at`, slice to `limit`.
- * Identical contract to mergeActivityEvents in lib/admin-dashboard, but
- * typed for PlatformActivityEvent so the two feeds stay independent.
- */
+// See also: lib/admin-dashboard/activity-feed.ts:mergeActivityEvents.
 export function mergePlatformEvents(
   lists: PlatformActivityEvent[][],
   limit: number
@@ -123,10 +119,6 @@ export async function getRecentAdminActions(): Promise<PlatformActivityEvent[]> 
   }));
 }
 
-/**
- * Failed charges across every connected account in the last 30 days.
- * autoPagingToArray walks pages so a busy account isn't truncated.
- */
 export async function getRecentFailedPaymentsAcrossPlatform(
   now: Date = new Date()
 ): Promise<PlatformActivityEvent[]> {
@@ -141,10 +133,7 @@ export async function getRecentFailedPaymentsAcrossPlatform(
 
   const perAccount = await Promise.all(
     accountRows.map(async (a) => {
-      try {
-        const account = await stripe.accounts.retrieve(a.stripe_account_id);
-        if (!account.charges_enabled) return [] as PlatformActivityEvent[];
-      } catch {
+      if (!(await isAccountChargesEnabled(a.stripe_account_id))) {
         return [] as PlatformActivityEvent[];
       }
 
@@ -167,10 +156,6 @@ export async function getRecentFailedPaymentsAcrossPlatform(
         }));
     })
   );
-
-  // Mark intentional unused — getAllConnectedAccountIds isn't reused here
-  // because we need slugs alongside ids; kept as exported helper for revenue.ts.
-  void getAllConnectedAccountIds;
 
   return perAccount.flat();
 }

--- a/lib/admin-platform/communities.ts
+++ b/lib/admin-platform/communities.ts
@@ -45,16 +45,6 @@ interface MemberCountRow {
   count: number;
 }
 
-/**
- * All communities with creator info, active member counts, and lifetime
- * Stripe revenue + platform fees per community.
- *
- * Fixes vs. the previous inline implementation:
- * - members_count filtered to status='active' (was including cancelled).
- * - Stripe data uses autoPagingToArray, no longer truncated at 100 entries.
- * - Platform fees come from applicationFees (the actual platform slice),
- *   not balance_transaction.fee (which is the Stripe processing fee).
- */
 export async function getAllAdminCommunities(): Promise<AdminCommunityRow[]> {
   const communities = await query<CommunityRow>`
     SELECT id, name, slug, description, image_url, created_at, created_by,
@@ -85,12 +75,8 @@ export async function getAllAdminCommunities(): Promise<AdminCommunityRow[]> {
   const creatorMap = new Map(creators.map((c) => [c.auth_user_id, c]));
   const memberCountMap = new Map(memberCounts.map((m) => [m.community_id, m.count]));
 
-  // Pull every application fee (with pagination) once and group them by
-  // the connected account they came from. One Stripe call instead of N.
   const platformFeesByAccount = await getPlatformFeesByAccount();
 
-  // Per-account succeeded charges. These DO need one call per account
-  // because charges live on the connected accounts, not the platform.
   const revenueByAccount = await getRevenueByAccount(
     communities
       .map((c) => c.stripe_account_id)

--- a/lib/admin-platform/community-snapshot.ts
+++ b/lib/admin-platform/community-snapshot.ts
@@ -39,11 +39,8 @@ interface CountRow {
   count: number;
 }
 
-/**
- * Slim snapshot for the inline detail panel on /admin/communities. Reuses
- * the per-community helpers from lib/admin-dashboard/* so the numbers shown
- * here match exactly what the community owner sees on their own admin page.
- */
+// Reuses lib/admin-dashboard/* helpers so the numbers shown here match
+// what the community owner sees on their own admin page.
 export async function getCommunitySnapshot(
   communityId: string,
   now: Date = new Date()

--- a/lib/admin-platform/courses.ts
+++ b/lib/admin-platform/courses.ts
@@ -39,11 +39,6 @@ interface LessonCountRow {
   count: number;
 }
 
-/**
- * All courses with their parent community, plus aggregate chapter and
- * lesson counts. Three queries (courses + chapters + lessons) instead of
- * N to avoid the original page's per-course follow-up calls.
- */
 export async function getAllAdminCourses(): Promise<AdminCourseRow[]> {
   const courses = await query<CourseRow>`
     SELECT c.id, c.title, c.slug, c.description, c.image_url, c.is_public,

--- a/lib/admin-platform/format.ts
+++ b/lib/admin-platform/format.ts
@@ -1,0 +1,19 @@
+// Shared formatters for the platform admin tables and dashboard.
+// Uses en-US Intl with EUR currency to match the rest of the app.
+
+const EUR_BIG = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+const EUR_SMALL = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 2,
+});
+
+// Drop the cents on amounts >= €1,000 so dense KPI tiles stay legible.
+export function formatEur(amount: number): string {
+  return amount >= 1000 ? EUR_BIG.format(amount) : EUR_SMALL.format(amount);
+}

--- a/lib/admin-platform/revenue.ts
+++ b/lib/admin-platform/revenue.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { stripe } from '@/lib/stripe';
 import { query } from '@/lib/db';
 import type Stripe from 'stripe';
@@ -18,11 +19,21 @@ export async function getAllConnectedAccountIds(): Promise<string[]> {
   return rows.map((r) => r.stripe_account_id!).filter(Boolean);
 }
 
-/**
- * Sum of application_fee.amount (platform's slice) on the platform account
- * within the given window. autoPagingToArray walks all pages so very busy
- * months don't get truncated.
- */
+// Memoized via React's request-scoped cache so a single render that touches
+// many helpers (sumSucceededOnAccount, getActiveSubscriptionsStats,
+// activity-feed's failed-payments fetch, etc.) only retrieves each account
+// once. Returns false on any error so callers can short-circuit safely.
+export const isAccountChargesEnabled = cache(
+  async (stripeAccountId: string): Promise<boolean> => {
+    try {
+      const account = await stripe.accounts.retrieve(stripeAccountId);
+      return Boolean(account.charges_enabled);
+    } catch {
+      return false;
+    }
+  }
+);
+
 async function sumPlatformFees(start: Date, end: Date): Promise<number> {
   const fees = await stripe.applicationFees
     .list({
@@ -36,21 +47,12 @@ async function sumPlatformFees(start: Date, end: Date): Promise<number> {
   return fees.reduce((sum, f) => sum + f.amount / 100, 0);
 }
 
-/**
- * Sum of succeeded charge amounts on a single connected account within
- * the given window.
- */
 async function sumSucceededOnAccount(
   stripeAccountId: string,
   start: Date,
   end: Date
 ): Promise<number> {
-  try {
-    const account = await stripe.accounts.retrieve(stripeAccountId);
-    if (!account.charges_enabled) return 0;
-  } catch {
-    return 0;
-  }
+  if (!(await isAccountChargesEnabled(stripeAccountId))) return 0;
 
   const charges = await stripe.charges
     .list(
@@ -83,10 +85,6 @@ async function sumCommunitiesRevenue(
   return perAccount.reduce((sum, v) => sum + v, 0);
 }
 
-/**
- * This-month and last-month totals for both revenue streams + MoM growth.
- * One Promise.all to parallelize the four sums.
- */
 export async function getMonthlyRevenueStats(now: Date = new Date()) {
   const accountIds = await getAllConnectedAccountIds();
   const thisMonth = getCalendarMonthRange(now, 0);
@@ -107,9 +105,6 @@ export async function getMonthlyRevenueStats(now: Date = new Date()) {
   };
 }
 
-/**
- * Last 6 months — one PlatformRevenuePoint per month with both series.
- */
 export async function getRevenueChart6Months(
   now: Date = new Date()
 ): Promise<PlatformRevenuePoint[]> {
@@ -133,13 +128,8 @@ export async function getRevenueChart6Months(
   }));
 }
 
-/**
- * Active subscriptions across the platform account + every connected account.
- * MoM growth compares this-month-end count to last-month-end count via
- * subscriptions created/cancelled in those windows — Stripe doesn't expose
- * a "count at point in time" so we approximate with current count vs.
- * (current - net new this month).
- */
+// MoM growth compares created-minus-cancelled in this month vs. last month —
+// Stripe has no point-in-time count, so this is a heuristic, not exact.
 export async function getActiveSubscriptionsStats(
   now: Date = new Date()
 ): Promise<{ count: number; growth: number }> {
@@ -151,12 +141,7 @@ export async function getActiveSubscriptionsStats(
 
   const connectedCounts = await Promise.all(
     accountIds.map(async (id) => {
-      try {
-        const account = await stripe.accounts.retrieve(id);
-        if (!account.charges_enabled) return 0;
-      } catch {
-        return 0;
-      }
+      if (!(await isAccountChargesEnabled(id))) return 0;
       const subs = await stripe.subscriptions
         .list({ status: 'active', limit: 100 }, { stripeAccount: id })
         .autoPagingToArray({ limit: 1000 });
@@ -166,9 +151,6 @@ export async function getActiveSubscriptionsStats(
 
   const total = platformSubs.length + connectedCounts.reduce((a, b) => a + b, 0);
 
-  // Approximate MoM: count subs created this month minus those cancelled
-  // this month (across all accounts), against last month's same delta.
-  // Cheap heuristic — good enough for a dashboard signal.
   const thisMonth = getCalendarMonthRange(now, 0);
   const lastMonth = getCalendarMonthRange(now, -1);
   const [thisDelta, lastDelta] = await Promise.all([
@@ -190,33 +172,32 @@ async function deltaInWindow(
   const sinceSec = Math.floor(start.getTime() / 1000);
   const untilSec = Math.floor(end.getTime() / 1000);
 
-  // Platform-account net new (created in window, minus cancelled in window).
-  const created = await stripe.subscriptions
+  const platformDelta = stripe.subscriptions
     .list({ created: { gte: sinceSec, lt: untilSec }, limit: 100 })
-    .autoPagingToArray({ limit: 1000 });
-  const cancelled = created.filter(
-    (s) => s.canceled_at && s.canceled_at >= sinceSec && s.canceled_at < untilSec
-  ).length;
+    .autoPagingToArray({ limit: 1000 })
+    .then((subs) => subs.length - countCancelledInWindow(subs, sinceSec, untilSec));
 
-  let total = created.length - cancelled;
-
-  for (const id of accountIds) {
-    try {
-      const account = await stripe.accounts.retrieve(id);
-      if (!account.charges_enabled) continue;
-    } catch {
-      continue;
-    }
-    const sub = await stripe.subscriptions
+  const connectedDeltas = accountIds.map(async (id) => {
+    if (!(await isAccountChargesEnabled(id))) return 0;
+    const subs = await stripe.subscriptions
       .list(
         { created: { gte: sinceSec, lt: untilSec }, limit: 100 },
         { stripeAccount: id }
       )
       .autoPagingToArray({ limit: 1000 });
-    const subCancelled = sub.filter(
-      (s) => s.canceled_at && s.canceled_at >= sinceSec && s.canceled_at < untilSec
-    ).length;
-    total += sub.length - subCancelled;
-  }
-  return total;
+    return subs.length - countCancelledInWindow(subs, sinceSec, untilSec);
+  });
+
+  const all = await Promise.all([platformDelta, ...connectedDeltas]);
+  return all.reduce((sum, v) => sum + v, 0);
+}
+
+function countCancelledInWindow(
+  subs: Stripe.Subscription[],
+  sinceSec: number,
+  untilSec: number
+): number {
+  return subs.filter(
+    (s) => s.canceled_at && s.canceled_at >= sinceSec && s.canceled_at < untilSec
+  ).length;
 }

--- a/lib/admin-platform/stats.ts
+++ b/lib/admin-platform/stats.ts
@@ -7,9 +7,6 @@ import type { PlatformGrowthPoint } from './types';
 
 type CountRow = { count: number };
 
-/**
- * Total profiles count + new this month + MoM growth.
- */
 export async function getUserStats(now: Date = new Date()) {
   const thisMonth = getCalendarMonthRange(now, 0);
   const lastMonth = getCalendarMonthRange(now, -1);
@@ -39,9 +36,6 @@ export async function getUserStats(now: Date = new Date()) {
   };
 }
 
-/**
- * Total communities count + new this month + MoM growth.
- */
 export async function getCommunityStats(now: Date = new Date()) {
   const thisMonth = getCalendarMonthRange(now, 0);
   const lastMonth = getCalendarMonthRange(now, -1);
@@ -71,10 +65,6 @@ export async function getCommunityStats(now: Date = new Date()) {
   };
 }
 
-/**
- * Cumulative users + communities, day-by-day, for the last 90 days.
- * Both series live on the same chart — see PlatformDashboardChart.
- */
 export async function getGrowthSeries90Days(
   now: Date = new Date()
 ): Promise<PlatformGrowthPoint[]> {

--- a/lib/admin-platform/threads.ts
+++ b/lib/admin-platform/threads.ts
@@ -47,10 +47,6 @@ interface ReportCountRow {
   count: number;
 }
 
-/**
- * All threads across the platform with community, author, and report-count
- * info attached for the moderation table on /admin/threads.
- */
 export async function getAllAdminThreads(): Promise<AdminThreadRow[]> {
   const threads = await query<ThreadRow>`
     SELECT id, title, content, created_at, community_id, created_by,
@@ -111,10 +107,7 @@ export async function getAllAdminThreads(): Promise<AdminThreadRow[]> {
   });
 }
 
-/**
- * Threads are stored as TipTap-rendered HTML. The admin table needs a
- * plain-text preview, so strip tags and collapse whitespace.
- */
+// Threads are stored as TipTap-rendered HTML; the table needs plain text.
 function stripHtml(html: string): string {
   return html
     .replace(/<[^>]+>/g, ' ')

--- a/lib/admin-platform/users.ts
+++ b/lib/admin-platform/users.ts
@@ -41,15 +41,8 @@ interface CommunityJoinedRow {
   slug: string;
 }
 
-/**
- * All users with their created and joined communities.
- *
- * Joins on `auth_user_id` (text), NOT `profiles.id` (uuid). The previous
- * implementation joined on profiles.id and silently returned empty arrays
- * for everyone — communities.created_by and community_members.user_id
- * both reference the better-auth user.id, which is exposed on profiles
- * as `auth_user_id`.
- */
+// communities.created_by and community_members.user_id are FKs to user.id
+// (text), not profiles.id (uuid). Join on auth_user_id, not the profile PK.
 export async function getAllAdminUsers(): Promise<AdminUserRow[]> {
   const profiles = await query<ProfileRow>`
     SELECT id, auth_user_id, email, full_name, display_name, avatar_url, is_admin, created_at

--- a/lib/community-data.ts
+++ b/lib/community-data.ts
@@ -33,23 +33,15 @@ export const getCommunityBySlug = cache(async (slug: string) => {
 
 // Mirrors the logic in /api/community/[slug]/check-subscription: active OR
 // in grace period after cancel. Returns false when user has no row.
-export const getCommunityMembership = cache(async (communityId: string, userId: string) => {
-  const member = await queryOne<{
-    status: string;
-    subscription_status: string | null;
-    current_period_end: string | null;
-  }>`
-    SELECT status, subscription_status, current_period_end
-    FROM community_members
-    WHERE community_id = ${communityId}
-      AND user_id = ${userId}
-  `;
-  if (!member) return false;
-  const periodEnd = member.current_period_end ? new Date(member.current_period_end) : null;
-  const inGracePeriod =
-    member.subscription_status === 'canceling' && periodEnd && periodEnd > new Date();
-  return member.status === 'active' || !!inGracePeriod;
-});
+// Thin wrapper over getMembershipStatus so the layout + page that hit this
+// pair share a single cached SQL query per request instead of two.
+export const getCommunityMembership = async (
+  communityId: string,
+  userId: string
+): Promise<boolean> => {
+  const status = await getMembershipStatus(communityId, userId);
+  return status.isMember;
+};
 
 // Shape matches the /api/community/[slug]/live-classes GET response.
 export type LiveClassStatus = 'scheduled' | 'live' | 'ended' | 'cancelled';


### PR DESCRIPTION
## Summary
Targeted cleanup of the admin overhaul (cycles 1–5 + 3.5 + admin-access fix) based on a three-agent simplify review. Picks the high-leverage findings; skips cosmetic ones the design doc explicitly accepted (KpiTile/EmptyState/etc extraction).

## Real bugs / efficiency wins

- **\`deltaInWindow\`** was walking \`accountIds\` with a sequential \`for…of\` loop, serialising N Stripe calls per call (and called twice per dashboard render). Switched to \`Promise.all\` parallel — same shape as \`sumCommunitiesRevenue\`.
- **\`stripe.accounts.retrieve\` was called ~14× per \`/admin\` render** for the same connected accounts. Wrapped in React's request-scoped \`cache()\` as \`isAccountChargesEnabled\` — each account now retrieved once per request.
- **\`getCommunityMembership\` and \`getMembershipStatus\` ran the same SELECT** on every community page load. Made \`getCommunityMembership\` a thin wrapper over \`getMembershipStatus\` so they share the cached query.

## Quality / cleanup

- Removed dead \`void getAllConnectedAccountIds\` in \`activity-feed.ts\` (was silencing an unused-import warning for a function that wasn't actually reused).
- Changed \`AdminDataTable.renderSubComponent\` from \`(row: Row<T>) => ReactNode\` to \`(rowData: T) => ReactNode\` — stopped leaking TanStack \`Row<T>\` to consumers who only used \`row.original\`.
- Dropped \`useState(initialIsCreator)\` in \`FeedClient\` (the setter was never called). Renamed destructure aliases from \`initialIsCreator\` / \`initialIsAdmin\` to plain \`isCreator\` / \`isAdmin\`, fixing the rename inconsistency the admin-access fix exposed.
- Collapsed \`PlatformDashboardActivityFeed\`'s duplicated empty-state card shell into a single shell with a conditional body.
- Extracted \`formatEur\` to \`lib/admin-platform/format.ts\` — was duplicated 3×.
- Trimmed changelog-style block comments from \`lib/admin-platform/*\` files.

## Test plan
- [x] Verified end-to-end on preprod (dashboard, expand community row, admin access to other communities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)