### PR TITLE
fix(tailwind): include lib/ and hooks/ in content paths (color picker regression)

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,8 @@ module.exports = {
     './components/**/*.{ts,tsx}',
     './app/**/*.{ts,tsx}',
     './src/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}',
+    './hooks/**/*.{ts,tsx}',
 	],
   theme: {
     container: {


### PR DESCRIPTION
## Summary
Hotfix for a regression introduced by the /simplify pass (PR #44).

When I moved the section color palette out of \`components/sections/HeroSection.tsx\` into \`lib/page-builder.ts\`, Tailwind's JIT stopped seeing the utility-class strings stored in that file. The 5 classes only referenced from \`lib/\` (\`bg-violet-600\`, \`bg-emerald-600\`, \`bg-amber-600\`, \`bg-cyan-600\`, \`bg-pink-500\`) got purged from the production CSS, so 5 of the 8 swatches in the Hero/CTA color picker rendered with no background — invisible to the user.

The 3 visible swatches (\`bg-black\`, \`bg-blue-600\`, \`bg-red-600\`) only survived because those classes are also referenced from files Tailwind already scans.

## Change
\`tailwind.config.js\`: add \`./lib/**/*.{ts,tsx}\` and \`./hooks/**/*.{ts,tsx}\` to the content array. Pure build-config — no source changes, no behavior changes apart from regenerating the CSS to include the missing classes.

## Test plan
- [ ] Open admin → community → /about → page-builder → add or edit a Hero section → open settings → all 8 color swatches visible (Black, Purple, Blue, Green, Red, Orange, Cyan, Pink)
- [ ] Same for a CTA section
- [ ] No visual regressions on other pages (\`bun run build\` regenerates CSS but doesn't drop anything; new content paths can only add classes, not remove)

🤖 Generated with [Claude Code](https://claude.com/claude-code)