### PR TITLE
feat(page-builder): in-session undo/redo

### DIFF
--- a/components/PageBuilder.tsx
+++ b/components/PageBuilder.tsx
@@ -4,8 +4,9 @@ import { useState } from "react";
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { SortableContext, arrayMove, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { Section, SectionType } from "@/types/page-builder";
+import { useUndoableState } from "@/hooks/useUndoableState";
 import { Button } from "./ui/button";
-import { Plus, Sparkles, Layout, Video, Type, Image, Megaphone, Save, RotateCcw } from "lucide-react";
+import { Plus, Sparkles, Layout, Video, Type, Image, Megaphone, Save, RotateCcw, Undo2, Redo2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   Select,
@@ -75,7 +76,14 @@ export default function PageBuilder({
   isSaving = false,
   communityData
 }: PageBuilderProps) {
-  const [sections, setSections] = useState<Section[]>(initialSections);
+  const {
+    value: sections,
+    setValue: setSections,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+  } = useUndoableState<Section[]>(initialSections, { onCommit: onChange });
   const [selectedSectionType, setSelectedSectionType] = useState<SectionType | ''>('');
   const [showClearDialog, setShowClearDialog] = useState(false);
 
@@ -172,7 +180,6 @@ export default function PageBuilder({
       order: idx,
     }));
     setSections(newSections);
-    onChange(newSections);
   };
 
   const sensors = useSensors(
@@ -198,44 +205,34 @@ export default function PageBuilder({
 
     const updatedSections = [...sections, newSection];
     setSections(updatedSections);
-    onChange(updatedSections);
     setSelectedSectionType('');
   };
 
   const handleDragEnd = (event: any) => {
     const { active, over } = event;
-
-    if (active.id !== over.id) {
-      setSections((items) => {
-        const oldIndex = items.findIndex((item) => item.id === active.id);
-        const newIndex = items.findIndex((item) => item.id === over.id);
-
-        const newOrder = arrayMove(items, oldIndex, newIndex).map(
-          (item, index) => ({ ...item, order: index })
-        );
-
-        onChange(newOrder);
-        return newOrder;
-      });
-    }
+    if (!over || active.id === over.id) return;
+    const oldIndex = sections.findIndex((item) => item.id === active.id);
+    const newIndex = sections.findIndex((item) => item.id === over.id);
+    const newOrder = arrayMove(sections, oldIndex, newIndex).map(
+      (item, index) => ({ ...item, order: index }),
+    );
+    setSections(newOrder);
   };
 
   const handleUpdateSection = (sectionId: string, content: Section['content']) => {
     const updatedSections = sections.map((section) =>
       section.id === sectionId ? { ...section, content } : section
     );
-    
     setSections(updatedSections);
-    onChange(updatedSections);
   };
 
   const handleDeleteSection = (sectionId: string) => {
     const updatedSections = sections
       .filter((section) => section.id !== sectionId)
       .map((section, index) => ({ ...section, order: index }));
-    
+
+
     setSections(updatedSections);
-    onChange(updatedSections);
   };
 
   return (
@@ -349,6 +346,28 @@ export default function PageBuilder({
             </div>
             {sections.length > 0 && (
               <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={undo}
+                  disabled={!canUndo}
+                  className="rounded-xl h-11 w-11 border-border/50 disabled:opacity-40"
+                  title="Undo (last change)"
+                  aria-label="Undo"
+                >
+                  <Undo2 className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={redo}
+                  disabled={!canRedo}
+                  className="rounded-xl h-11 w-11 border-border/50 disabled:opacity-40"
+                  title="Redo"
+                  aria-label="Redo"
+                >
+                  <Redo2 className="h-4 w-4" />
+                </Button>
                 <AlertDialog open={showClearDialog} onOpenChange={setShowClearDialog}>
                   <AlertDialogTrigger asChild>
                     <Button
@@ -373,7 +392,6 @@ export default function PageBuilder({
                         className="rounded-xl bg-destructive hover:bg-destructive/90"
                         onClick={() => {
                           setSections([]);
-                          onChange([]);
                           setShowClearDialog(false);
                         }}
                       >

--- a/hooks/useUndoableState.ts
+++ b/hooks/useUndoableState.ts
@@ -1,0 +1,139 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UndoableState<T> {
+  past: T[];
+  present: T;
+  future: T[];
+}
+
+interface UseUndoableOptions<T> {
+  /**
+   * Called every time the committed value changes (set / undo / redo).
+   * Debounced changes during a typing burst still emit per keystroke;
+   * only the history push is debounced.
+   */
+  onCommit?: (value: T) => void;
+  /** Milliseconds to debounce the history push. Defaults to 500. */
+  debounceMs?: number;
+  /** Cap on the past stack length to prevent unbounded growth. Defaults to 50. */
+  limit?: number;
+}
+
+export interface UseUndoableResult<T> {
+  value: T;
+  setValue: (next: T) => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
+/**
+ * useUndoableState — a useState-shaped hook with an in-session undo/redo
+ * history. The current value updates synchronously on `setValue`, but the
+ * history push happens after a `debounceMs` quiet window so that a burst of
+ * keystrokes collapses into a single history entry (otherwise undo would
+ * step character-by-character).
+ *
+ * `undo` / `redo` flush any pending debounce immediately and step the
+ * history pointer; both fire `onCommit` so callers (parent state, persist
+ * layer) can react.
+ */
+export function useUndoableState<T>(
+  initial: T,
+  { onCommit, debounceMs = 500, limit = 50 }: UseUndoableOptions<T> = {},
+): UseUndoableResult<T> {
+  const [state, setState] = useState<UndoableState<T>>({
+    past: [],
+    present: initial,
+    future: [],
+  });
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The value as of the last committed history entry. Differs from
+  // state.present during a debounce window.
+  const lastCommittedRef = useRef<T>(initial);
+
+  // Keep the latest onCommit in a ref so setValue/undo/redo identities stay stable.
+  const onCommitRef = useRef(onCommit);
+  useEffect(() => {
+    onCommitRef.current = onCommit;
+  }, [onCommit]);
+
+  useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
+  const setValue = useCallback(
+    (next: T) => {
+      setState((prev) => ({ ...prev, present: next }));
+      onCommitRef.current?.(next);
+
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        setState((prev) => {
+          if (Object.is(prev.present, lastCommittedRef.current)) return prev;
+          const trimmedPast =
+            prev.past.length >= limit ? prev.past.slice(-(limit - 1)) : prev.past;
+          const updated: UndoableState<T> = {
+            past: [...trimmedPast, lastCommittedRef.current],
+            present: prev.present,
+            future: [],
+          };
+          lastCommittedRef.current = prev.present;
+          return updated;
+        });
+      }, debounceMs);
+    },
+    [debounceMs, limit],
+  );
+
+  const undo = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setState((prev) => {
+      if (prev.past.length === 0) return prev;
+      const previous = prev.past[prev.past.length - 1];
+      lastCommittedRef.current = previous;
+      onCommitRef.current?.(previous);
+      return {
+        past: prev.past.slice(0, -1),
+        present: previous,
+        future: [prev.present, ...prev.future],
+      };
+    });
+  }, []);
+
+  const redo = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setState((prev) => {
+      if (prev.future.length === 0) return prev;
+      const next = prev.future[0];
+      lastCommittedRef.current = next;
+      onCommitRef.current?.(next);
+      return {
+        past: [...prev.past, prev.present],
+        present: next,
+        future: prev.future.slice(1),
+      };
+    });
+  }, []);
+
+  return {
+    value: state.present,
+    setValue,
+    undo,
+    redo,
+    canUndo: state.past.length > 0,
+    canRedo: state.future.length > 0,
+  };
+}


### PR DESCRIPTION
## Summary
Adds **Undo / Redo** to the page builder editor (about page).

- New \`hooks/useUndoableState.ts\` — useState-shaped hook with a past/present/future stack. \`setValue\` updates the present synchronously (so the UI is responsive); the history push is debounced (default 500 ms) so a burst of typing in a contentEditable title collapses into one undo step instead of one-per-keystroke. \`undo\` / \`redo\` cancel the pending debounce and step the pointer.
- \`components/PageBuilder.tsx\` — replaces the local \`useState<Section[]>(initialSections)\` with the new hook. Two icon buttons (\`Undo2\` / \`Redo2\`) in the editor toolbar, disabled when there's nothing to step. The hook's \`onCommit\` callback receives the parent's existing \`onChange\` so propagation continues to work; the prior duplicate \`onChange(...)\` calls scattered through \`handleTemplateSelect / handleAddSection / handleDragEnd / handleUpdateSection / handleDeleteSection / clear-all\` are dropped. \`handleDragEnd\` also refactored from a functional \`setSections(items => …)\` to a value-form set since the hook doesn't expose a functional setter.

## Scope (what's intentionally NOT here)
- **In-session only.** History blows away on save or page refresh — matches the "(a) in-session" choice agreed on. No \`page_history\` table, no cross-session restore.
- **No keyboard shortcuts.** Cmd/Ctrl+Z conflicts with the browser's contentEditable undo when focus is in a Hero/CTA title. Easy to add later if you want it.
- **History cap of 50** to prevent runaway memory on long editing sessions; oldest entries get trimmed.

## Test plan
- [ ] Add a Hero section → click Undo → section disappears. Redo → comes back.
- [ ] Edit a title inline (typing fast) → wait ~half a second → click Undo once → reverts the whole edit, not character-by-character.
- [ ] Drag-reorder two sections → Undo → original order restored.
- [ ] Delete a section → Undo → restored.
- [ ] Open settings popover → change color → close popover → Undo → color reverts.
- [ ] Clear All → Undo → all sections back.
- [ ] After several Undos, do a new edit → Redo button becomes disabled (future stack cleared, as expected).
- [ ] Click Save → reload the page → Undo button starts disabled (history reset on reload, as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)