### PR TITLE
feat(payouts): creator-controlled payout schedule (ASAP / Weekly / Monthly)

### DIFF
--- a/app/api/community/[communitySlug]/payouts/schedule/route.ts
+++ b/app/api/community/[communitySlug]/payouts/schedule/route.ts
@@ -58,6 +58,7 @@ export async function GET(
   try {
     const session = await getSession();
     if (!session) {
+      console.warn("[payouts/schedule] No session — returning 401");
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     const result = await loadCommunityForOwner(params.communitySlug, session.user.id);
@@ -87,6 +88,7 @@ export async function PUT(
   try {
     const session = await getSession();
     if (!session) {
+      console.warn("[payouts/schedule] No session — returning 401");
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     const result = await loadCommunityForOwner(params.communitySlug, session.user.id);
@@ -132,6 +134,12 @@ export async function PUT(
     } else {
       return NextResponse.json({ error: "Unknown choice.kind" }, { status: 400 });
     }
+
+    console.log("[payouts/schedule] Updating", {
+      slug: params.communitySlug,
+      account: result.row.stripe_account_id,
+      schedule: scheduleUpdate,
+    });
 
     const updated = await stripe.accounts.update(result.row.stripe_account_id!, {
       settings: { payouts: { schedule: scheduleUpdate } },

--- a/app/api/community/[communitySlug]/payouts/schedule/route.ts
+++ b/app/api/community/[communitySlug]/payouts/schedule/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { getSession } from "@/lib/auth-session";
+import { queryOne } from "@/lib/db";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2025-12-15.clover" as Stripe.LatestApiVersion,
+});
+
+interface CommunityRow {
+  id: string;
+  created_by: string;
+  stripe_account_id: string | null;
+}
+
+const VALID_WEEKDAYS = new Set([
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+]);
+
+async function loadCommunityForOwner(
+  communitySlug: string,
+  userId: string
+): Promise<{ row: CommunityRow } | { error: NextResponse }> {
+  const row = await queryOne<CommunityRow>`
+    SELECT id, created_by, stripe_account_id
+    FROM communities
+    WHERE slug = ${communitySlug}
+  `;
+  if (!row) {
+    return {
+      error: NextResponse.json({ error: "Community not found" }, { status: 404 }),
+    };
+  }
+  if (row.created_by !== userId) {
+    return {
+      error: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+  if (!row.stripe_account_id) {
+    return {
+      error: NextResponse.json(
+        { error: "Stripe account not connected" },
+        { status: 400 }
+      ),
+    };
+  }
+  return { row };
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const result = await loadCommunityForOwner(params.communitySlug, session.user.id);
+    if ("error" in result) return result.error;
+
+    const account = await stripe.accounts.retrieve(result.row.stripe_account_id!);
+    const schedule = account.settings?.payouts?.schedule;
+    return NextResponse.json({
+      interval: schedule?.interval ?? "daily",
+      delayDays: schedule?.delay_days ?? null,
+      weeklyAnchor: schedule?.weekly_anchor ?? null,
+      monthlyAnchor: schedule?.monthly_anchor ?? null,
+    });
+  } catch (error) {
+    console.error("Error reading payout schedule:", error);
+    return NextResponse.json(
+      { error: "Failed to read payout schedule" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { communitySlug: string } }
+) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const result = await loadCommunityForOwner(params.communitySlug, session.user.id);
+    if ("error" in result) return result.error;
+
+    const body = await request.json();
+    const choice = body?.choice as
+      | { kind: "asap" }
+      | { kind: "weekly"; weekday: string }
+      | { kind: "monthly"; dayOfMonth: number }
+      | undefined;
+
+    if (!choice || typeof choice !== "object") {
+      return NextResponse.json({ error: "Missing 'choice'" }, { status: 400 });
+    }
+
+    let scheduleUpdate: Stripe.AccountUpdateParams.Settings.Payouts.Schedule;
+    if (choice.kind === "asap") {
+      scheduleUpdate = { interval: "daily", delay_days: "minimum" };
+    } else if (choice.kind === "weekly") {
+      if (!VALID_WEEKDAYS.has(choice.weekday)) {
+        return NextResponse.json(
+          { error: "weekday must be monday-friday" },
+          { status: 400 }
+        );
+      }
+      scheduleUpdate = {
+        interval: "weekly",
+        weekly_anchor: choice.weekday as Stripe.AccountUpdateParams.Settings.Payouts.Schedule.WeeklyAnchor,
+      };
+    } else if (choice.kind === "monthly") {
+      const day = Number(choice.dayOfMonth);
+      // Cap at 28 so creators don't get the silent "29-31 → last day of month"
+      // shift that Stripe applies. If they want end-of-month, we can add a
+      // dedicated option later.
+      if (!Number.isInteger(day) || day < 1 || day > 28) {
+        return NextResponse.json(
+          { error: "dayOfMonth must be an integer between 1 and 28" },
+          { status: 400 }
+        );
+      }
+      scheduleUpdate = { interval: "monthly", monthly_anchor: day };
+    } else {
+      return NextResponse.json({ error: "Unknown choice.kind" }, { status: 400 });
+    }
+
+    const updated = await stripe.accounts.update(result.row.stripe_account_id!, {
+      settings: { payouts: { schedule: scheduleUpdate } },
+    });
+
+    const schedule = updated.settings?.payouts?.schedule;
+    return NextResponse.json({
+      interval: schedule?.interval ?? "daily",
+      delayDays: schedule?.delay_days ?? null,
+      weeklyAnchor: schedule?.weekly_anchor ?? null,
+      monthlyAnchor: schedule?.monthly_anchor ?? null,
+    });
+  } catch (error: any) {
+    if (error instanceof Stripe.errors.StripeInvalidRequestError) {
+      // Country restrictions (e.g. BR/IN forced daily, JP forbids daily) and
+      // anything else Stripe rejects — surface the message so the creator
+      // sees what's going on.
+      return NextResponse.json(
+        { error: error.message || "Stripe rejected the schedule update" },
+        { status: 400 }
+      );
+    }
+    console.error("Error updating payout schedule:", error);
+    return NextResponse.json(
+      { error: "Failed to update payout schedule" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/admin/PayoutScheduleForm.tsx
+++ b/components/admin/PayoutScheduleForm.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import { Calendar, CalendarDays, Loader2, Zap } from "lucide-react";
+import { toast } from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+type Kind = "asap" | "weekly" | "monthly";
+
+interface PayoutScheduleFormProps {
+  communitySlug: string;
+  initialInterval: string; // "daily" | "weekly" | "monthly" | "manual"
+  initialWeeklyAnchor: string | null;
+  initialMonthlyAnchor: number | null;
+}
+
+const WEEKDAYS = [
+  { value: "monday", label: "Monday" },
+  { value: "tuesday", label: "Tuesday" },
+  { value: "wednesday", label: "Wednesday" },
+  { value: "thursday", label: "Thursday" },
+  { value: "friday", label: "Friday" },
+];
+
+const MONTH_DAYS = Array.from({ length: 28 }, (_, i) => i + 1);
+
+const OPTIONS: { kind: Kind; title: string; subtitle: string; icon: typeof Zap }[] = [
+  {
+    kind: "asap",
+    title: "As soon as possible",
+    subtitle: "Auto-paid out as soon as funds clear (uses your country's default delay).",
+    icon: Zap,
+  },
+  {
+    kind: "weekly",
+    title: "Weekly",
+    subtitle: "One payout per week on a fixed weekday.",
+    icon: Calendar,
+  },
+  {
+    kind: "monthly",
+    title: "Monthly",
+    subtitle: "One payout per month on a fixed day.",
+    icon: CalendarDays,
+  },
+];
+
+function intervalToKind(interval: string): Kind {
+  if (interval === "weekly") return "weekly";
+  if (interval === "monthly") return "monthly";
+  // daily / manual / unknown all collapse to ASAP for our 3-option model.
+  return "asap";
+}
+
+export function PayoutScheduleForm({
+  communitySlug,
+  initialInterval,
+  initialWeeklyAnchor,
+  initialMonthlyAnchor,
+}: PayoutScheduleFormProps) {
+  const [kind, setKind] = useState<Kind>(intervalToKind(initialInterval));
+  const [weekday, setWeekday] = useState<string>(
+    initialWeeklyAnchor && WEEKDAYS.some((d) => d.value === initialWeeklyAnchor)
+      ? initialWeeklyAnchor
+      : "monday"
+  );
+  const [dayOfMonth, setDayOfMonth] = useState<number>(
+    initialMonthlyAnchor && initialMonthlyAnchor >= 1 && initialMonthlyAnchor <= 28
+      ? initialMonthlyAnchor
+      : 1
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function handleSave() {
+    setIsSaving(true);
+    try {
+      const choice =
+        kind === "asap"
+          ? { kind: "asap" as const }
+          : kind === "weekly"
+          ? { kind: "weekly" as const, weekday }
+          : { kind: "monthly" as const, dayOfMonth };
+
+      const response = await fetch(
+        `/api/community/${communitySlug}/payouts/schedule`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ choice }),
+        }
+      );
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to update payout schedule");
+      }
+      toast.success("Payout schedule updated");
+    } catch (error) {
+      console.error("Error updating payout schedule:", error);
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update schedule"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <section className="bg-card rounded-2xl p-6 border border-border/50 space-y-5">
+      <div>
+        <h2 className="font-display text-lg font-semibold text-foreground">
+          Payout schedule
+        </h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Choose how often Stripe sends your earnings to your bank account.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {OPTIONS.map((opt) => {
+          const Icon = opt.icon;
+          const selected = kind === opt.kind;
+          return (
+            <button
+              key={opt.kind}
+              type="button"
+              onClick={() => setKind(opt.kind)}
+              className={cn(
+                "flex flex-col items-start gap-2 rounded-2xl border p-4 text-left transition-all",
+                selected
+                  ? "border-primary bg-primary/5 shadow-sm"
+                  : "border-border/50 hover:border-border bg-background"
+              )}
+              aria-pressed={selected}
+            >
+              <div
+                className={cn(
+                  "h-9 w-9 rounded-xl flex items-center justify-center",
+                  selected ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
+                )}
+              >
+                <Icon className="h-4 w-4" />
+              </div>
+              <div className="font-medium text-foreground">{opt.title}</div>
+              <div className="text-xs text-muted-foreground leading-snug">
+                {opt.subtitle}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {kind === "weekly" && (
+        <div className="max-w-xs space-y-2">
+          <label className="block text-sm font-medium text-foreground">
+            Payout day
+          </label>
+          <Select value={weekday} onValueChange={setWeekday}>
+            <SelectTrigger className="rounded-xl">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {WEEKDAYS.map((d) => (
+                <SelectItem key={d.value} value={d.value}>
+                  {d.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {kind === "monthly" && (
+        <div className="max-w-xs space-y-2">
+          <label className="block text-sm font-medium text-foreground">
+            Day of month
+          </label>
+          <Select
+            value={String(dayOfMonth)}
+            onValueChange={(v) => setDayOfMonth(Number(v))}
+          >
+            <SelectTrigger className="rounded-xl">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MONTH_DAYS.map((d) => (
+                <SelectItem key={d} value={String(d)}>
+                  {d}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Capped at the 28th so the date is the same every month.
+          </p>
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={isSaving} className="rounded-xl">
+          {isSaving ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            "Save schedule"
+          )}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/components/admin/PayoutScheduleForm.tsx
+++ b/components/admin/PayoutScheduleForm.tsx
@@ -119,7 +119,7 @@ export function PayoutScheduleForm({
           Payout schedule
         </h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Choose how often Stripe sends your earnings to your bank account.
+          Choose how often your earnings are sent to your bank account.
         </p>
       </div>
 

--- a/components/admin/SubscriptionsEditor.tsx
+++ b/components/admin/SubscriptionsEditor.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { useAuth } from "@/contexts/AuthContext";
 import { OnboardingWizard } from "@/components/stripe-onboarding/OnboardingWizard";
+import { PayoutScheduleForm } from "@/components/admin/PayoutScheduleForm";
 
 // Ported from CommunitySettingsModal.tsx lines 92-120.
 interface StripeRequirement {
@@ -748,6 +749,28 @@ export function SubscriptionsEditor({
             </p>
           )}
         </div>
+
+        {/* Payout Schedule — creator picks ASAP / weekly / monthly. We seed
+            the picker with whatever Stripe currently has so it reflects the
+            true schedule even if it was changed in the Stripe dashboard. */}
+        <PayoutScheduleForm
+          communitySlug={communitySlug}
+          initialInterval={
+            ((stripeAccountStatus.details?.payoutSchedule as
+              | { interval?: string }
+              | undefined)?.interval) ?? "daily"
+          }
+          initialWeeklyAnchor={
+            ((stripeAccountStatus.details?.payoutSchedule as
+              | { weekly_anchor?: string | null }
+              | undefined)?.weekly_anchor) ?? null
+          }
+          initialMonthlyAnchor={
+            ((stripeAccountStatus.details?.payoutSchedule as
+              | { monthly_anchor?: number | null }
+              | undefined)?.monthly_anchor) ?? null
+          }
+        />
 
         {/* Bank Account Details Section - Fluid Movement style */}
         <div className="bg-card rounded-2xl p-6 border border-border/50 space-y-4">


### PR DESCRIPTION
## Summary
- New "Payout schedule" card in Subscriptions admin → Payout Management section
- Three options: As soon as possible (daily + minimum delay), Weekly (weekday picker), Monthly (day-of-month, capped at 28)
- Calls \`stripe.accounts.update\` via new \`PUT /api/community/[slug]/payouts/schedule\`
- Reads current schedule from existing account-status fetch (no extra round-trip)
- Surfaces Stripe rejection messages in toast (e.g. country-locked schedules)

## Test plan
- [x] Daily → Weekly Monday: confirmed in preprod logs
- [x] Weekly Monday → Monthly day 5: confirmed in preprod logs
- [ ] Verify picker reflects current Stripe schedule on page load
- [ ] Try invalid country (none locally to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)