### PR TITLE
fix(settings): avatar matches the single-letter pattern used elsewhere

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -158,6 +159,16 @@ export default function SettingsPage() {
     return formatDisplayName(profile.full_name) || '';
   };
 
+  const getUserInitials = () => {
+    const name = profile?.display_name || profile?.full_name || user?.name;
+    if (name) {
+      const parts = name.split(' ');
+      if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+      return name.substring(0, 2).toUpperCase();
+    }
+    return user?.email ? user.email.substring(0, 2).toUpperCase() : 'U';
+  };
+
   const handleDisplayNameChange = (value: string) => {
     setProfile(prev =>
       prev ? { ...prev, display_name: value || null } : null
@@ -250,11 +261,12 @@ export default function SettingsPage() {
             {/* Avatar Upload */}
             <div className="flex items-center space-x-4">
               <div className="relative">
-                <img
-                  src={profile?.avatar_url || user?.image || '/placeholder-avatar.png'}
-                  alt="Profile"
-                  className="h-20 w-20 rounded-full object-cover"
-                />
+                <Avatar className="h-20 w-20">
+                  <AvatarImage src={profile?.avatar_url || user?.image || undefined} alt="Profile" />
+                  <AvatarFallback className="bg-primary/10 text-primary text-lg font-semibold">
+                    {getUserInitials()}
+                  </AvatarFallback>
+                </Avatar>
                 <Label
                   htmlFor="avatar-upload"
                   className={`absolute bottom-0 right-0 p-1 bg-white rounded-full shadow-lg cursor-pointer hover:bg-gray-100 ${

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -159,14 +159,14 @@ export default function SettingsPage() {
     return formatDisplayName(profile.full_name) || '';
   };
 
-  const getUserInitials = () => {
-    const name = profile?.display_name || profile?.full_name || user?.name;
-    if (name) {
-      const parts = name.split(' ');
-      if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
-      return name.substring(0, 2).toUpperCase();
-    }
-    return user?.email ? user.email.substring(0, 2).toUpperCase() : 'U';
+  const getUserInitial = () => {
+    return (
+      profile?.display_name?.[0] ||
+      profile?.full_name?.[0] ||
+      user?.name?.[0] ||
+      user?.email?.[0] ||
+      'U'
+    ).toUpperCase();
   };
 
   const handleDisplayNameChange = (value: string) => {
@@ -263,8 +263,8 @@ export default function SettingsPage() {
               <div className="relative">
                 <Avatar className="h-20 w-20">
                   <AvatarImage src={profile?.avatar_url || user?.image || undefined} alt="Profile" />
-                  <AvatarFallback className="bg-primary/10 text-primary text-lg font-semibold">
-                    {getUserInitials()}
+                  <AvatarFallback className="text-lg uppercase">
+                    {getUserInitial()}
                   </AvatarFallback>
                 </Avatar>
                 <Label


### PR DESCRIPTION
## Summary
Settings page rendered a raw \`<img>\` with a placeholder PNG fallback, so email/password users (no \`profile.avatar_url\`, no \`user.image\`) saw the broken placeholder instead of the initials avatar shown everywhere else.

Switch to the same \`<Avatar>/<AvatarImage>/<AvatarFallback>\` pattern used app-wide, with a single uppercase initial to match the navbar and threads.

## Test plan
- [x] Email/password user (no upload) sees their initial in a soft-purple circle, identical to the navbar avatar
- [x] Google user keeps showing the Google profile picture (\`user.image\` fallback unchanged)
- [x] Uploading an avatar still works and displays immediately