### PR TITLE
fix(members): exclude creator/admin from member listings + counts

### DIFF
--- a/app/[communitySlug]/admin/members/page.tsx
+++ b/app/[communitySlug]/admin/members/page.tsx
@@ -33,6 +33,7 @@ export default async function MembersPage({
     FROM community_members_with_profiles
     WHERE community_id = ${community.id}
       AND status = 'active'
+      AND role != 'admin'
       AND (subscription_status = 'active' OR subscription_status IS NULL)
     ORDER BY joined_at DESC
   `;

--- a/app/api/communities/route.ts
+++ b/app/api/communities/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
     const communities = await query<CommunityRow>`
       SELECT
         c.*,
-        COALESCE((SELECT COUNT(*) FROM community_members WHERE community_id = c.id), 0)::int as members_count
+        COALESCE((SELECT COUNT(*) FROM community_members WHERE community_id = c.id AND role != 'admin'), 0)::int as members_count
       FROM communities c
       ORDER BY c.created_at DESC
     `;

--- a/app/api/community/[communitySlug]/members/route.ts
+++ b/app/api/community/[communitySlug]/members/route.ts
@@ -38,12 +38,15 @@ export async function GET(
       );
     }
 
-    // Get members with their profiles (only active members with successful payment)
+    // Get members with their profiles (only active members with successful payment).
+    // Exclude the community creator/admin — they should not appear in the member roster
+    // shown to themselves or other members.
     const membersData = await query<MemberWithProfile>`
       SELECT *
       FROM community_members_with_profiles
       WHERE community_id = ${community.id}
         AND status = 'active'
+        AND role != 'admin'
         AND (subscription_status = 'active' OR subscription_status IS NULL)
     `;
 

--- a/app/api/community/[communitySlug]/route.ts
+++ b/app/api/community/[communitySlug]/route.ts
@@ -63,7 +63,7 @@ export async function GET(
         c.status,
         c.opening_date,
         c.can_change_opening_date,
-        (SELECT COUNT(*) FROM community_members cm WHERE cm.community_id = c.id)::int as members_count
+        (SELECT COUNT(*) FROM community_members cm WHERE cm.community_id = c.id AND cm.role != 'admin')::int as members_count
       FROM communities c
       WHERE c.slug = ${communitySlug}
     `;

--- a/app/api/user/[userId]/communities/route.ts
+++ b/app/api/user/[userId]/communities/route.ts
@@ -47,7 +47,7 @@ export async function GET(
       communities = await sql`
         SELECT
           c.*,
-          COALESCE((SELECT COUNT(*) FROM community_members WHERE community_id = c.id), 0)::int as members_count
+          COALESCE((SELECT COUNT(*) FROM community_members WHERE community_id = c.id AND role != 'admin'), 0)::int as members_count
         FROM communities c
         WHERE c.id = ANY(${communityIds})
         ORDER BY c.created_at DESC


### PR DESCRIPTION
## Summary
Community creators are stored in \`community_members\` with \`role='admin'\`, which made them appear in:
- Admin → Members tab
- Public member roster (banner avatar previews + the X-members count)
- Discovery and dashboard community-card member counts

Add \`role != 'admin'\` to the five surfaces. Operational queries (subscription checks, join/leave, cron, permission checks) keep their full view.

## Test plan (verified on preprod)
- [x] Lesfousdubus: 2 → 1 member
- [x] Bachata Online by Marcela: 23 → 22 members
- [x] BachataFlowLive2: 3 → 2 members
- [x] Creator no longer in their own admin Members table or in the banner avatar preview