### PR TITLE
fix(prereg): hard reload after pre-registration completes

### DIFF
--- a/app/[communitySlug]/FeedClient.tsx
+++ b/app/[communitySlug]/FeedClient.tsx
@@ -840,6 +840,7 @@ export default function FeedClient({
           setIsPreRegistered(true);
           setShowPreRegistrationModal(false);
           toast.success("Pre-registration successful! You'll be charged on the opening date.");
+          window.location.reload();
         }}
       />
 

--- a/hooks/useJoinCommunity.tsx
+++ b/hooks/useJoinCommunity.tsx
@@ -60,7 +60,7 @@ export function useJoinCommunity(
   const onPreRegSuccess = () => {
     closePreReg();
     toast.success('Pre-registration confirmed!');
-    if (community) router.push(`/${community.slug}`);
+    window.location.reload();
   };
 
   const join = async () => {


### PR DESCRIPTION
## Summary
Pre-registration's `onSuccess` handlers updated local state and showed a toast but never refreshed the server-rendered layout. Users had to manually reload to see the updated UI. Mirrors the `PaymentModal` fix from PR #56.

Touches:
- `app/[communitySlug]/FeedClient.tsx` — inline pre-reg modal
- `hooks/useJoinCommunity.tsx` — shared hook used by `HeroSection` / `CTASection`

## Test plan
- [x] Build green
- [ ] Smoke pre-registration on a community in pre_registration status (no live community has this state right now, so manual smoke deferred to next time it's exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)