### PR TITLE
fix(tests): stop hitting prod DB + repair 4 schema-drift suites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 # Neon Database
 DATABASE_URL=postgresql://user:password@host/database?sslmode=require
 
+# Test database (use a dedicated Neon branch, NEVER prod). Required for `bun test`.
+TEST_DATABASE_URL=postgresql://user:password@host/database?sslmode=require
+
 # Stripe
 STRIPE_SECRET_KEY=your_stripe_secret_key
 STRIPE_WEBHOOK_SECRET=your_stripe_webhook_secret

--- a/__tests__/api/auth-database.test.ts
+++ b/__tests__/api/auth-database.test.ts
@@ -13,8 +13,14 @@
  * - Better Auth "user" table uses camelCase: emailVerified, createdAt, updatedAt
  * - profiles table uses snake_case: auth_user_id, created_at, updated_at
  * - auth_user_id is TEXT type (matching Better Auth user.id)
+ *
+ * Isolation notes:
+ * - Each test that needs persistent data creates its own user/profile pair
+ *   via `makeAuthUser()` and tracks them in `createdUserIds` / `createdProfileIds`.
+ *   `afterAll` cleans them up. No module-level shared mutable state.
  */
 
+import crypto from 'crypto';
 import {
   testQuery,
   testQueryOne,
@@ -43,75 +49,69 @@ interface BetterAuthUser {
   updatedAt: string;       // camelCase
 }
 
-// Test data IDs for auth tests
-const AUTH_TEST_IDS = {
-  profileId: '',
-  authUserId: '',
-  secondProfileId: '',
-  secondAuthUserId: '',
-};
-
 describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
-  // Generate unique identifiers for this test run
-  const uniqueSuffix = Date.now().toString(36);
+  // Track every user/profile we create so afterAll can clean up.
+  const createdUserIds: string[] = [];
+  const createdProfileIds: string[] = [];
 
-  beforeAll(async () => {
-    // Create a test Better Auth user first
-    // Note: Better Auth uses camelCase column names and TEXT id
-    const authUser = await testQueryOne<{ id: string }>`
+  /**
+   * Insert a fresh Better-Auth user row, track its id, and return it.
+   *
+   * The DB has an `on_user_created` AFTER INSERT trigger that auto-inserts a
+   * matching `profiles` row from the user's email/name. We rely on that here
+   * — never insert a second profile for the same auth_user_id, or queries
+   * like `WHERE auth_user_id = X` will return multiple rows and break
+   * UPDATE...RETURNING.
+   */
+  async function makeAuthUser(label: string = 'user'): Promise<{ id: string; email: string }> {
+    const id = `auth-test-${label}-${crypto.randomUUID()}`;
+    const email = `${id}@test.com`;
+    await testSql`
       INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
-      VALUES (
-        ${'auth-test-' + uniqueSuffix},
-        ${'auth-test-user-' + uniqueSuffix + '@test.com'},
-        'Test Auth User',
-        false,
-        NOW(),
-        NOW()
-      )
-      RETURNING id
+      VALUES (${id}, ${email}, ${`Test User ${label}`}, false, NOW(), NOW())
     `;
+    createdUserIds.push(id);
+    return { id, email };
+  }
 
-    if (!authUser) throw new Error('Failed to create test auth user');
-    AUTH_TEST_IDS.authUserId = authUser.id;
+  /**
+   * Look up the profile auto-created by the `on_user_created` trigger,
+   * optionally rewriting full_name/display_name. We do NOT insert a new
+   * profile row — the trigger already created one with auth_user_id set.
+   */
+  async function makeProfile(
+    authUserId: string,
+    overrides: Partial<{ full_name: string | null; display_name: string | null }> = {},
+  ): Promise<Profile> {
+    const fullName = overrides.full_name === undefined ? 'Test Profile User' : overrides.full_name;
+    const displayName = overrides.display_name === undefined
+      ? (fullName?.split(' ')[0] ?? null)
+      : overrides.display_name;
 
-    // Create a second auth user for additional tests
-    const secondAuthUser = await testQueryOne<{ id: string }>`
-      INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
-      VALUES (
-        ${'auth-test2-' + uniqueSuffix},
-        ${'auth-test-user2-' + uniqueSuffix + '@test.com'},
-        'Test Auth User 2',
-        false,
-        NOW(),
-        NOW()
-      )
-      RETURNING id
+    const profile = await testQueryOne<Profile>`
+      UPDATE profiles
+      SET full_name = ${fullName}, display_name = ${displayName}, updated_at = NOW()
+      WHERE auth_user_id = ${authUserId}
+      RETURNING *
     `;
-
-    if (!secondAuthUser) throw new Error('Failed to create second test auth user');
-    AUTH_TEST_IDS.secondAuthUserId = secondAuthUser.id;
-  });
+    if (!profile) {
+      throw new Error(
+        `Expected on_user_created trigger to have inserted profile for ${authUserId}`,
+      );
+    }
+    return profile;
+  }
 
   afterAll(async () => {
-    // Clean up test data in reverse order (profiles first due to FK)
-    if (AUTH_TEST_IDS.profileId) {
-      await testSql`DELETE FROM profiles WHERE id = ${AUTH_TEST_IDS.profileId}`;
+    // Profiles first (FK auth_user_id -> "user".id), then users.
+    for (const id of createdProfileIds) {
+      await testSql`DELETE FROM profiles WHERE id = ${id}`;
     }
-    if (AUTH_TEST_IDS.secondProfileId) {
-      await testSql`DELETE FROM profiles WHERE id = ${AUTH_TEST_IDS.secondProfileId}`;
+    for (const id of createdUserIds) {
+      await testSql`DELETE FROM "user" WHERE id = ${id}`;
     }
-    if (AUTH_TEST_IDS.authUserId) {
-      await testSql`DELETE FROM "user" WHERE id = ${AUTH_TEST_IDS.authUserId}`;
-    }
-    if (AUTH_TEST_IDS.secondAuthUserId) {
-      await testSql`DELETE FROM "user" WHERE id = ${AUTH_TEST_IDS.secondAuthUserId}`;
-    }
-
-    // Reset IDs
-    AUTH_TEST_IDS.profileId = '';
-    AUTH_TEST_IDS.authUserId = '';
-    AUTH_TEST_IDS.secondProfileId = '';
-    AUTH_TEST_IDS.secondAuthUserId = '';
+    createdProfileIds.length = 0;
+    createdUserIds.length = 0;
   });
 
   describe('1. Database Connection', () => {
@@ -144,10 +144,10 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
 
   describe('2. Signup Profile Creation (app/api/auth/signup/route.ts pattern)', () => {
     it('should create profile with full_name and auto-generate display_name', async () => {
-      const email = `signup-test-${uniqueSuffix}@test.com`;
+      const authUser = await makeAuthUser('signup-fullname');
+      const email = `signup-test-${crypto.randomUUID()}@test.com`;
       const fullName = 'John Doe';
 
-      // Pattern from signup route: INSERT with all fields
       const profile = await testQueryOne<Profile>`
         INSERT INTO profiles (id, email, full_name, display_name, created_at, updated_at, auth_user_id)
         VALUES (
@@ -157,7 +157,7 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
           ${fullName.split(' ')[0]},
           NOW(),
           NOW(),
-          ${AUTH_TEST_IDS.authUserId}
+          ${authUser.id}
         )
         RETURNING *
       `;
@@ -166,17 +166,17 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
       expect(profile?.email).toBe(email);
       expect(profile?.full_name).toBe(fullName);
       expect(profile?.display_name).toBe('John');
-      expect(profile?.auth_user_id).toBe(AUTH_TEST_IDS.authUserId);
+      expect(profile?.auth_user_id).toBe(authUser.id);
 
-      AUTH_TEST_IDS.profileId = profile!.id;
+      createdProfileIds.push(profile!.id);
     });
 
     it('should create profile with NULL full_name and display_name', async () => {
-      const email = `signup-test-null-${uniqueSuffix}@test.com`;
+      const authUser = await makeAuthUser('signup-null');
+      const email = `signup-test-null-${crypto.randomUUID()}@test.com`;
       const fullName = null as string | null;
       const displayName = fullName?.split(' ')[0] || null;
 
-      // Pattern from signup route: INSERT with NULL values
       const profile = await testQueryOne<Profile>`
         INSERT INTO profiles (id, email, full_name, display_name, created_at, updated_at, auth_user_id)
         VALUES (
@@ -186,7 +186,7 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
           ${displayName},
           NOW(),
           NOW(),
-          ${AUTH_TEST_IDS.secondAuthUserId}
+          ${authUser.id}
         )
         RETURNING *
       `;
@@ -195,58 +195,45 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
       expect(profile?.email).toBe(email);
       expect(profile?.full_name).toBeNull();
       expect(profile?.display_name).toBeNull();
-      expect(profile?.auth_user_id).toBe(AUTH_TEST_IDS.secondAuthUserId);
+      expect(profile?.auth_user_id).toBe(authUser.id);
 
-      AUTH_TEST_IDS.secondProfileId = profile!.id;
+      createdProfileIds.push(profile!.id);
     });
 
     it('should handle ON CONFLICT (email) upsert pattern from signup route', async () => {
-      // First, get the existing profile
-      const existingProfile = await testQueryOne<Profile>`
-        SELECT * FROM profiles WHERE id = ${AUTH_TEST_IDS.profileId}
-      `;
-      expect(existingProfile).not.toBeNull();
+      const authUser = await makeAuthUser('signup-conflict');
+      const profile = await makeProfile(authUser.id, { full_name: 'Original Name' });
 
-      const newAuthUserId = AUTH_TEST_IDS.authUserId;
-
-      // Pattern from signup route: ON CONFLICT (email) updates auth_user_id
-      // This works because profiles.email has a unique constraint
+      // ON CONFLICT (email) should update auth_user_id and updated_at, leaving
+      // other columns alone.
       const updatedProfile = await testQueryOne<Profile>`
         INSERT INTO profiles (id, email, full_name, display_name, created_at, updated_at, auth_user_id)
         VALUES (
           gen_random_uuid(),
-          ${existingProfile!.email},
+          ${profile.email},
           ${'Updated Name'},
           ${'Updated'},
           NOW(),
           NOW(),
-          ${newAuthUserId}
+          ${authUser.id}
         )
         ON CONFLICT (email) DO UPDATE SET
-          auth_user_id = ${newAuthUserId},
+          auth_user_id = ${authUser.id},
           updated_at = NOW()
         RETURNING *
       `;
 
       expect(updatedProfile).not.toBeNull();
-      // Should keep the same ID (upsert on existing row)
-      expect(updatedProfile?.id).toBe(existingProfile!.id);
-      // auth_user_id should be updated
-      expect(updatedProfile?.auth_user_id).toBe(newAuthUserId);
-      // original fields should NOT change (only auth_user_id and updated_at)
-      expect(updatedProfile?.full_name).toBe(existingProfile!.full_name);
+      expect(updatedProfile?.id).toBe(profile.id);
+      expect(updatedProfile?.auth_user_id).toBe(authUser.id);
+      // Original full_name should NOT change (only auth_user_id and updated_at do)
+      expect(updatedProfile?.full_name).toBe('Original Name');
     });
 
     it('should handle display_name extraction from multi-word full_name', async () => {
       const fullName = 'Maria Garcia Lopez';
-      const email = `multi-word-test-${uniqueSuffix}@test.com`;
-
-      // Create a temp auth user for this test (Better Auth uses TEXT id)
-      const tempAuthUser = await testQueryOne<{ id: string }>`
-        INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
-        VALUES (${'temp-auth-' + uniqueSuffix}, ${email}, ${fullName}, false, NOW(), NOW())
-        RETURNING id
-      `;
+      const authUser = await makeAuthUser('signup-multiword');
+      const email = `multi-word-test-${crypto.randomUUID()}@test.com`;
 
       const profile = await testQueryOne<Profile>`
         INSERT INTO profiles (id, email, full_name, display_name, created_at, updated_at, auth_user_id)
@@ -257,67 +244,67 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
           ${fullName.split(' ')[0]},
           NOW(),
           NOW(),
-          ${tempAuthUser!.id}
+          ${authUser.id}
         )
         RETURNING *
       `;
 
       expect(profile?.display_name).toBe('Maria');
       expect(profile?.full_name).toBe('Maria Garcia Lopez');
-
-      // Cleanup
-      await testSql`DELETE FROM profiles WHERE id = ${profile!.id}`;
-      await testSql`DELETE FROM "user" WHERE id = ${tempAuthUser!.id}`;
+      createdProfileIds.push(profile!.id);
     });
   });
 
   describe('3. Email Verification Sync (app/api/auth/verify-email/route.ts pattern)', () => {
     it('should update profile email by auth_user_id', async () => {
-      const newEmail = `verified-${uniqueSuffix}@test.com`;
+      const authUser = await makeAuthUser('verify');
+      await makeProfile(authUser.id);
 
-      // Pattern from verify-email route: UPDATE by auth_user_id
+      const newEmail = `verified-${crypto.randomUUID()}@test.com`;
+
       const updatedProfile = await testQueryOne<Profile>`
         UPDATE profiles
         SET email = ${newEmail}, updated_at = NOW()
-        WHERE auth_user_id = ${AUTH_TEST_IDS.authUserId}
+        WHERE auth_user_id = ${authUser.id}
         RETURNING *
       `;
 
       expect(updatedProfile).not.toBeNull();
       expect(updatedProfile?.email).toBe(newEmail);
-      expect(updatedProfile?.auth_user_id).toBe(AUTH_TEST_IDS.authUserId);
+      expect(updatedProfile?.auth_user_id).toBe(authUser.id);
     });
 
     it('should update updated_at timestamp on email change', async () => {
-      // Get current timestamp
+      const authUser = await makeAuthUser('verify-updated-at');
+      await makeProfile(authUser.id);
+
       const before = await testQueryOne<Profile>`
-        SELECT * FROM profiles WHERE auth_user_id = ${AUTH_TEST_IDS.authUserId}
+        SELECT * FROM profiles WHERE auth_user_id = ${authUser.id}
       `;
       expect(before).not.toBeNull();
 
       // Small delay to ensure timestamp difference
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
-      const newEmail = `verified2-${uniqueSuffix}@test.com`;
+      const newEmail = `verified2-${crypto.randomUUID()}@test.com`;
 
       const after = await testQueryOne<Profile>`
         UPDATE profiles
         SET email = ${newEmail}, updated_at = NOW()
-        WHERE auth_user_id = ${AUTH_TEST_IDS.authUserId}
+        WHERE auth_user_id = ${authUser.id}
         RETURNING *
       `;
 
       expect(after).not.toBeNull();
       expect(new Date(after!.updated_at).getTime()).toBeGreaterThan(
-        new Date(before!.updated_at).getTime()
+        new Date(before!.updated_at).getTime(),
       );
     });
 
     it('should handle update when profile does not exist (no-op)', async () => {
-      const nonExistentAuthUserId = 'non-existent-auth-user-id';
+      const nonExistentAuthUserId = `non-existent-${crypto.randomUUID()}`;
       const newEmail = 'should-not-update@test.com';
 
-      // This should return null (no rows updated)
       const result = await testQueryOne<Profile>`
         UPDATE profiles
         SET email = ${newEmail}, updated_at = NOW()
@@ -331,13 +318,15 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
 
   describe('4. Email Change Sync (app/api/auth/verify-email-change/route.ts pattern)', () => {
     it('should update email on change verification', async () => {
-      const changedEmail = `changed-email-${uniqueSuffix}@test.com`;
+      const authUser = await makeAuthUser('change');
+      await makeProfile(authUser.id);
 
-      // Pattern from verify-email-change route (same as verify-email)
+      const changedEmail = `changed-email-${crypto.randomUUID()}@test.com`;
+
       const updatedProfile = await testQueryOne<Profile>`
         UPDATE profiles
         SET email = ${changedEmail}, updated_at = NOW()
-        WHERE auth_user_id = ${AUTH_TEST_IDS.authUserId}
+        WHERE auth_user_id = ${authUser.id}
         RETURNING *
       `;
 
@@ -346,24 +335,26 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
     });
 
     it('should handle sequential email updates', async () => {
-      // Simulate two updates in sequence
-      const email1 = `sequential1-${uniqueSuffix}@test.com`;
-      const email2 = `sequential2-${uniqueSuffix}@test.com`;
+      const authUser = await makeAuthUser('sequential');
+      await makeProfile(authUser.id);
+
+      const email1 = `sequential1-${crypto.randomUUID()}@test.com`;
+      const email2 = `sequential2-${crypto.randomUUID()}@test.com`;
 
       await testSql`
         UPDATE profiles
         SET email = ${email1}, updated_at = NOW()
-        WHERE auth_user_id = ${AUTH_TEST_IDS.authUserId}
+        WHERE auth_user_id = ${authUser.id}
       `;
 
       await testSql`
         UPDATE profiles
         SET email = ${email2}, updated_at = NOW()
-        WHERE auth_user_id = ${AUTH_TEST_IDS.authUserId}
+        WHERE auth_user_id = ${authUser.id}
       `;
 
       const result = await testQueryOne<Profile>`
-        SELECT * FROM profiles WHERE auth_user_id = ${AUTH_TEST_IDS.authUserId}
+        SELECT * FROM profiles WHERE auth_user_id = ${authUser.id}
       `;
 
       // Last update should win
@@ -373,12 +364,13 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
 
   describe('5. Better Auth User Table Tests', () => {
     it('should query Better Auth user by id', async () => {
+      const authUser = await makeAuthUser('lookup');
       const user = await testQueryOne<BetterAuthUser>`
-        SELECT * FROM "user" WHERE id = ${AUTH_TEST_IDS.authUserId}
+        SELECT * FROM "user" WHERE id = ${authUser.id}
       `;
 
       expect(user).not.toBeNull();
-      expect(user?.email).toContain('auth-test-user');
+      expect(user?.email).toBe(authUser.email);
     });
 
     it('should have session table', async () => {
@@ -414,6 +406,9 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
 
   describe('6. Profile-User Relationship Tests', () => {
     it('should join profiles with Better Auth user table', async () => {
+      const authUser = await makeAuthUser('join');
+      const profile = await makeProfile(authUser.id);
+
       const result = await testQueryOne<{
         profile_id: string;
         profile_email: string;
@@ -429,25 +424,27 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
           u.name as auth_name
         FROM profiles p
         JOIN "user" u ON p.auth_user_id = u.id
-        WHERE p.id = ${AUTH_TEST_IDS.profileId}
+        WHERE p.id = ${profile.id}
       `;
 
       expect(result).not.toBeNull();
-      expect(result?.auth_user_id).toBe(AUTH_TEST_IDS.authUserId);
+      expect(result?.auth_user_id).toBe(authUser.id);
     });
 
     it('should find profile by auth_user_id', async () => {
-      const profile = await testQueryOne<Profile>`
-        SELECT * FROM profiles WHERE auth_user_id = ${AUTH_TEST_IDS.authUserId}
+      const authUser = await makeAuthUser('lookup-by-auth');
+      const profile = await makeProfile(authUser.id);
+
+      const found = await testQueryOne<Profile>`
+        SELECT * FROM profiles WHERE auth_user_id = ${authUser.id}
       `;
 
-      expect(profile).not.toBeNull();
-      expect(profile?.id).toBe(AUTH_TEST_IDS.profileId);
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(profile.id);
     });
 
     it('should allow NULL auth_user_id for legacy profiles', async () => {
-      // Create a profile without auth_user_id (legacy migration case)
-      const legacyEmail = `legacy-profile-${uniqueSuffix}@test.com`;
+      const legacyEmail = `legacy-profile-${crypto.randomUUID()}@test.com`;
 
       const legacyProfile = await testQueryOne<Profile>`
         INSERT INTO profiles (id, email, full_name, display_name, created_at, updated_at, auth_user_id)
@@ -465,45 +462,34 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
 
       expect(legacyProfile).not.toBeNull();
       expect(legacyProfile?.auth_user_id).toBeNull();
-
-      // Cleanup
-      await testSql`DELETE FROM profiles WHERE id = ${legacyProfile!.id}`;
+      createdProfileIds.push(legacyProfile!.id);
     });
   });
 
   describe('7. Constraint Tests', () => {
     it('should enforce unique email constraint on profiles', async () => {
-      const existingProfile = await testQueryOne<Profile>`
-        SELECT * FROM profiles WHERE id = ${AUTH_TEST_IDS.profileId}
-      `;
+      const authUser = await makeAuthUser('unique-1');
+      const profile = await makeProfile(authUser.id);
 
-      // Create a temp auth user for the duplicate email test
-      const tempAuthUser = await testQueryOne<{ id: string }>`
-        INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
-        VALUES (${'temp-dup-' + Date.now()}, ${'temp-dup-' + Date.now() + '@test.com'}, 'Temp', false, NOW(), NOW())
-        RETURNING id
-      `;
+      const otherUser = await makeAuthUser('unique-2');
 
       // Try to insert duplicate email without ON CONFLICT - should fail
       let errorThrown = false;
       try {
         await testSql`
           INSERT INTO profiles (id, email, created_at, updated_at, auth_user_id)
-          VALUES (gen_random_uuid(), ${existingProfile!.email}, NOW(), NOW(), ${tempAuthUser!.id})
+          VALUES (gen_random_uuid(), ${profile.email}, NOW(), NOW(), ${otherUser.id})
         `;
       } catch (error) {
         errorThrown = true;
         expect(String(error)).toContain('profiles_email_key');
       }
       expect(errorThrown).toBe(true);
-
-      // Cleanup
-      await testSql`DELETE FROM "user" WHERE id = ${tempAuthUser!.id}`;
     });
 
     it('should allow multiple NULL display_names', async () => {
-      const email1 = `null-display1-${uniqueSuffix}@test.com`;
-      const email2 = `null-display2-${uniqueSuffix}@test.com`;
+      const email1 = `null-display1-${crypto.randomUUID()}@test.com`;
+      const email2 = `null-display2-${crypto.randomUUID()}@test.com`;
 
       const profile1 = await testQueryOne<Profile>`
         INSERT INTO profiles (id, email, display_name, created_at, updated_at)
@@ -519,17 +505,13 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
 
       expect(profile1?.display_name).toBeNull();
       expect(profile2?.display_name).toBeNull();
-
-      // Cleanup
-      await testSql`DELETE FROM profiles WHERE id = ${profile1!.id}`;
-      await testSql`DELETE FROM profiles WHERE id = ${profile2!.id}`;
+      createdProfileIds.push(profile1!.id, profile2!.id);
     });
 
     it('should enforce foreign key from profiles.auth_user_id to user.id', async () => {
-      const fakeAuthUserId = 'this-user-does-not-exist';
-      const email = `fk-test-${uniqueSuffix}@test.com`;
+      const fakeAuthUserId = `this-user-does-not-exist-${crypto.randomUUID()}`;
+      const email = `fk-test-${crypto.randomUUID()}@test.com`;
 
-      // Try to insert profile with non-existent auth_user_id - should fail
       let errorThrown = false;
       try {
         await testSql`
@@ -553,9 +535,8 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
         ORDER BY ordinal_position
       `;
 
-      const columnNames = columns.map(c => c.column_name);
+      const columnNames = columns.map((c) => c.column_name);
 
-      // Required Better Auth columns (camelCase)
       expect(columnNames).toContain('id');
       expect(columnNames).toContain('email');
       expect(columnNames).toContain('name');
@@ -572,9 +553,8 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
         ORDER BY ordinal_position
       `;
 
-      const columnNames = columns.map(c => c.column_name);
+      const columnNames = columns.map((c) => c.column_name);
 
-      // Custom fields added in auth-server.ts
       expect(columnNames).toContain('displayName');
       expect(columnNames).toContain('fullName');
       expect(columnNames).toContain('avatarUrl');
@@ -590,7 +570,7 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
         ORDER BY ordinal_position
       `;
 
-      const columnNames = columns.map(c => c.column_name);
+      const columnNames = columns.map((c) => c.column_name);
 
       expect(columnNames).toContain('id');
       expect(columnNames).toContain('userId');
@@ -606,7 +586,7 @@ describe('Auth Database Layer Tests - Better Auth + Neon Integration', () => {
         ORDER BY ordinal_position
       `;
 
-      const columnNames = columns.map(c => c.column_name);
+      const columnNames = columns.map((c) => c.column_name);
 
       expect(columnNames).toContain('id');
       expect(columnNames).toContain('userId');

--- a/__tests__/api/database-views-functions.test.ts
+++ b/__tests__/api/database-views-functions.test.ts
@@ -59,6 +59,9 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
 
   describe('2. community_members_with_profiles View', () => {
     it('should return member with profile data', async () => {
+      // The view exposes cm.* plus p.full_name, p.display_name, p.avatar_url,
+      // p.email — no `formatted_display_name` (that helper lives on the
+      // get_display_name function instead).
       const result = await testQueryOne<{
         id: string;
         user_id: string;
@@ -66,7 +69,6 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
         role: string;
         full_name: string | null;
         display_name: string | null;
-        formatted_display_name: string;
       }>`
         SELECT * FROM community_members_with_profiles
         WHERE id = ${TEST_IDS.memberId}
@@ -74,10 +76,9 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
 
       expect(result).not.toBeNull();
       expect(result?.community_id).toBe(TEST_IDS.communityId);
-      expect(result?.user_id).toBe(TEST_IDS.secondProfileId);
+      // After Better-Auth migration, community_members.user_id is the TEXT user id.
+      expect(result?.user_id).toBe(TEST_IDS.secondUserId);
       expect(result?.role).toBe('member');
-      // formatted_display_name should fallback if display_name is null
-      expect(result?.formatted_display_name).toBeDefined();
     });
 
     it('should join profile fields correctly', async () => {
@@ -96,20 +97,23 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
     });
 
     it('should include subscription fields', async () => {
+      // The view exposes subscription_status, stripe_customer_id, and
+      // stripe_subscription_id (no separate `subscription_id` column).
       const result = await testQueryOne<{
-        subscription_id: string | null;
         subscription_status: string | null;
         stripe_customer_id: string | null;
+        stripe_subscription_id: string | null;
       }>`
-        SELECT subscription_id, subscription_status, stripe_customer_id
+        SELECT subscription_status, stripe_customer_id, stripe_subscription_id
         FROM community_members_with_profiles
         WHERE id = ${TEST_IDS.memberId}
       `;
 
       expect(result).not.toBeNull();
       // Fields should exist even if null
-      expect('subscription_id' in result!).toBe(true);
       expect('subscription_status' in result!).toBe(true);
+      expect('stripe_customer_id' in result!).toBe(true);
+      expect('stripe_subscription_id' in result!).toBe(true);
     });
   });
 
@@ -144,7 +148,7 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
         VALUES (
           gen_random_uuid(),
           ${TEST_IDS.communityId},
-          ${TEST_IDS.profileId},
+          ${TEST_IDS.userId},
           'Currently Active Class',
           NOW() - INTERVAL '5 minutes',
           60,
@@ -171,7 +175,7 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
         VALUES (
           gen_random_uuid(),
           ${TEST_IDS.communityId},
-          ${TEST_IDS.profileId},
+          ${TEST_IDS.userId},
           'Starting Soon Class',
           NOW() + INTERVAL '10 minutes',
           60,
@@ -295,21 +299,24 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
       expect(result?.exists).toBe(true);
     });
 
-    it('should auto-update updated_at on profile change', async () => {
+    it('should auto-update updated_at via trigger on communities change', async () => {
+      // The update_updated_at_column trigger is wired to communities (and a few
+      // other tables) but NOT to profiles. Use communities to verify the
+      // trigger function actually fires.
       const before = await testQueryOne<{ updated_at: string }>`
-        SELECT updated_at FROM profiles WHERE id = ${TEST_IDS.profileId}
+        SELECT updated_at FROM communities WHERE id = ${TEST_IDS.communityId}
       `;
 
       // Longer delay to ensure timestamp difference (Postgres timestamp precision)
       await new Promise(resolve => setTimeout(resolve, 1100));
 
       await testSql`
-        UPDATE profiles SET full_name = 'Trigger Test Name'
-        WHERE id = ${TEST_IDS.profileId}
+        UPDATE communities SET description = 'Trigger Test Description'
+        WHERE id = ${TEST_IDS.communityId}
       `;
 
       const after = await testQueryOne<{ updated_at: string }>`
-        SELECT updated_at FROM profiles WHERE id = ${TEST_IDS.profileId}
+        SELECT updated_at FROM communities WHERE id = ${TEST_IDS.communityId}
       `;
 
       // Check that updated_at changed (>= because trigger may have same second precision)
@@ -319,8 +326,8 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
 
       // Reset
       await testSql`
-        UPDATE profiles SET full_name = 'Test Creator User'
-        WHERE id = ${TEST_IDS.profileId}
+        UPDATE communities SET description = 'A test community for integration tests'
+        WHERE id = ${TEST_IDS.communityId}
       `;
     });
   });
@@ -349,10 +356,10 @@ describe('Database Views & Functions Tests - Neon Migration', () => {
     });
 
     it('should get lessons in correct order', async () => {
-      // Create a second lesson
+      // Create a second lesson. lessons.created_by is TEXT (Better-Auth user id).
       const lesson2 = await testQueryOne<{ id: string }>`
         INSERT INTO lessons (id, title, lesson_position, chapter_id, created_by)
-        VALUES (gen_random_uuid(), 'Second Lesson', 2, ${TEST_IDS.chapterId}, ${TEST_IDS.profileId})
+        VALUES (gen_random_uuid(), 'Second Lesson', 2, ${TEST_IDS.chapterId}, ${TEST_IDS.userId})
         RETURNING id
       `;
 

--- a/__tests__/api/wave5-integration.test.ts
+++ b/__tests__/api/wave5-integration.test.ts
@@ -244,10 +244,12 @@ describe('Wave 5 Integration Tests - Neon Database Layer', () => {
       `;
       expect(lesson).not.toBeNull();
 
+      // private_lessons.teacher_id is the Better-Auth user id (TEXT), so we
+      // join profiles via auth_user_id rather than profiles.id.
       const teacher = await testQueryOne<Profile>`
         SELECT id, display_name, full_name, avatar_url
         FROM profiles
-        WHERE id = ${lesson!.teacher_id}
+        WHERE auth_user_id = ${lesson!.teacher_id}
       `;
       expect(teacher).not.toBeNull();
     });

--- a/__tests__/api/waves1-4-integration.test.ts
+++ b/__tests__/api/waves1-4-integration.test.ts
@@ -172,7 +172,7 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
         const members = await testQuery<CommunityMember & { display_name: string | null }>`
           SELECT cm.*, p.display_name
           FROM community_members cm
-          JOIN profiles p ON p.id = cm.user_id
+          JOIN profiles p ON p.auth_user_id = cm.user_id
           WHERE cm.community_id = ${TEST_IDS.communityId}
         `;
         expect(members.length).toBeGreaterThan(0);
@@ -238,22 +238,23 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
 
     describe('threads/[threadId]/like/route.ts', () => {
       it('should add like to thread', async () => {
-        // Add a like using array_append
+        // threads.likes is TEXT[] post Better-Auth migration; entries are
+        // Better-Auth user ids, no ::uuid cast.
         await testSql`
           UPDATE threads
-          SET likes = array_append(COALESCE(likes, '{}'), ${TEST_IDS.secondProfileId}::uuid)
+          SET likes = array_append(COALESCE(likes, '{}'), ${TEST_IDS.secondUserId})
           WHERE id = ${TEST_IDS.threadId}
         `;
 
         const thread = await testQueryOne<{ likes: string[] }>`
           SELECT likes FROM threads WHERE id = ${TEST_IDS.threadId}
         `;
-        expect(thread?.likes).toContain(TEST_IDS.secondProfileId);
+        expect(thread?.likes).toContain(TEST_IDS.secondUserId);
 
         // Remove the like
         await testSql`
           UPDATE threads
-          SET likes = array_remove(likes, ${TEST_IDS.secondProfileId}::uuid)
+          SET likes = array_remove(likes, ${TEST_IDS.secondUserId})
           WHERE id = ${TEST_IDS.threadId}
         `;
       });
@@ -264,7 +265,7 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
         const members = await testQuery<CommunityMember & Profile>`
           SELECT cm.*, p.full_name, p.avatar_url, p.display_name
           FROM community_members cm
-          JOIN profiles p ON p.id = cm.user_id
+          JOIN profiles p ON p.auth_user_id = cm.user_id
           WHERE cm.community_id = ${TEST_IDS.communityId}
           AND cm.status = 'active'
         `;
@@ -290,7 +291,8 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
           FROM communities
           WHERE slug = ${TEST_IDS.communitySlug}
         `;
-        expect(community?.created_by).toBe(TEST_IDS.profileId);
+        // communities.created_by is TEXT (Better-Auth user id) post-migration.
+        expect(community?.created_by).toBe(TEST_IDS.userId);
       });
     });
 
@@ -340,7 +342,7 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
             'Test Create Community',
             ${testSlug},
             'Created for testing',
-            ${TEST_IDS.profileId},
+            ${TEST_IDS.userId},
             'active'
           )
           RETURNING *
@@ -377,9 +379,9 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
           VALUES (
             'New Test Thread',
             'New test thread content',
-            ${TEST_IDS.profileId},
+            ${TEST_IDS.userId},
             ${TEST_IDS.communityId},
-            ${TEST_IDS.profileId},
+            ${TEST_IDS.userId},
             'Test Creator User'
           )
           RETURNING *
@@ -467,7 +469,7 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
         const membership = await testQueryOne<CommunityMember>`
           SELECT * FROM community_members
           WHERE community_id = ${TEST_IDS.communityId}
-          AND user_id = ${TEST_IDS.secondProfileId}
+          AND user_id = ${TEST_IDS.secondUserId}
         `;
         expect(membership).not.toBeNull();
         expect(membership?.status).toBe('active');
@@ -516,7 +518,7 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
       it('should query teacher availability slots', async () => {
         const slots = await testQuery<{ id: string }>`
           SELECT * FROM teacher_availability_slots
-          WHERE teacher_id = ${TEST_IDS.profileId}
+          WHERE teacher_id = ${TEST_IDS.userId}
           LIMIT 10
         `;
         // May be empty but query should work
@@ -526,10 +528,10 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
 
     describe('community/[communitySlug]/leave/route.ts', () => {
       it('should handle member leaving community', async () => {
-        // Create a temporary member to leave
+        // Create a temporary member to leave. community_members.user_id is TEXT.
         const tempMember = await testQueryOne<{ id: string }>`
           INSERT INTO community_members (user_id, community_id, role, status)
-          VALUES (${TEST_IDS.profileId}, ${TEST_IDS.communityId}, 'member', 'active')
+          VALUES (${TEST_IDS.userId}, ${TEST_IDS.communityId}, 'member', 'active')
           ON CONFLICT (user_id, community_id) DO NOTHING
           RETURNING id
         `;
@@ -551,10 +553,10 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
 
     describe('community/[communitySlug]/join/route.ts', () => {
       it('should handle joining community', async () => {
-        // Check if already a member
+        // Check if already a member. community_members.user_id is TEXT.
         const existingMember = await testQueryOne<{ id: string }>`
           SELECT id FROM community_members
-          WHERE user_id = ${TEST_IDS.profileId}
+          WHERE user_id = ${TEST_IDS.userId}
           AND community_id = ${TEST_IDS.communityId}
         `;
 
@@ -562,7 +564,7 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
           // Join the community
           const newMember = await testQueryOne<CommunityMember>`
             INSERT INTO community_members (user_id, community_id, role, status)
-            VALUES (${TEST_IDS.profileId}, ${TEST_IDS.communityId}, 'member', 'active')
+            VALUES (${TEST_IDS.userId}, ${TEST_IDS.communityId}, 'member', 'active')
             RETURNING *
           `;
           expect(newMember).not.toBeNull();
@@ -661,7 +663,7 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
             'New lesson content',
             ${(maxPos?.max || 0) + 1},
             ${TEST_IDS.chapterId},
-            ${TEST_IDS.profileId}
+            ${TEST_IDS.userId}
           )
           RETURNING *
         `;
@@ -728,7 +730,7 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
       const membersWithProfiles = await testQuery<CommunityMember & { full_name: string }>`
         SELECT cm.*, p.full_name
         FROM community_members cm
-        INNER JOIN profiles p ON p.id = cm.user_id
+        INNER JOIN profiles p ON p.auth_user_id = cm.user_id
         WHERE cm.community_id = ${TEST_IDS.communityId}
       `;
       expect(membersWithProfiles.length).toBeGreaterThan(0);
@@ -744,36 +746,37 @@ describe('Waves 1-4 Integration Tests - Neon Database Layer', () => {
     });
 
     it('should handle array operations (array_append/array_remove)', async () => {
-      // Add to array
+      // threads.likes is TEXT[] now (Better-Auth migration), no uuid cast.
       await testSql`
         UPDATE threads
-        SET likes = array_append(COALESCE(likes, '{}'), ${TEST_IDS.profileId}::uuid)
+        SET likes = array_append(COALESCE(likes, '{}'), ${TEST_IDS.userId})
         WHERE id = ${TEST_IDS.threadId}
       `;
 
       let thread = await testQueryOne<{ likes: string[] }>`
         SELECT likes FROM threads WHERE id = ${TEST_IDS.threadId}
       `;
-      expect(thread?.likes).toContain(TEST_IDS.profileId);
+      expect(thread?.likes).toContain(TEST_IDS.userId);
 
       // Remove from array
       await testSql`
         UPDATE threads
-        SET likes = array_remove(likes, ${TEST_IDS.profileId}::uuid)
+        SET likes = array_remove(likes, ${TEST_IDS.userId})
         WHERE id = ${TEST_IDS.threadId}
       `;
 
       thread = await testQueryOne<{ likes: string[] }>`
         SELECT likes FROM threads WHERE id = ${TEST_IDS.threadId}
       `;
-      expect(thread?.likes).not.toContain(TEST_IDS.profileId);
+      expect(thread?.likes).not.toContain(TEST_IDS.userId);
     });
 
     it('should handle ON CONFLICT (upsert)', async () => {
-      // This tests the upsert pattern - will either insert or do nothing
+      // This tests the upsert pattern - will either insert or do nothing.
+      // community_members.user_id is TEXT (Better-Auth user id).
       const result = await testQuery<{ id: string }>`
         INSERT INTO community_members (user_id, community_id, role, status)
-        VALUES (${TEST_IDS.secondProfileId}, ${TEST_IDS.communityId}, 'member', 'active')
+        VALUES (${TEST_IDS.secondUserId}, ${TEST_IDS.communityId}, 'member', 'active')
         ON CONFLICT (user_id, community_id) DO NOTHING
         RETURNING id
       `;

--- a/__tests__/utils/test-db.ts
+++ b/__tests__/utils/test-db.ts
@@ -1,18 +1,24 @@
 /**
  * Test database utilities for Neon integration tests
- * Provides direct database access for testing API route migrations
+ *
+ * Connects to a dedicated test Neon branch via TEST_DATABASE_URL.
+ * Never falls back to DATABASE_URL — running tests against prod would
+ * delete real rows in cleanupTestData().
  */
 import { neon } from '@neondatabase/serverless';
 import { config } from 'dotenv';
 import { resolve } from 'path';
+import crypto from 'crypto';
 
 // Load environment variables from .env.local
 config({ path: resolve(process.cwd(), '.env.local') });
 
-const databaseUrl = process.env.DATABASE_URL;
+const databaseUrl = process.env.TEST_DATABASE_URL;
 
 if (!databaseUrl) {
-  throw new Error('DATABASE_URL environment variable is required for tests');
+  throw new Error(
+    'TEST_DATABASE_URL is required for tests. Never run tests against prod DB.',
+  );
 }
 
 export const testSql = neon(databaseUrl);
@@ -39,8 +45,23 @@ export async function testQueryOne<T>(
 }
 
 // Test data IDs - will be populated during setup
+//
+// Note on the Better-Auth migration:
+// - `profiles.id` is still UUID
+// - `profiles.auth_user_id` is TEXT and references `"user".id`
+// - All FK columns that used to point at `profiles.id` (communities.created_by,
+//   community_members.user_id, threads.user_id, lessons.created_by,
+//   private_lessons.teacher_id, live_classes.teacher_id, ...) now reference
+//   the Better-Auth user TEXT id, NOT profiles.id.
+//
+// `userId` / `secondUserId` are the TEXT Better-Auth ids and the values that
+// belong in those FK columns. `profileId` / `secondProfileId` are kept around
+// for tests that still need to assert on the profiles row directly.
 export const TEST_IDS = {
+  userId: '',
+  secondUserId: '',
   profileId: '',
+  secondProfileId: '',
   communityId: '',
   communitySlug: '',
   courseId: '',
@@ -51,53 +72,83 @@ export const TEST_IDS = {
   liveClassId: '',
   threadId: '',
   memberId: '',
-  secondProfileId: '',
 };
 
 /**
  * Create test data for integration tests
  */
 export async function setupTestData(): Promise<typeof TEST_IDS> {
-  // Generate unique identifiers for this test run
-  const uniqueSuffix = Date.now().toString(36);
+  // crypto.randomUUID() collision-free across re-runs and parallel workers
+  const uniqueSuffix = crypto.randomUUID();
   const testEmail = `test-wave-${uniqueSuffix}@dancehub-test.com`;
   const secondTestEmail = `test-wave-member-${uniqueSuffix}@dancehub-test.com`;
-  const communitySlug = `test-community-${uniqueSuffix}`;
-  const courseSlug = `test-course-${uniqueSuffix}`;
+  const communitySlug = `test-community-${uniqueSuffix}`.slice(0, 60);
+  const courseSlug = `test-course-${uniqueSuffix}`.slice(0, 60);
+  const userId = `test-user-${uniqueSuffix}`;
+  const secondUserId = `test-user-member-${uniqueSuffix}`;
 
-  // Create a test profile (community creator)
-  const profile = await testQueryOne<{ id: string }>`
-    INSERT INTO profiles (id, email, display_name, full_name, is_admin)
+  // Create the Better-Auth user rows FIRST. Downstream FKs point here.
+  // The DB has an `on_user_created` trigger on "user" that auto-inserts a
+  // matching profile row (via create_profile_for_user). So we DO NOT insert
+  // profiles manually here — we look up the auto-created ones after.
+  await testSql`
+    INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
     VALUES (
-      gen_random_uuid(),
+      ${userId},
       ${testEmail},
-      ${'test_creator_' + uniqueSuffix},
       'Test Creator User',
-      false
+      false,
+      NOW(),
+      NOW()
     )
-    RETURNING id
   `;
+  TEST_IDS.userId = userId;
 
-  if (!profile) throw new Error('Failed to create test profile');
+  await testSql`
+    INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
+    VALUES (
+      ${secondUserId},
+      ${secondTestEmail},
+      'Test Member User',
+      false,
+      NOW(),
+      NOW()
+    )
+  `;
+  TEST_IDS.secondUserId = secondUserId;
+
+  // Look up the trigger-created profiles.
+  const profile = await testQueryOne<{ id: string }>`
+    SELECT id FROM profiles WHERE auth_user_id = ${userId}
+  `;
+  if (!profile) {
+    throw new Error('Expected on_user_created trigger to have inserted profile for creator');
+  }
   TEST_IDS.profileId = profile.id;
 
-  // Create a second test profile (community member)
   const secondProfile = await testQueryOne<{ id: string }>`
-    INSERT INTO profiles (id, email, display_name, full_name, is_admin)
-    VALUES (
-      gen_random_uuid(),
-      ${secondTestEmail},
-      ${'test_member_' + uniqueSuffix},
-      'Test Member User',
-      false
-    )
-    RETURNING id
+    SELECT id FROM profiles WHERE auth_user_id = ${secondUserId}
   `;
-
-  if (!secondProfile) throw new Error('Failed to create second test profile');
+  if (!secondProfile) {
+    throw new Error('Expected on_user_created trigger to have inserted profile for member');
+  }
   TEST_IDS.secondProfileId = secondProfile.id;
 
-  // Create a test community
+  // Backfill the display_name / full_name overrides used by the views tests.
+  await testSql`
+    UPDATE profiles
+    SET display_name = ${'test_creator_' + uniqueSuffix.slice(0, 8)},
+        full_name = 'Test Creator User'
+    WHERE id = ${TEST_IDS.profileId}
+  `;
+  await testSql`
+    UPDATE profiles
+    SET display_name = ${'test_member_' + uniqueSuffix.slice(0, 8)},
+        full_name = 'Test Member User'
+    WHERE id = ${TEST_IDS.secondProfileId}
+  `;
+
+  // Communities — created_by references "user".id (TEXT)
   const community = await testQueryOne<{ id: string }>`
     INSERT INTO communities (id, name, slug, description, created_by, status, membership_enabled, membership_price)
     VALUES (
@@ -105,7 +156,7 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
       'Test Integration Community',
       ${communitySlug},
       'A test community for integration tests',
-      ${TEST_IDS.profileId},
+      ${userId},
       'active',
       true,
       10.00
@@ -117,12 +168,12 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
   TEST_IDS.communityId = community.id;
   TEST_IDS.communitySlug = communitySlug;
 
-  // Create a community member
+  // community_members.user_id is TEXT (Better-Auth user id)
   const member = await testQueryOne<{ id: string }>`
     INSERT INTO community_members (id, user_id, community_id, role, status)
     VALUES (
       gen_random_uuid(),
-      ${TEST_IDS.secondProfileId},
+      ${secondUserId},
       ${TEST_IDS.communityId},
       'member',
       'active'
@@ -133,7 +184,7 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
   if (!member) throw new Error('Failed to create test member');
   TEST_IDS.memberId = member.id;
 
-  // Create a test course
+  // courses.created_by is TEXT (Better-Auth user id)
   const course = await testQueryOne<{ id: string }>`
     INSERT INTO courses (id, title, slug, description, community_id, created_by, is_public)
     VALUES (
@@ -142,7 +193,7 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
       ${courseSlug},
       'A test course for integration tests',
       ${TEST_IDS.communityId},
-      ${TEST_IDS.profileId},
+      ${userId},
       true
     )
     RETURNING id
@@ -152,7 +203,6 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
   TEST_IDS.courseId = course.id;
   TEST_IDS.courseSlug = courseSlug;
 
-  // Create a test chapter
   const chapter = await testQueryOne<{ id: string }>`
     INSERT INTO chapters (id, title, chapter_position, course_id)
     VALUES (
@@ -167,7 +217,7 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
   if (!chapter) throw new Error('Failed to create test chapter');
   TEST_IDS.chapterId = chapter.id;
 
-  // Create a test lesson
+  // lessons.created_by is TEXT (Better-Auth user id)
   const lesson = await testQueryOne<{ id: string }>`
     INSERT INTO lessons (id, title, content, lesson_position, chapter_id, created_by)
     VALUES (
@@ -176,7 +226,7 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
       'Test lesson content for integration tests',
       1,
       ${TEST_IDS.chapterId},
-      ${TEST_IDS.profileId}
+      ${userId}
     )
     RETURNING id
   `;
@@ -184,13 +234,13 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
   if (!lesson) throw new Error('Failed to create test lesson');
   TEST_IDS.lessonId = lesson.id;
 
-  // Create a test private lesson
+  // private_lessons.teacher_id is TEXT (Better-Auth user id)
   const privateLesson = await testQueryOne<{ id: string }>`
     INSERT INTO private_lessons (id, community_id, teacher_id, title, description, duration_minutes, regular_price, is_active)
     VALUES (
       gen_random_uuid(),
       ${TEST_IDS.communityId},
-      ${TEST_IDS.profileId},
+      ${userId},
       'Test Integration Private Lesson',
       'A test private lesson for integration tests',
       60,
@@ -203,13 +253,13 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
   if (!privateLesson) throw new Error('Failed to create test private lesson');
   TEST_IDS.privateLessonId = privateLesson.id;
 
-  // Create a test live class
+  // live_classes.teacher_id is TEXT (Better-Auth user id)
   const liveClass = await testQueryOne<{ id: string }>`
     INSERT INTO live_classes (id, community_id, teacher_id, title, description, scheduled_start_time, duration_minutes, status)
     VALUES (
       gen_random_uuid(),
       ${TEST_IDS.communityId},
-      ${TEST_IDS.profileId},
+      ${userId},
       'Test Integration Live Class',
       'A test live class for integration tests',
       NOW() + INTERVAL '1 day',
@@ -222,16 +272,16 @@ export async function setupTestData(): Promise<typeof TEST_IDS> {
   if (!liveClass) throw new Error('Failed to create test live class');
   TEST_IDS.liveClassId = liveClass.id;
 
-  // Create a test thread
+  // threads.user_id and threads.created_by are TEXT (Better-Auth user id)
   const thread = await testQueryOne<{ id: string }>`
     INSERT INTO threads (id, title, content, user_id, community_id, created_by, author_name)
     VALUES (
       gen_random_uuid(),
       'Test Integration Thread',
       'Test thread content for integration tests',
-      ${TEST_IDS.profileId},
+      ${userId},
       ${TEST_IDS.communityId},
-      ${TEST_IDS.profileId},
+      ${userId},
       'Test Creator User'
     )
     RETURNING id
@@ -278,9 +328,19 @@ export async function cleanupTestData(): Promise<void> {
   if (TEST_IDS.profileId) {
     await testSql`DELETE FROM profiles WHERE id = ${TEST_IDS.profileId}`;
   }
+  // "user" rows last — profiles FK back to them via auth_user_id.
+  if (TEST_IDS.secondUserId) {
+    await testSql`DELETE FROM "user" WHERE id = ${TEST_IDS.secondUserId}`;
+  }
+  if (TEST_IDS.userId) {
+    await testSql`DELETE FROM "user" WHERE id = ${TEST_IDS.userId}`;
+  }
 
   // Reset IDs
+  TEST_IDS.userId = '';
+  TEST_IDS.secondUserId = '';
   TEST_IDS.profileId = '';
+  TEST_IDS.secondProfileId = '';
   TEST_IDS.communityId = '';
   TEST_IDS.communitySlug = '';
   TEST_IDS.courseId = '';
@@ -291,5 +351,4 @@ export async function cleanupTestData(): Promise<void> {
   TEST_IDS.liveClassId = '';
   TEST_IDS.threadId = '';
   TEST_IDS.memberId = '';
-  TEST_IDS.secondProfileId = '';
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,10 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/$1',
   },
   setupFiles: ['dotenv/config'],
+  // Integration suites under __tests__/api hit the same Neon test branch and
+  // share seed slugs/emails. Serializing avoids races on that DB; the unit
+  // suites are fast enough that single-worker doesn't hurt much.
+  maxWorkers: 1,
   projects: [
     {
       displayName: 'api',


### PR DESCRIPTION
## Summary
Tests were running against the **production Neon pooler** (discovered during the Next 16 upgrade follow-up). This PR fixes that and repairs 4 long-failing suites that had drifted from the Better-Auth schema migrations.

## Changes
- **Require `TEST_DATABASE_URL`**: `__tests__/utils/test-db.ts` throws if missing; never falls back to `DATABASE_URL`. New Neon `test` branch already provisioned.
- **Seed util aligned with Better-Auth schema**: inserts `"user"` row first (TEXT id), uses the `on_user_created` trigger for the profile, sets all FK references to the user TEXT id (not profiles UUID).
- **Schema-drift fixes**:
  - `database-views-functions`: drop `subscription_id` and `formatted_display_name` assertions (not in view); moved `update_updated_at_column` test from `profiles` (no trigger) to `communities`.
  - `waves1-4-integration`: drop `::uuid` casts on `threads.likes` (TEXT[] now); switch FK inserts to user TEXT id.
  - `wave5-integration`: similar.
  - `auth-database`: full rewrite for isolation — `crypto.randomUUID()` for unique IDs, per-test cleanup arrays, no module-level shared state.
- **`jest.config.js`**: `maxWorkers: 1` to avoid parallel writes racing on the shared test DB.
- **`.env.example`**: documents `TEST_DATABASE_URL`.

## Result
- Before: 22 passing suites, 4 failing (auth-database, wave5, waves1-4, database-views-functions)
- After: 26 passing suites, 0 failing, 292/292 tests pass, 1 skipped (pre-existing)
- Tests no longer touch prod data

## Schema follow-ups (not in this PR)
- `update_updated_at_column` trigger missing from `profiles` — app sets it manually, fine for now
- View `community_members_with_profiles` doesn't expose `formatted_display_name` — UI computes via `get_display_name()` directly
- `on_user_created` trigger means apps that do plain `INSERT INTO profiles` after creating a Better-Auth user must handle the unique-email conflict (current code uses `ON CONFLICT (email) DO UPDATE`)

## Test plan
- [x] All 292 tests pass
- [x] Tests confirmed running against Neon `test` branch, not prod or preprod
- [N/A] No prod deploy needed — test changes don't ship in the bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)